### PR TITLE
fix(auth, dashboard): safe empty list handling, tenant mapping and auth routing

### DIFF
--- a/backend/internal/infrastructure/client/mongo/repository.go
+++ b/backend/internal/infrastructure/client/mongo/repository.go
@@ -38,7 +38,7 @@ func (r *repository) List(ctx context.Context, tenantID string) ([]*domain.Seaso
 	}
 	defer cursor.Close(ctx)
 
-	var list []*domain.SeasonClient
+	list := make([]*domain.SeasonClient, 0)
 	if err = cursor.All(ctx, &list); err != nil {
 		return nil, err
 	}

--- a/backend/internal/infrastructure/person/mongo/repository.go
+++ b/backend/internal/infrastructure/person/mongo/repository.go
@@ -38,7 +38,7 @@ func (r *repository) List(ctx context.Context, tenantID string) ([]*domain.Perso
 	}
 	defer cursor.Close(ctx)
 
-	var list []*domain.Person
+	list := make([]*domain.Person, 0)
 	if err = cursor.All(ctx, &list); err != nil {
 		return nil, err
 	}

--- a/backend/internal/infrastructure/photographer/mongo/repository.go
+++ b/backend/internal/infrastructure/photographer/mongo/repository.go
@@ -38,7 +38,7 @@ func (r *repository) List(ctx context.Context, tenantID string) ([]*domain.Photo
 	}
 	defer cursor.Close(ctx)
 
-	var list []*domain.Photographer
+	list := make([]*domain.Photographer, 0)
 	if err = cursor.All(ctx, &list); err != nil {
 		return nil, err
 	}

--- a/backend/internal/infrastructure/season/mongo/repository.go
+++ b/backend/internal/infrastructure/season/mongo/repository.go
@@ -38,7 +38,7 @@ func (r *repository) List(ctx context.Context, tenantID string) ([]*domain.Seaso
 	}
 	defer cursor.Close(ctx)
 
-	var list []*domain.Season
+	list := make([]*domain.Season, 0)
 	if err = cursor.All(ctx, &list); err != nil {
 		return nil, err
 	}

--- a/backend/internal/interfaces/rest/handlers/client_handler.go
+++ b/backend/internal/interfaces/rest/handlers/client_handler.go
@@ -41,6 +41,10 @@ func (h *SeasonClientHandler) List(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if list == nil {
+		list = make([]*domain.SeasonClient, 0)
+	}
+
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(list)
 }

--- a/backend/internal/interfaces/rest/handlers/person_handler.go
+++ b/backend/internal/interfaces/rest/handlers/person_handler.go
@@ -41,6 +41,10 @@ func (h *PersonHandler) List(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if list == nil {
+		list = make([]*domain.Person, 0)
+	}
+
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(list)
 }

--- a/backend/internal/interfaces/rest/handlers/photographer_handler.go
+++ b/backend/internal/interfaces/rest/handlers/photographer_handler.go
@@ -41,6 +41,10 @@ func (h *PhotographerHandler) List(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if list == nil {
+		list = make([]*domain.Photographer, 0)
+	}
+
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(list)
 }

--- a/backend/internal/interfaces/rest/handlers/season_handler.go
+++ b/backend/internal/interfaces/rest/handlers/season_handler.go
@@ -41,6 +41,10 @@ func (h *SeasonHandler) List(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if list == nil {
+		list = make([]*domain.Season, 0)
+	}
+
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(list)
 }

--- a/frontend/src/layouts/Topbar.tsx
+++ b/frontend/src/layouts/Topbar.tsx
@@ -35,12 +35,18 @@ export function Topbar({ onDrawerToggle }: TopbarProps) {
   const { activeSeason, setActiveSeason } = useSeasonStore();
 
   useEffect(() => {
-    seasonService.list().then((data) => {
-      setSeasons(data);
-      if (data.length > 0 && !activeSeason) {
-        setActiveSeason({ id: data[0].id, name: data[0].name });
-      }
-    });
+    seasonService
+      .list()
+      .then((data) => {
+        const seasonList = data || [];
+        setSeasons(seasonList);
+        if (seasonList.length > 0 && !activeSeason) {
+          setActiveSeason({ id: seasonList[0].id, name: seasonList[0].name });
+        }
+      })
+      .catch(() => {
+        setSeasons([]);
+      });
   }, [activeSeason, setActiveSeason]);
 
   const handleMenu = (event: React.MouseEvent<HTMLElement>) => {
@@ -103,7 +109,7 @@ export function Topbar({ onDrawerToggle }: TopbarProps) {
               label="Temporada Ativa"
               onChange={(e) => handleChangeSeason(e.target.value)}
             >
-              {seasons.map((s) => (
+              {(seasons || []).map((s) => (
                 <MenuItem key={s.id} value={s.id}>
                   {s.name}
                 </MenuItem>

--- a/frontend/src/services/api/client.service.ts
+++ b/frontend/src/services/api/client.service.ts
@@ -27,7 +27,7 @@ export interface SeasonClient {
 export const clientService = {
   list: async () => {
     const { data } = await apiClient.get<SeasonClient[]>("/clients");
-    return data;
+    return data || [];
   },
   getById: async (id: string) => {
     const { data } = await apiClient.get<SeasonClient>(`/clients/${id}`);

--- a/frontend/src/services/api/person.service.ts
+++ b/frontend/src/services/api/person.service.ts
@@ -11,7 +11,7 @@ export interface Person {
 export const personService = {
   list: async () => {
     const { data } = await apiClient.get<Person[]>("/people");
-    return data;
+    return data || [];
   },
   getById: async (id: string) => {
     const { data } = await apiClient.get<Person>(`/people/${id}`);

--- a/frontend/src/services/api/photographer.service.ts
+++ b/frontend/src/services/api/photographer.service.ts
@@ -8,7 +8,7 @@ export interface Photographer {
 export const photographerService = {
   list: async () => {
     const { data } = await apiClient.get<Photographer[]>("/photographers");
-    return data;
+    return data || [];
   },
   create: async (photographer: Omit<Photographer, "id">) => {
     const { data } = await apiClient.post<Photographer>(

--- a/frontend/src/services/api/season.service.ts
+++ b/frontend/src/services/api/season.service.ts
@@ -9,7 +9,7 @@ export interface Season {
 export const seasonService = {
   list: async () => {
     const { data } = await apiClient.get<Season[]>("/seasons");
-    return data;
+    return data || [];
   },
   create: async (season: Omit<Season, "id">) => {
     const { data } = await apiClient.post<Season>("/seasons", season);


### PR DESCRIPTION
## Resumo das Alterações

Este Pull Request resolve problemas de inicialização de sessão, rotas de autenticação, tratamento de listas vazias no backend/frontend e limpeza de artefatos legados.

### 1. Fix no Dashboard e Topbar (Renderização com coleções vazias)
- **Problema:** Quando uma conta nova ou sem temporadas cadastradas entrava no dashboard, o endpoint `/api/v1/seasons` retornava `null` (comportamento padrão de `nil` slice em Go), causando quebra no frontend (`Cannot read properties of null (reading 'map')` e `reading 'length'`).
- **Solução:** 
  - Repositórios MongoDB (`seasons`, `photographers`, `people`, `season_clients`) agora inicializam os slices com `make([]*Entity, 0)` para serializar como `[]` no JSON.
  - Handlers REST aplicam fallback defensivo caso `list == nil`.
  - Frontend services e o componente `Topbar.tsx` implementam validação e fallback para listas vazias.

### 2. Autenticação e Mapeamento de `tenantId`
- O `tenantId` agora é retornado explicitamente nos payloads JSON dos handlers `Login`, `Refresh` e `Me`, permitindo ao frontend liberar a navegação para usuários já vinculados a um tenant.
- Rotas de autenticação (`/verify-email`, `/forgot-password`, `/reset-password`, `/resend-verification`) foram mapeadas tanto no roteador Go (`router.go`) quanto no React Router (`AppRoutes`).

### 3. Limpeza de Templates e Swagger
- Atualizados os templates de e-mail (`verification.html`, `password_reset.html` e `sender.go`) removendo termos e emojis de veículos/frotas e adotando a nomenclatura da plataforma de fotos caninas (📸).
- Documentação do Swagger atualizada.

---
**Validação:** `./scripts/check.sh all` executado com sucesso (backend vet/testes, frontend typecheck/lint/format/testes e terraform fmt).