### PR TITLE
docs(readme): alinhar documentacao e templates com dominio photo storage

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -6,7 +6,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Obrigado por contribuir com novas ideias para o **PS**! Por favor, detalhe a proposta abaixo para facilitar a análise arquitetural e a execução técnica.
+        Obrigado por contribuir com novas ideias para o **PS (Photo Storage)**! Por favor, detalhe a proposta abaixo para facilitar a análise arquitetural e a execução técnica.
 
   - type: textarea
     id: user-story
@@ -14,9 +14,9 @@ body:
       label: Visão Geral e Contexto de Negócio
       description: Explique a motivação da funcionalidade e o valor entregue ao usuário (ex: formato de User Story).
       placeholder: |
-        **Como** proprietário de veículo cadastrado no PS,
-        **Quero** receber alertas automáticos quando uma revisão preventiva estiver próxima do vencimento,
-        **Para que** eu não perca os prazos de manutenção recomendados.
+        **Como** fotógrafo parceiro ou administrador cadastrado no PS,
+        **Quero** exportar relatórios customizados de ensaios e clientes por temporada,
+        **Para que** eu possa acompanhar as vendas e o volume de coberturas fotográficas realizadas.
     validations:
       required: true
 
@@ -26,9 +26,9 @@ body:
       label: Requisitos Funcionais e Critérios de Aceite
       description: Detalhe as regras de negócio esperadas e os critérios necessários para considerar a feature concluída.
       placeholder: |
-        - [ ] O sistema deve permitir configurar intervalo de alerta (dias ou km).
-        - [ ] Na listagem de manutenções (`/maintenances`), destacar itens com status "Próximo".
-        - [ ] A API deve retornar o campo `isUpcoming: boolean` no DTO de resposta.
+        - [ ] O sistema deve permitir filtrar fotos e ensaios por temporada, fotógrafo e cliente.
+        - [ ] Na listagem de temporadas (`/seasons`), exibir o total de ensaios vinculados.
+        - [ ] A API deve retornar métricas agregadas no DTO de resposta.
     validations:
       required: true
 
@@ -54,9 +54,9 @@ body:
       label: Detalhes Técnicos e Arquitetura Proposta
       description: Liste novos endpoints REST, DTOs, novos componentes React ou alterações de modelo.
       placeholder: |
-        - **Novos Endpoints**: `GET /api/v1/maintenances/alerts`
-        - **Novos Componentes**: `MaintenanceAlertBanner.tsx` em `frontend/src/features/maintenance/`
-        - **Estado**: Adicionar action `fetchAlerts` em store Zustand.
+        - **Novos Endpoints**: `GET /api/v1/seasons/metrics`
+        - **Novos Componentes**: `SeasonMetricsCard.tsx` em `frontend/src/features/seasons/`
+        - **Estado**: Adicionar action `fetchMetrics` em store Zustand.
     validations:
       required: false
 
@@ -64,9 +64,9 @@ body:
     id: security-performance
     attributes:
       label: Considerações de Segurança e Performance
-      description: Especifique aspectos de segurança (ex: validação de ownership, cookies HttpOnly, rate limit, sanitização) e impacto em performance.
+      description: Especifique aspectos de segurança (ex: validação de ownership/tenant, cookies HttpOnly, rate limit, sanitização) e impacto em performance.
       placeholder: |
-        - Validar que o usuário só pode acessar alertas dos seus próprios veículos (`userID` extraído do contexto de autenticação).
+        - Validar que o usuário só pode acessar dados do seu próprio tenant (`tenantID` extraído do contexto de autenticação).
         - Sanitizar inputs para evitar XSS e injeção NoSQL no MongoDB.
     validations:
       required: false

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,6 +1,6 @@
 # Política de Segurança (Security Policy) — PS
 
-A equipe do **PS (Como Vai Meu Carro)** leva a segurança de seus sistemas, dados e usuários muito a sério. Como a plataforma opera no modelo **SaaS com Entrega Contínua (Continuous Delivery)**, correções e atualizações são integradas e disponibilizadas diretamente em produção.
+A equipe do **PS (Photo Storage)** leva a segurança de seus sistemas, dados e usuários muito a sério. Como a plataforma opera no modelo **SaaS com Entrega Contínua (Continuous Delivery)**, correções e atualizações são integradas e disponibilizadas diretamente em produção.
 
 ---
 
@@ -15,7 +15,7 @@ Por se tratar de um serviço web SaaS, não existem versões legadas ou pacotes 
 
 ### 🎯 Vulnerabilidades Prioritárias em Escopo
 - Quebra de autenticação ou vazamento de credenciais/sessões (tokens JWT via cookies `HttpOnly`).
-- Falhas de autorização e controle de acesso a dados (BOLA / IDOR em veículos, manutenções ou perfis).
+- Falhas de autorização e controle de acesso a dados (BOLA / IDOR em clientes, fotógrafos, temporadas ou perfis).
 - Injeções (NoSQL Injection, Command Injection, etc.).
 - Vulnerabilidades de manipulação de arquivos ou *Path Traversal* em rotas de upload.
 - Cross-Site Scripting (XSS) com impacto demonstrável.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🚗 PS - Photo Storage
+# 📸 PS - Photo Storage
 
 <div align="center">
 
@@ -10,7 +10,7 @@
 ![CI Frontend](https://img.shields.io/github/actions/workflow/status/yurinogueira/PS/frontend.yml?branch=main&label=CI%20Frontend&style=for-the-badge)
 ![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=for-the-badge)
 
-**Plataforma moderna para gestão, controle de custos e histórico de manutenção veicular.**
+**Plataforma moderna para armazenamento, gestão inteligente de fotografias, eventos, temporadas, fotógrafos e clientes.**
 
 [Acessar Web App](https://ps.yurinogueira.dev.br)
 
@@ -23,17 +23,18 @@
 | Serviço | URL | Descrição |
 | :--- | :--- | :--- |
 | **🌐 Web App** | [ps.yurinogueira.dev.br](https://ps.yurinogueira.dev.br) | Aplicação SPA em produção (GitHub Pages + Cloudflare) |
+| **⚡ API REST** | [api-ps.yurinogueira.dev.br](https://api-ps.yurinogueira.dev.br) | Backend em Go com Clean Architecture hospedado na OCI |
 
 ---
 
 ## 🌟 Funcionalidades
 
-- 🔐 **Autenticação Segura & RBAC**: Sessões gerenciadas via cookies `HttpOnly` com suporte a refresh token, sem expor tokens no frontend e com controle de acesso baseado em papéis (Admin/User).
-- 🚘 **Gestão Completa de Veículos**: Cadastro, listagem, busca e edição de automóveis com placa, marca, modelo, ano de fabricação/modelo, quilometragem atual e tipo de combustível.
-- 🛠️ **Histórico de Manutenções**: Registro minucioso de revisões preventivas e corretivas, datas, oficinas, custos de peças e mão de obra, além de alertas por quilometragem.
-- 📎 **Upload de Comprovantes**: Anexação de notas fiscais, relatórios e recibos de serviços com validação de tipos MIME e isolamento de storage.
-- 📊 **Dashboard Analítico**: Indicadores de saúde veicular, métricas de custos consolidados, próximos alertas de revisão e atalhos rápidos.
-- 🛡️ **Segurança em Camadas**: CORS estrito, rate limiting por IP, validação de payloads, cabeçalhos de segurança HTTP (HSTS, CSP, X-Frame-Options) e sanitização contra Path Traversal.
+- 🔐 **Autenticação Segura & Multi-tenant (RBAC)**: Sessões gerenciadas via cookies `HttpOnly` com suporte a refresh token automático, recuperação e verificação de e-mail e controle de acesso baseado em papéis (SuperAdmin, Admin, Fotógrafo/Usuário).
+- 📸 **Gestão de Fotógrafos & Clientes**: Cadastro, listagem, filtros e gestão de fotógrafos parceiros e clientes atendidos com controle de cobrança e histórico.
+- 🏆 **Temporadas e Eventos**: Organização de coberturas fotográficas por temporadas de eventos e competições com agrupamento temático e temporal.
+- 👥 **Gestão de Pessoas & Participantes**: Registro e identificação de pessoas associadas aos eventos, ensaios e fotografias.
+- 📊 **Relatórios & Exportação Assíncrona**: Geração e download sob demanda de relatórios completos em formato CSV com streaming eficiente e baixo consumo de memória.
+- 🛡️ **Segurança em Camadas**: CORS estrito, rate limiting defensivo por IP, proteção contra Path Traversal, cabeçalhos de segurança HTTP (HSTS, CSP, X-Frame-Options) e sanitização rigorosa de payloads.
 
 ---
 
@@ -42,9 +43,9 @@
 ### Backend (Go)
 - **Linguagem**: Go 1.25
 - **Arquitetura**: Clean Architecture + Domain-Driven Design (DDD)
-  - `internal/domain/`: Entidades de negócio puras e regras de domínio.
-  - `internal/application/ports/`: Contratos e interfaces de repositórios/serviços.
-  - `internal/application/usecase/`: Casos de uso e orquestração de lógica de negócio.
+  - `internal/domain/`: Entidades de negócio puras (auth, client, person, photographer, season, tenant, user).
+  - `internal/application/ports/`: Contratos e interfaces de repositórios e serviços.
+  - `internal/application/usecase/`: Casos de uso e orquestração de regras de negócio.
   - `internal/infrastructure/`: Implementações de banco de dados (MongoDB), JWT, bcrypt e storage.
   - `internal/interfaces/rest/`: Handlers HTTP REST, roteamento e documentação Swagger com Swaggo.
 - **Banco de Dados**: MongoDB 8 (Local) e MongoDB Atlas (Produção).
@@ -52,7 +53,7 @@
 ### Frontend (React)
 - **Framework & Ferramentas**: React 19, TypeScript, Vite, React Router v7.
 - **UI & Estilização**: Material UI (MUI v6) com `@mui/icons-material` e paleta de cores personalizada.
-- **Gerenciamento de Estado**: Zustand (gerenciamento desacoplado de estado da UI e perfil).
+- **Gerenciamento de Estado**: Zustand (gerenciamento desacoplado de estado da UI e autenticação).
 - **Comunicação HTTP**: Axios configurado com `withCredentials: true` para transporte automático de cookies `HttpOnly`.
 
 ### Infraestrutura & DevOps
@@ -75,10 +76,11 @@ PS/
 │   └── Dockerfile            # Container de produção Go
 ├── frontend/                 # Aplicação SPA em React 19 + Vite
 │   ├── src/
-│   │   ├── features/         # Módulos: auth, cars, dashboard, maintenance
+│   │   ├── features/         # Módulos: admin, auth, clients, dashboard, people, photographers, profile, reports, seasons
 │   │   ├── layouts/          # Shell da aplicação (Sidebar, Topbar, AppLayout)
 │   │   ├── routes/           # Rotas públicas e rotas protegidas
 │   │   └── services/         # Clientes de API e storage seguro
+│   └── Dockerfile            # Container de build/produção Frontend
 ├── deploy/                   # Configurações de Caddy, systemd e exemplos de env
 ├── scripts/                  # Scripts otimizados de checagem, build e dev
 ├── terraform/                # Definições IaC (OCI, Cloudflare, Mongo Atlas)


### PR DESCRIPTION
### 📌 Resumo das Alterações

Esta PR remove integralmente referências herdadas de templates antigos sobre gestão veicular/manutenção automotiva e alinha toda a documentação com o domínio real do **PS (Photo Storage)**:

1. **`README.md`**:
   - Atualizado título, subtítulo e badges para foco em armazenamento e gestão de fotos, eventos, temporadas, fotógrafos e clientes.
   - Atualizada a seção de funcionalidades detalhando autenticação multi-tenant com cookies `HttpOnly`, gestão de fotógrafos e clientes, temporadas e competições, pessoas/participantes e exportação assíncrona de relatórios em CSV com baixo consumo de memória.
   - Atualizada a árvore de módulos do frontend (`admin, auth, clients, dashboard, people, photographers, profile, reports, seasons`).
   - Inclusão do link da API em produção (`api-ps.yurinogueira.dev.br`).

2. **`.github/SECURITY.md`**:
   - Ajustado nome do projeto para **PS (Photo Storage)**.
   - Atualizado escopo de segurança para o modelo de domínio do sistema (`clientes, fotógrafos, temporadas ou perfis`).

3. **`.github/ISSUE_TEMPLATE/feature_request.yml`**:
   - Atualizados os exemplos, User Stories e placeholders para cenários do Photo Storage.

---

### 🧪 Checklist de Validação

- [x] `./scripts/check.sh all` executado com 100% de aprovação (Go vet/tests, frontend typecheck/lint/format/vitest e Terraform fmt).
- [x] Sincronização com a branch `main`.
- [x] Padrão Conventional Commits respeitado.