### PR TITLE
fix(reports): rota no frontend para download seguro de relatorios csv enviados por email

### DIFF
--- a/backend/internal/application/usecase/report/service.go
+++ b/backend/internal/application/usecase/report/service.go
@@ -263,7 +263,7 @@ func (s *Service) GenerateClientsCSV(ctx context.Context, tenantID, userEmail, u
 
 	// 6. Send notification email with download link if userEmail is provided
 	if userEmail != "" {
-		downloadURL := fmt.Sprintf("%s/api/v1/reports/download?file=%s", s.appBaseURL, url.QueryEscape(relativePath))
+		downloadURL := fmt.Sprintf("%s/reports/download?file=%s", s.appBaseURL, url.QueryEscape(relativePath))
 		if err := s.emailSender.SendReportReadyEmail(ctx, userEmail, userName, "Relatório de Clientes", downloadURL); err != nil {
 			log.Printf("[REPORT-EMAIL-ERROR] Failed to send report ready email to %s: %v", userEmail, err)
 		}

--- a/backend/internal/application/usecase/report/service_test.go
+++ b/backend/internal/application/usecase/report/service_test.go
@@ -8,10 +8,10 @@ import (
 	"strings"
 	"testing"
 
+	storageport "ps/internal/application/ports/storage"
 	clientdomain "ps/internal/domain/client"
 	persondomain "ps/internal/domain/person"
 	photographerdomain "ps/internal/domain/photographer"
-	storageport "ps/internal/application/ports/storage"
 )
 
 // Mock implementations

--- a/backend/internal/infrastructure/email/sender_test.go
+++ b/backend/internal/infrastructure/email/sender_test.go
@@ -30,7 +30,7 @@ func TestEmailSenderSimulation(t *testing.T) {
 	}
 
 	// 3. Send report ready email
-	err = service.SendReportReadyEmail(ctx, "motorista@ps.com.br", "Yuri Nogueira", "Relatório de Clientes", "https://ps.com.br/api/v1/reports/download?file=abc")
+	err = service.SendReportReadyEmail(ctx, "motorista@ps.com.br", "Yuri Nogueira", "Relatório de Clientes", "https://ps.com.br/reports/download?file=abc")
 	if err != nil {
 		t.Fatalf("expected SendReportReadyEmail to succeed in simulation mode, got %v", err)
 	}
@@ -100,14 +100,14 @@ func TestEmailTemplatesRender(t *testing.T) {
 	}{
 		Name:        "Carlos Silva",
 		ReportName:  "Relatório de Clientes",
-		DownloadURL: "https://ps.com.br/api/v1/reports/download?file=xyz",
+		DownloadURL: "https://ps.com.br/reports/download?file=xyz",
 		CurrentYear: currentYear,
 	})
 	if err != nil {
 		t.Fatalf("failed to render report ready template: %v", err)
 	}
 	reportStr := bufReport.String()
-	if !strings.Contains(reportStr, "Carlos Silva") || !strings.Contains(reportStr, "Relatório de Clientes") || !strings.Contains(reportStr, "https://ps.com.br/api/v1/reports/download?file=xyz") {
+	if !strings.Contains(reportStr, "Carlos Silva") || !strings.Contains(reportStr, "Relatório de Clientes") || !strings.Contains(reportStr, "https://ps.com.br/reports/download?file=xyz") {
 		t.Fatalf("report ready template missing expected fields")
 	}
 	if !strings.Contains(reportStr, expectedYearStr) {

--- a/frontend/src/features/auth/pages/LoginPage.tsx
+++ b/frontend/src/features/auth/pages/LoginPage.tsx
@@ -1,5 +1,9 @@
 import React, { useState } from "react";
-import { Link as RouterLink, useNavigate } from "react-router-dom";
+import {
+  Link as RouterLink,
+  useNavigate,
+  useSearchParams,
+} from "react-router-dom";
 import {
   Box,
   Card,
@@ -28,6 +32,8 @@ import { brandColors } from "../../../styles/theme";
 export function LoginPage() {
   useDocumentTitle("Entrar");
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const redirectUrl = searchParams.get("redirect") || "/dashboard";
   const setUser = useAuthStore((state) => state.setUser);
 
   const [email, setEmail] = useState("");
@@ -49,7 +55,7 @@ export function LoginPage() {
       setLoading(true);
       const data = await authService.login({ email: email.trim(), password });
       setUser(data.user);
-      navigate("/dashboard", { replace: true });
+      navigate(redirectUrl, { replace: true });
     } catch (err: unknown) {
       const errorObj = err as { response?: { data?: { message?: string } } };
       const message =

--- a/frontend/src/features/reports/pages/ReportDownloadPage.tsx
+++ b/frontend/src/features/reports/pages/ReportDownloadPage.tsx
@@ -1,0 +1,283 @@
+import { useState, useEffect, useCallback } from "react";
+import { useSearchParams, useNavigate } from "react-router-dom";
+import {
+  Box,
+  Card,
+  CardContent,
+  Typography,
+  Button,
+  CircularProgress,
+  Alert,
+} from "@mui/material";
+import FileDownloadDoneRoundedIcon from "@mui/icons-material/FileDownloadDoneRounded";
+import ErrorOutlineRoundedIcon from "@mui/icons-material/ErrorOutlineRounded";
+import FileDownloadRoundedIcon from "@mui/icons-material/FileDownloadRounded";
+import { AuthHeroBanner } from "../../auth/components/AuthHeroBanner";
+import { reportService } from "../../../services/api/report.service";
+import { useAuthStore } from "../../auth/state/auth.store";
+import { useDocumentTitle } from "../../shared";
+import { brandColors } from "../../../styles/theme";
+
+export function ReportDownloadPage() {
+  useDocumentTitle("Download de Relatório");
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const fileParam = searchParams.get("file") || "";
+  const hasFile = Boolean(fileParam.trim());
+
+  const { isAuthenticated } = useAuthStore();
+
+  const [loading, setLoading] = useState(false);
+  const [downloaded, setDownloaded] = useState(false);
+  const [errorMsg, setErrorMsg] = useState<string | null>(
+    hasFile
+      ? null
+      : "Parâmetro de arquivo ausente. Utilize o link enviado para seu e-mail.",
+  );
+
+  const triggerDownload = useCallback(async () => {
+    if (!hasFile) return;
+
+    try {
+      setLoading(true);
+      setErrorMsg(null);
+      const blob = await reportService.downloadReport(fileParam.trim());
+
+      const fileName =
+        fileParam.split("/").pop() ||
+        `clientes_${Math.floor(Date.now() / 1000)}.csv`;
+      const blobUrl = window.URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = blobUrl;
+      link.setAttribute("download", fileName);
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      window.URL.revokeObjectURL(blobUrl);
+
+      setDownloaded(true);
+    } catch (err: unknown) {
+      let message =
+        "Não foi possível baixar o relatório. Verifique se o arquivo ainda existe e se você tem permissão de acesso.";
+      const errorObj = err as {
+        response?: { status?: number; data?: { message?: string } };
+      };
+      if (errorObj?.response?.status === 403) {
+        message = "Acesso negado: este relatório pertence a outro tenant.";
+      } else if (errorObj?.response?.status === 404) {
+        message = "Relatório não encontrado ou link expirado.";
+      } else if (errorObj?.response?.data?.message) {
+        message = errorObj.response.data.message;
+      }
+      setErrorMsg(message);
+    } finally {
+      setLoading(false);
+    }
+  }, [hasFile, fileParam]);
+
+  useEffect(() => {
+    if (isAuthenticated && hasFile && !downloaded && !loading && !errorMsg) {
+      triggerDownload();
+    }
+  }, [
+    isAuthenticated,
+    hasFile,
+    downloaded,
+    loading,
+    errorMsg,
+    triggerDownload,
+  ]);
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        minHeight: "100vh",
+        bgcolor: "background.default",
+      }}
+    >
+      {/* Visual Left Banner */}
+      <Box
+        sx={{
+          display: { xs: "none", md: "flex" },
+          flex: { md: "0 0 50%", lg: "0 0 52%" },
+        }}
+      >
+        <AuthHeroBanner />
+      </Box>
+
+      {/* Content Right Panel */}
+      <Box
+        sx={{
+          flex: 1,
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "center",
+          alignItems: "center",
+          p: { xs: 3, sm: 6, md: 8 },
+        }}
+      >
+        <Card
+          elevation={0}
+          sx={{
+            width: "100%",
+            maxWidth: 440,
+            border: { xs: "none", sm: "1px solid #E2E8F0" },
+            bgcolor: { xs: "transparent", sm: "background.paper" },
+            p: { xs: 0, sm: 2 },
+          }}
+        >
+          <CardContent sx={{ p: { xs: 1, sm: 3 }, textAlign: "center" }}>
+            {/* Mobile Header / Brand */}
+            <Box
+              sx={{
+                display: { xs: "flex", md: "none" },
+                alignItems: "center",
+                justifyContent: "center",
+                mb: 3,
+                gap: 1,
+              }}
+            >
+              <Box
+                sx={{
+                  bgcolor: brandColors.primary,
+                  borderRadius: 1.5,
+                  p: 0.75,
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                }}
+              />
+              <Typography
+                variant="h6"
+                sx={{ fontWeight: 800, color: "primary.main" }}
+              >
+                PS
+              </Typography>
+            </Box>
+
+            {!isAuthenticated ? (
+              <Box sx={{ py: 3 }}>
+                <FileDownloadRoundedIcon
+                  sx={{ fontSize: 64, color: "primary.main", mb: 2 }}
+                />
+                <Typography variant="h5" sx={{ fontWeight: 700, mb: 1 }}>
+                  Download de Relatório
+                </Typography>
+                <Typography
+                  variant="body2"
+                  sx={{ color: "text.secondary", mb: 4 }}
+                >
+                  Você precisa estar conectado à sua conta para fazer o download
+                  deste relatório com segurança.
+                </Typography>
+                <Button
+                  onClick={() =>
+                    navigate(
+                      `/login?redirect=${encodeURIComponent(
+                        `/reports/download?file=${fileParam}`,
+                      )}`,
+                      { replace: true },
+                    )
+                  }
+                  variant="contained"
+                  fullWidth
+                  size="large"
+                  sx={{ py: 1.4, fontWeight: 600 }}
+                >
+                  Fazer Login para Baixar
+                </Button>
+              </Box>
+            ) : loading ? (
+              <Box sx={{ py: 6 }}>
+                <CircularProgress size={48} sx={{ mb: 3 }} />
+                <Typography variant="h6" sx={{ fontWeight: 600, mb: 1 }}>
+                  Baixando seu relatório...
+                </Typography>
+                <Typography variant="body2" sx={{ color: "text.secondary" }}>
+                  Aguarde enquanto seu arquivo CSV é transferido com segurança.
+                </Typography>
+              </Box>
+            ) : downloaded ? (
+              <Box sx={{ py: 3 }}>
+                <FileDownloadDoneRoundedIcon
+                  sx={{ fontSize: 64, color: "success.main", mb: 2 }}
+                />
+                <Typography variant="h5" sx={{ fontWeight: 700, mb: 1 }}>
+                  Download Concluído!
+                </Typography>
+                <Typography
+                  variant="body2"
+                  sx={{ color: "text.secondary", mb: 4 }}
+                >
+                  O relatório de clientes foi gerado e baixado no seu navegador.
+                </Typography>
+                <Box
+                  sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}
+                >
+                  <Button
+                    onClick={triggerDownload}
+                    variant="outlined"
+                    fullWidth
+                    size="large"
+                    startIcon={<FileDownloadRoundedIcon />}
+                    sx={{ py: 1.4, fontWeight: 600 }}
+                  >
+                    Baixar Novamente
+                  </Button>
+                  <Button
+                    onClick={() => navigate("/dashboard", { replace: true })}
+                    variant="contained"
+                    fullWidth
+                    size="large"
+                    sx={{ py: 1.4, fontWeight: 600 }}
+                  >
+                    Ir para o Painel
+                  </Button>
+                </Box>
+              </Box>
+            ) : (
+              <Box sx={{ py: 3 }}>
+                <ErrorOutlineRoundedIcon
+                  sx={{ fontSize: 64, color: "error.main", mb: 2 }}
+                />
+                <Typography variant="h5" sx={{ fontWeight: 700, mb: 1 }}>
+                  Falha no Download
+                </Typography>
+                {errorMsg && (
+                  <Alert severity="error" sx={{ mb: 3, textAlign: "left" }}>
+                    {errorMsg}
+                  </Alert>
+                )}
+                <Box
+                  sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}
+                >
+                  {hasFile && (
+                    <Button
+                      onClick={triggerDownload}
+                      variant="contained"
+                      fullWidth
+                      size="large"
+                      sx={{ py: 1.4, fontWeight: 600 }}
+                    >
+                      Tentar Novamente
+                    </Button>
+                  )}
+                  <Button
+                    onClick={() => navigate("/dashboard", { replace: true })}
+                    variant="outlined"
+                    fullWidth
+                    size="large"
+                    sx={{ py: 1.4, fontWeight: 600 }}
+                  >
+                    Ir para o Painel
+                  </Button>
+                </Box>
+              </Box>
+            )}
+          </CardContent>
+        </Card>
+      </Box>
+    </Box>
+  );
+}

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -31,6 +31,11 @@ const ResetPasswordPage = lazy(() =>
     default: m.ResetPasswordPage,
   })),
 );
+const ReportDownloadPage = lazy(() =>
+  import("../features/reports/pages/ReportDownloadPage").then((m) => ({
+    default: m.ReportDownloadPage,
+  })),
+);
 const DashboardPage = lazy(() =>
   import("../features/dashboard/pages/DashboardPage").then((m) => ({
     default: m.DashboardPage,
@@ -95,6 +100,7 @@ export function AppRoutes() {
         <Route path="/verify-email" element={<VerifyEmailPage />} />
         <Route path="/forgot-password" element={<ForgotPasswordPage />} />
         <Route path="/reset-password" element={<ResetPasswordPage />} />
+        <Route path="/reports/download" element={<ReportDownloadPage />} />
 
         <Route element={<ProtectedRoute />}>
           <Route element={<AppLayout />}>

--- a/frontend/src/services/api/report.service.ts
+++ b/frontend/src/services/api/report.service.ts
@@ -11,4 +11,12 @@ export const reportService = {
     );
     return data;
   },
+
+  downloadReport: async (filePath: string): Promise<Blob> => {
+    const { data } = await apiClient.get<Blob>("/reports/download", {
+      params: { file: filePath },
+      responseType: "blob",
+    });
+    return data;
+  },
 };


### PR DESCRIPTION
### 📑 Resumo da Correção

Criação da rota frontend `/reports/download` e página dedicada para realizar o download dos arquivos CSV gerados assincronamente através do link enviado por e-mail.

#### 🔧 Detalhes das Alterações
1. **Backend**:
   - Ajustado o gerador de link de download no e-mail (`SendReportReadyEmail`) para apontar diretamente para a rota frontend `${APP_BASE_URL}/reports/download?file=...`.
2. **Frontend**:
   - **Página de Download (`ReportDownloadPage.tsx`)**: 
     - Captura o parâmetro `file` da URL.
     - Se o usuário estiver autenticado, dispara automaticamente `reportService.downloadReport`, cria um `Blob` e aciona o download nativo do arquivo no navegador.
     - Se o usuário não estiver autenticado, exibe um card solicitando login com redirecionamento de volta para o download após autenticação.
     - Exibe feedback visual com estados de carregamento, sucesso ("Baixar novamente" / "Ir para o painel") ou erro de permissão/expiração.
   - **Serviço de API (`report.service.ts`)**:
     - Adicionado método `downloadReport(filePath)` com suporte a retorno em formato `Blob`.
   - **Login com Redirecionamento (`LoginPage.tsx`)**:
     - Suporte ao query parameter `redirect` para redirecionar o usuário após o login para a URL original de download.
   - **Rotas (`routes/index.tsx`)**:
     - Registro da rota pública/autenticada `/reports/download`.

#### 🧪 Validação
- [x] `./scripts/check.sh all` aprovado (Backend vet e testes, Frontend typecheck/lint/format/tests e Terraform).
