### PR TITLE
fix(reports): padronizar formatacao de telefone e traduzir formas de pagamento para portugues

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -1755,7 +1755,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "payment_method": {
-                    "description": "Pix, Credit Card, Debit Card, Cash, Não pago",
+                    "description": "Pix, Cartão de Crédito, Cartão de Débito, Dinheiro, Não pago",
                     "type": "string"
                 },
                 "photographer_id": {

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -1749,7 +1749,7 @@
                     "type": "string"
                 },
                 "payment_method": {
-                    "description": "Pix, Credit Card, Debit Card, Cash, Não pago",
+                    "description": "Pix, Cartão de Crédito, Cartão de Débito, Dinheiro, Não pago",
                     "type": "string"
                 },
                 "photographer_id": {

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -39,7 +39,7 @@ definitions:
       file_number:
         type: string
       payment_method:
-        description: Pix, Credit Card, Debit Card, Cash, Não pago
+        description: Pix, Cartão de Crédito, Cartão de Débito, Dinheiro, Não pago
         type: string
       photographer_id:
         type: string

--- a/backend/internal/application/usecase/report/service.go
+++ b/backend/internal/application/usecase/report/service.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+	"unicode"
 
 	clientport "ps/internal/application/ports/client"
 	emailport "ps/internal/application/ports/email"
@@ -53,6 +54,49 @@ func NewService(
 		storageProvider:  storageProvider,
 		emailSender:      emailSender,
 		appBaseURL:       strings.TrimRight(appBaseURL, "/"),
+	}
+}
+
+// FormatPhone standardizes Brazilian phone numbers into (XX) XXXXX-XXXX or (XX) XXXX-XXXX
+func FormatPhone(phone string) string {
+	var digits strings.Builder
+	for _, r := range phone {
+		if unicode.IsDigit(r) {
+			digits.WriteRune(r)
+		}
+	}
+	d := digits.String()
+	switch len(d) {
+	case 11:
+		return fmt.Sprintf("(%s) %s-%s", d[0:2], d[2:7], d[7:11])
+	case 10:
+		return fmt.Sprintf("(%s) %s-%s", d[0:2], d[2:6], d[6:10])
+	case 9:
+		return fmt.Sprintf("%s-%s", d[0:5], d[5:9])
+	case 8:
+		return fmt.Sprintf("%s-%s", d[0:4], d[4:8])
+	default:
+		return strings.TrimSpace(phone)
+	}
+}
+
+// NormalizePaymentMethod translates any English or legacy payment method into Portuguese
+func NormalizePaymentMethod(method string) string {
+	trimmed := strings.TrimSpace(method)
+	lower := strings.ToLower(trimmed)
+	switch lower {
+	case "credit card", "credit_card", "cartao de credito", "cartão de crédito", "crédito", "credito":
+		return "Cartão de Crédito"
+	case "debit card", "debit_card", "cartao de debito", "cartão de débito", "débito", "debito":
+		return "Cartão de Débito"
+	case "cash", "dinheiro", "especie", "espécie":
+		return "Dinheiro"
+	case "pix":
+		return "Pix"
+	case "não pago", "nao pago", "nao_pago", "not paid", "not_paid", "pendente":
+		return "Não pago"
+	default:
+		return trimmed
 	}
 }
 
@@ -137,12 +181,14 @@ func (s *Service) GenerateClientsCSV(ctx context.Context, tenantID, userEmail, u
 			p = personObj
 		}
 
+		formattedPhone := FormatPhone(p.Phone)
+
 		if len(c.Dogs) == 0 {
 			row := []string{
 				p.Name,
 				p.Email,
 				p.AlternativeEmail,
-				p.Phone,
+				formattedPhone,
 				"",
 				"",
 				"",
@@ -168,7 +214,7 @@ func (s *Service) GenerateClientsCSV(ctx context.Context, tenantID, userEmail, u
 					p.Name,
 					p.Email,
 					p.AlternativeEmail,
-					p.Phone,
+					formattedPhone,
 					"",
 					"",
 					"",
@@ -198,7 +244,7 @@ func (s *Service) GenerateClientsCSV(ctx context.Context, tenantID, userEmail, u
 					} else {
 						photographerName = photo.PhotographerID
 					}
-					paymentMethod = photo.PaymentMethod
+					paymentMethod = NormalizePaymentMethod(photo.PaymentMethod)
 					if photo.AmountPaid != nil {
 						amountPaid = fmt.Sprintf("%.2f", *photo.AmountPaid)
 					}
@@ -219,7 +265,7 @@ func (s *Service) GenerateClientsCSV(ctx context.Context, tenantID, userEmail, u
 					p.Name,
 					p.Email,
 					p.AlternativeEmail,
-					p.Phone,
+					formattedPhone,
 					fileNumber,
 					photographerName,
 					competitionWon,

--- a/backend/internal/application/usecase/report/service_test.go
+++ b/backend/internal/application/usecase/report/service_test.go
@@ -285,21 +285,21 @@ func TestGenerateClientsCSV_FullExpansionAndRules(t *testing.T) {
 
 	// Check dog-1 rows (2 rows)
 	row1 := records[1]
-	if row1[0] != "Maria Souza" || row1[4] != "IMG_001" || row1[5] != "Fotógrafo Alpha" || row1[6] != "Melhor da Raça" || row1[10] != "100.50" {
+	if row1[0] != "Maria Souza" || row1[3] != "(11) 99999-8888" || row1[4] != "IMG_001" || row1[5] != "Fotógrafo Alpha" || row1[6] != "Melhor da Raça" || row1[8] != "Pix" || row1[10] != "100.50" {
 		t.Fatalf("row 1 mismatch: %v", row1)
 	}
 	row2 := records[2]
-	if row2[4] != "IMG_002" || row2[5] != "Fotógrafo Beta" || row2[6] != "Campeão Adulto" || row2[10] != "200.00" {
+	if row2[3] != "(11) 99999-8888" || row2[4] != "IMG_002" || row2[5] != "Fotógrafo Beta" || row2[6] != "Campeão Adulto" || row2[8] != "Cartão de Crédito" || row2[10] != "200.00" {
 		t.Fatalf("row 2 mismatch: %v", row2)
 	}
 
 	// Check dog-2 rows (3 rows, CSV injection sanitized with single quote, photo repeated on 3rd row)
 	row3 := records[3]
-	if row3[4] != "'=MALICIOUS_CMD" || row3[6] != "Sim" {
-		t.Fatalf("expected sanitized CSV injection field, got: %s", row3[4])
+	if row3[4] != "'=MALICIOUS_CMD" || row3[6] != "Sim" || row3[8] != "Dinheiro" {
+		t.Fatalf("expected sanitized CSV injection and Dinheiro payment, got: %v", row3)
 	}
 	row4 := records[4]
-	if row4[4] != "'+SUM(A1:A2)" || row4[6] != "Sim" {
+	if row4[4] != "'+SUM(A1:A2)" || row4[6] != "Sim" || row4[8] != "Pix" {
 		t.Fatalf("expected sanitized CSV injection field, got: %s", row4[4])
 	}
 	row5 := records[5]
@@ -346,6 +346,54 @@ func TestSanitizeCSVField(t *testing.T) {
 		got := SanitizeCSVField(tc.input)
 		if got != tc.expected {
 			t.Errorf("SanitizeCSVField(%q) = %q, expected %q", tc.input, got, tc.expected)
+		}
+	}
+}
+
+func TestFormatPhone(t *testing.T) {
+	cases := []struct {
+		input    string
+		expected string
+	}{
+		{"92991803034", "(92) 99180-3034"},
+		{"62996578137", "(62) 99657-8137"},
+		{"(21) 97297-8784", "(21) 97297-8784"},
+		{"1133334444", "(11) 3333-4444"},
+		{"999998888", "99999-8888"},
+		{"33334444", "3333-4444"},
+		{"", ""},
+	}
+
+	for _, tc := range cases {
+		got := FormatPhone(tc.input)
+		if got != tc.expected {
+			t.Errorf("FormatPhone(%q) = %q, expected %q", tc.input, got, tc.expected)
+		}
+	}
+}
+
+func TestNormalizePaymentMethod(t *testing.T) {
+	cases := []struct {
+		input    string
+		expected string
+	}{
+		{"Credit Card", "Cartão de Crédito"},
+		{"credit_card", "Cartão de Crédito"},
+		{"Debit Card", "Cartão de Débito"},
+		{"debit_card", "Cartão de Débito"},
+		{"Cash", "Dinheiro"},
+		{"dinheiro", "Dinheiro"},
+		{"Pix", "Pix"},
+		{"Não pago", "Não pago"},
+		{"nao_pago", "Não pago"},
+		{"Not Paid", "Não pago"},
+		{"Outro", "Outro"},
+	}
+
+	for _, tc := range cases {
+		got := NormalizePaymentMethod(tc.input)
+		if got != tc.expected {
+			t.Errorf("NormalizePaymentMethod(%q) = %q, expected %q", tc.input, got, tc.expected)
 		}
 	}
 }

--- a/backend/internal/domain/client/client.go
+++ b/backend/internal/domain/client/client.go
@@ -26,7 +26,7 @@ type Dog struct {
 type Photo struct {
 	FileNumber     string   `json:"file_number" bson:"file_number"`
 	PhotographerID string   `json:"photographer_id" bson:"photographer_id"`
-	PaymentMethod  string   `json:"payment_method" bson:"payment_method"` // Pix, Credit Card, Debit Card, Cash, Não pago
+	PaymentMethod  string   `json:"payment_method" bson:"payment_method"` // Pix, Cartão de Crédito, Cartão de Débito, Dinheiro, Não pago
 	AmountPaid     *float64 `json:"amount_paid" bson:"amount_paid"`
 }
 

--- a/frontend/src/features/clients/components/ClientDetailsModal.tsx
+++ b/frontend/src/features/clients/components/ClientDetailsModal.tsx
@@ -40,9 +40,9 @@ import { formatPhone } from "../../../utils/phone";
 
 const PAYMENT_METHODS = [
   "Pix",
-  "Credit Card",
-  "Debit Card",
-  "Cash",
+  "Cartão de Crédito",
+  "Cartão de Débito",
+  "Dinheiro",
   "Não pago",
 ];
 

--- a/frontend/src/features/clients/components/LinkClientModal.tsx
+++ b/frontend/src/features/clients/components/LinkClientModal.tsx
@@ -31,9 +31,9 @@ import {
 
 const PAYMENT_METHODS = [
   "Pix",
-  "Credit Card",
-  "Debit Card",
-  "Cash",
+  "Cartão de Crédito",
+  "Cartão de Débito",
+  "Dinheiro",
   "Não pago",
 ];
 

--- a/frontend/src/features/clients/pages/ClientDetailsPage.tsx
+++ b/frontend/src/features/clients/pages/ClientDetailsPage.tsx
@@ -43,9 +43,9 @@ import { formatPhone } from "../../../utils/phone";
 
 const PAYMENT_METHODS = [
   "Pix",
-  "Credit Card",
-  "Debit Card",
-  "Cash",
+  "Cartão de Crédito",
+  "Cartão de Débito",
+  "Dinheiro",
   "Não pago",
 ];
 

--- a/frontend/src/features/clients/pages/ClientsPage.tsx
+++ b/frontend/src/features/clients/pages/ClientsPage.tsx
@@ -52,9 +52,9 @@ import { useSeasonStore } from "../../../store/seasonStore";
 
 const PAYMENT_METHODS = [
   "Pix",
-  "Credit Card",
-  "Debit Card",
-  "Cash",
+  "Cartão de Crédito",
+  "Cartão de Débito",
+  "Dinheiro",
   "Não pago",
 ];
 

--- a/frontend/src/features/people/pages/PersonDetailsPage.tsx
+++ b/frontend/src/features/people/pages/PersonDetailsPage.tsx
@@ -60,9 +60,9 @@ import { formatPhone } from "../../../utils/phone";
 
 const PAYMENT_METHODS = [
   "Pix",
-  "Credit Card",
-  "Debit Card",
-  "Cash",
+  "Cartão de Crédito",
+  "Cartão de Débito",
+  "Dinheiro",
   "Não pago",
 ];
 
@@ -72,9 +72,12 @@ const getPaymentColor = (
   switch (method) {
     case "Pix":
       return "success";
+    case "Cartão de Crédito":
+    case "Cartão de Débito":
     case "Credit Card":
     case "Debit Card":
       return "primary";
+    case "Dinheiro":
     case "Cash":
       return "warning";
     case "Não pago":


### PR DESCRIPTION
### 📑 Resumo da Correção

1. **Padronização de Telefones no Relatório CSV**:
   - Correção do motivo de alguns telefones virem apenas com dígitos e outros formatados: no banco de dados, cadastros legados ou importados continham apenas números (`92991803034`), fazendo o Excel interpretá-los como valor numérico sem máscara.
   - Implementada a função `FormatPhone` no backend (`report.Service`) que sanitiza os dígitos e padroniza qualquer telefone brasileiro para `(XX) XXXXX-XXXX` (11 dígitos) ou `(XX) XXXX-XXXX` (10 dígitos).

2. **Formas de Pagamento 100% em Português**:
   - Implementada função `NormalizePaymentMethod` no backend para mapear e normalizar qualquer registro pré-existente em inglês (`Credit Card`, `Debit Card`, `Cash`, etc.) para o português (`Cartão de Crédito`, `Cartão de Débito`, `Dinheiro`, `Pix`, `Não pago`).
   - Atualizadas todas as constantes `PAYMENT_METHODS` e seletores nos componentes e telas do Frontend (`ClientsPage`, `ClientDetailsPage`, `ClientDetailsModal`, `LinkClientModal`, `PersonDetailsPage`).
   - Documentação OpenAPI/Swagger atualizada.

#### 🧪 Validação
- [x] Testes unitários para `FormatPhone` e `NormalizePaymentMethod`.
- [x] `./scripts/check.sh all` aprovado (Backend vet e testes, Frontend typecheck/lint/format/tests e Terraform).
