### PR TITLE
chore(repo): remover binario compilado backend/api do git e ajustar gitignore (#20)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Build outputs
 dist/
 backend/bin/
+backend/api
 backend/.coverprofile
 
 # Node


### PR DESCRIPTION
## 📌 Descrição das Alterações

- Desindexado e removido o binário ELF compilado `backend/api` (~32MB) do controle de versão do Git.
- Atualizado o arquivo `.gitignore` com a regra `backend/api` na seção de saídas de compilação.

Closes #20

---

## 🧪 Validações Realizadas

- [x] `./scripts/check.sh all` executado com sucesso (Backend vet/tests, Frontend typecheck/lint/format/tests, Terraform fmt).
- [x] Validação de status git e rastreamento de arquivos.
