### PR TITLE
fix(terraform): restringir permissoes do usuario da aplicacao no mongodb atlas (#19)

### DIFF
--- a/terraform/mongodb.tf
+++ b/terraform/mongodb.tf
@@ -34,8 +34,8 @@ resource "mongodbatlas_database_user" "app_user" {
   auth_database_name = "admin"
 
   roles {
-    role_name     = "readWriteAnyDatabase"
-    database_name = "admin"
+    role_name     = "readWrite"
+    database_name = var.project_name
   }
 }
 


### PR DESCRIPTION
### Descrição das Alterações
Restringe as permissões do usuário de banco de dados da aplicação (`mongodbatlas_database_user.app_user`) no MongoDB Atlas para a role `readWrite` aplicada única e exclusivamente no database específico do projeto (`var.project_name`), em conformidade com o princípio do menor privilégio (Least Privilege).

### Referência
Resolves #19

### Checklist de Validação
- [x] `./scripts/check.sh all` executado com 100% de sucesso (Backend, Frontend e Terraform fmt).
- [x] Formatação HCL verificada via `terraform fmt`.