### PR TITLE
fix(clients): validar pertinencia de tenant em referencias cruzadas de person_id, season_id e photographer_id (#18)

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -654,7 +654,7 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Requisição inválida",
+                        "description": "Requisição inválida ou referência não pertencente ao tenant",
                         "schema": {
                             "type": "string"
                         }
@@ -764,13 +764,19 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Requisição inválida",
+                        "description": "Requisição inválida ou referência não pertencente ao tenant",
                         "schema": {
                             "type": "string"
                         }
                     },
                     "401": {
                         "description": "Não autenticado",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "Cliente não encontrado",
                         "schema": {
                             "type": "string"
                         }

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -648,7 +648,7 @@
                         }
                     },
                     "400": {
-                        "description": "Requisição inválida",
+                        "description": "Requisição inválida ou referência não pertencente ao tenant",
                         "schema": {
                             "type": "string"
                         }
@@ -758,13 +758,19 @@
                         }
                     },
                     "400": {
-                        "description": "Requisição inválida",
+                        "description": "Requisição inválida ou referência não pertencente ao tenant",
                         "schema": {
                             "type": "string"
                         }
                     },
                     "401": {
                         "description": "Não autenticado",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "Cliente não encontrado",
                         "schema": {
                             "type": "string"
                         }

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -606,7 +606,7 @@ paths:
           schema:
             $ref: '#/definitions/client.SeasonClient'
         "400":
-          description: Requisição inválida
+          description: Requisição inválida ou referência não pertencente ao tenant
           schema:
             type: string
         "401":
@@ -707,11 +707,15 @@ paths:
           schema:
             $ref: '#/definitions/client.SeasonClient'
         "400":
-          description: Requisição inválida
+          description: Requisição inválida ou referência não pertencente ao tenant
           schema:
             type: string
         "401":
           description: Não autenticado
+          schema:
+            type: string
+        "404":
+          description: Cliente não encontrado
           schema:
             type: string
         "500":

--- a/backend/internal/application/usecase/client/service.go
+++ b/backend/internal/application/usecase/client/service.go
@@ -2,20 +2,90 @@ package client
 
 import (
 	"context"
-	"ps/internal/application/ports/client"
+	"errors"
+
+	clientport "ps/internal/application/ports/client"
+	personport "ps/internal/application/ports/person"
+	photographerport "ps/internal/application/ports/photographer"
+	seasonport "ps/internal/application/ports/season"
 	domain "ps/internal/domain/client"
 )
 
+var (
+	ErrPersonNotFound       = errors.New("person not found or does not belong to tenant")
+	ErrSeasonNotFound       = errors.New("season not found or does not belong to tenant")
+	ErrPhotographerNotFound = errors.New("photographer not found or does not belong to tenant")
+	ErrClientNotFound       = errors.New("client not found or does not belong to tenant")
+)
+
 type Service struct {
-	repo client.Repository
+	repo             clientport.Repository
+	personRepo       personport.Repository
+	seasonRepo       seasonport.Repository
+	photographerRepo photographerport.Repository
 }
 
-func NewService(repo client.Repository) *Service {
-	return &Service{repo: repo}
+func NewService(
+	repo clientport.Repository,
+	personRepo personport.Repository,
+	seasonRepo seasonport.Repository,
+	photographerRepo photographerport.Repository,
+) *Service {
+	return &Service{
+		repo:             repo,
+		personRepo:       personRepo,
+		seasonRepo:       seasonRepo,
+		photographerRepo: photographerRepo,
+	}
+}
+
+func (s *Service) validateReferences(ctx context.Context, c *domain.SeasonClient, tenantID string) error {
+	if s.personRepo != nil {
+		if c.PersonID == "" {
+			return ErrPersonNotFound
+		}
+		person, err := s.personRepo.GetByID(ctx, c.PersonID, tenantID)
+		if err != nil || person == nil {
+			return ErrPersonNotFound
+		}
+	}
+
+	if s.seasonRepo != nil {
+		if c.SeasonID == "" {
+			return ErrSeasonNotFound
+		}
+		season, err := s.seasonRepo.GetByID(ctx, c.SeasonID, tenantID)
+		if err != nil || season == nil {
+			return ErrSeasonNotFound
+		}
+	}
+
+	if s.photographerRepo != nil {
+		validatedPhotographers := make(map[string]bool)
+		for _, dog := range c.Dogs {
+			for _, photo := range dog.Photos {
+				if photo.PhotographerID != "" {
+					if validatedPhotographers[photo.PhotographerID] {
+						continue
+					}
+					photog, err := s.photographerRepo.GetByID(ctx, photo.PhotographerID, tenantID)
+					if err != nil || photog == nil {
+						return ErrPhotographerNotFound
+					}
+					validatedPhotographers[photo.PhotographerID] = true
+				}
+			}
+		}
+	}
+
+	return nil
 }
 
 func (s *Service) Create(ctx context.Context, client *domain.SeasonClient, tenantID string) error {
 	client.TenantID = tenantID
+	if err := s.validateReferences(ctx, client, tenantID); err != nil {
+		return err
+	}
 	return s.repo.Create(ctx, client)
 }
 
@@ -38,6 +108,12 @@ func (s *Service) List(ctx context.Context, tenantID string, filter domain.ListF
 
 func (s *Service) Update(ctx context.Context, client *domain.SeasonClient, tenantID string) error {
 	client.TenantID = tenantID
+	if _, err := s.repo.GetByID(ctx, client.ID, tenantID); err != nil {
+		return ErrClientNotFound
+	}
+	if err := s.validateReferences(ctx, client, tenantID); err != nil {
+		return err
+	}
 	return s.repo.Update(ctx, client)
 }
 

--- a/backend/internal/application/usecase/client/service_test.go
+++ b/backend/internal/application/usecase/client/service_test.go
@@ -7,6 +7,9 @@ import (
 
 	"ps/internal/application/usecase/client"
 	domain "ps/internal/domain/client"
+	persondomain "ps/internal/domain/person"
+	photographerdomain "ps/internal/domain/photographer"
+	seasondomain "ps/internal/domain/season"
 )
 
 type mockRepo struct {
@@ -90,13 +93,145 @@ func (m *mockRepo) Delete(ctx context.Context, id, tenantID string) error {
 	return nil
 }
 
+type mockPersonRepo struct {
+	items map[string]*persondomain.Person
+}
+
+func newMockPersonRepo() *mockPersonRepo {
+	return &mockPersonRepo{items: make(map[string]*persondomain.Person)}
+}
+
+func (m *mockPersonRepo) Create(ctx context.Context, p *persondomain.Person) error {
+	m.items[p.ID] = p
+	return nil
+}
+
+func (m *mockPersonRepo) GetByID(ctx context.Context, id, tenantID string) (*persondomain.Person, error) {
+	p, ok := m.items[id]
+	if !ok || p.TenantID != tenantID {
+		return nil, errors.New("not found")
+	}
+	return p, nil
+}
+
+func (m *mockPersonRepo) List(ctx context.Context, tenantID string) ([]*persondomain.Person, error) {
+	var res []*persondomain.Person
+	for _, p := range m.items {
+		if p.TenantID == tenantID {
+			res = append(res, p)
+		}
+	}
+	return res, nil
+}
+
+func (m *mockPersonRepo) Update(ctx context.Context, p *persondomain.Person) error {
+	m.items[p.ID] = p
+	return nil
+}
+
+func (m *mockPersonRepo) Delete(ctx context.Context, id, tenantID string) error {
+	delete(m.items, id)
+	return nil
+}
+
+type mockSeasonRepo struct {
+	items map[string]*seasondomain.Season
+}
+
+func newMockSeasonRepo() *mockSeasonRepo {
+	return &mockSeasonRepo{items: make(map[string]*seasondomain.Season)}
+}
+
+func (m *mockSeasonRepo) Create(ctx context.Context, s *seasondomain.Season) error {
+	m.items[s.ID] = s
+	return nil
+}
+
+func (m *mockSeasonRepo) GetByID(ctx context.Context, id, tenantID string) (*seasondomain.Season, error) {
+	s, ok := m.items[id]
+	if !ok || s.TenantID != tenantID {
+		return nil, errors.New("not found")
+	}
+	return s, nil
+}
+
+func (m *mockSeasonRepo) List(ctx context.Context, tenantID string) ([]*seasondomain.Season, error) {
+	var res []*seasondomain.Season
+	for _, s := range m.items {
+		if s.TenantID == tenantID {
+			res = append(res, s)
+		}
+	}
+	return res, nil
+}
+
+func (m *mockSeasonRepo) Update(ctx context.Context, s *seasondomain.Season) error {
+	m.items[s.ID] = s
+	return nil
+}
+
+func (m *mockSeasonRepo) Delete(ctx context.Context, id, tenantID string) error {
+	delete(m.items, id)
+	return nil
+}
+
+type mockPhotographerRepo struct {
+	items map[string]*photographerdomain.Photographer
+}
+
+func newMockPhotographerRepo() *mockPhotographerRepo {
+	return &mockPhotographerRepo{items: make(map[string]*photographerdomain.Photographer)}
+}
+
+func (m *mockPhotographerRepo) Create(ctx context.Context, p *photographerdomain.Photographer) error {
+	m.items[p.ID] = p
+	return nil
+}
+
+func (m *mockPhotographerRepo) GetByID(ctx context.Context, id, tenantID string) (*photographerdomain.Photographer, error) {
+	p, ok := m.items[id]
+	if !ok || p.TenantID != tenantID {
+		return nil, errors.New("not found")
+	}
+	return p, nil
+}
+
+func (m *mockPhotographerRepo) List(ctx context.Context, tenantID string) ([]*photographerdomain.Photographer, error) {
+	var res []*photographerdomain.Photographer
+	for _, p := range m.items {
+		if p.TenantID == tenantID {
+			res = append(res, p)
+		}
+	}
+	return res, nil
+}
+
+func (m *mockPhotographerRepo) Update(ctx context.Context, p *photographerdomain.Photographer) error {
+	m.items[p.ID] = p
+	return nil
+}
+
+func (m *mockPhotographerRepo) Delete(ctx context.Context, id, tenantID string) error {
+	delete(m.items, id)
+	return nil
+}
+
 func TestClientService(t *testing.T) {
 	repo := newMockRepo()
-	svc := client.NewService(repo)
+	personRepo := newMockPersonRepo()
+	seasonRepo := newMockSeasonRepo()
+	photogRepo := newMockPhotographerRepo()
+
+	svc := client.NewService(repo, personRepo, seasonRepo, photogRepo)
 	ctx := context.Background()
 	tenantID := "tenant-client"
 
-	// 1. Create
+	// Seed valid foreign records for tenantID
+	personRepo.items["person-123"] = &persondomain.Person{ID: "person-123", TenantID: tenantID, Name: "John Doe"}
+	seasonRepo.items["season-123"] = &seasondomain.Season{ID: "season-123", TenantID: tenantID, Name: "Season 2026"}
+	photogRepo.items["photo-1"] = &photographerdomain.Photographer{ID: "photo-1", TenantID: tenantID, Name: "Photographer 1"}
+
+	// 1. Create with valid references
 	c := &domain.SeasonClient{
 		PersonID: "person-123",
 		SeasonID: "season-123",
@@ -132,7 +267,7 @@ func TestClientService(t *testing.T) {
 		t.Fatalf("expected 1 dog, person-123, and 2 won competitions, got %v", found)
 	}
 
-	// Multi-tenant check
+	// Multi-tenant check on client itself
 	if _, err := svc.GetByID(ctx, c.ID, "tenant-other"); err == nil {
 		t.Fatalf("expected error accessing across tenant, got nil")
 	}
@@ -176,3 +311,159 @@ func TestClientService(t *testing.T) {
 		t.Fatalf("expected error after delete, got nil")
 	}
 }
+
+func TestClientService_CrossTenantValidation(t *testing.T) {
+	repo := newMockRepo()
+	personRepo := newMockPersonRepo()
+	seasonRepo := newMockSeasonRepo()
+	photogRepo := newMockPhotographerRepo()
+
+	svc := client.NewService(repo, personRepo, seasonRepo, photogRepo)
+	ctx := context.Background()
+
+	tenantA := "tenant-A"
+	tenantB := "tenant-B"
+
+	// Populate tenantA entities
+	personRepo.items["person-A"] = &persondomain.Person{ID: "person-A", TenantID: tenantA, Name: "Person A"}
+	seasonRepo.items["season-A"] = &seasondomain.Season{ID: "season-A", TenantID: tenantA, Name: "Season A"}
+	photogRepo.items["photo-A"] = &photographerdomain.Photographer{ID: "photo-A", TenantID: tenantA, Name: "Photo A"}
+
+	// Populate tenantB entities
+	personRepo.items["person-B"] = &persondomain.Person{ID: "person-B", TenantID: tenantB, Name: "Person B"}
+	seasonRepo.items["season-B"] = &seasondomain.Season{ID: "season-B", TenantID: tenantB, Name: "Season B"}
+	photogRepo.items["photo-B"] = &photographerdomain.Photographer{ID: "photo-B", TenantID: tenantB, Name: "Photo B"}
+
+	// 1. Create with alien PersonID
+	t.Run("Create - alien PersonID", func(t *testing.T) {
+		c := &domain.SeasonClient{
+			PersonID: "person-B", // belongs to tenantB
+			SeasonID: "season-A",
+		}
+		err := svc.Create(ctx, c, tenantA)
+		if !errors.Is(err, client.ErrPersonNotFound) {
+			t.Fatalf("expected ErrPersonNotFound, got %v", err)
+		}
+	})
+
+	// 2. Create with non-existent PersonID
+	t.Run("Create - non-existent PersonID", func(t *testing.T) {
+		c := &domain.SeasonClient{
+			PersonID: "person-non-existent",
+			SeasonID: "season-A",
+		}
+		err := svc.Create(ctx, c, tenantA)
+		if !errors.Is(err, client.ErrPersonNotFound) {
+			t.Fatalf("expected ErrPersonNotFound, got %v", err)
+		}
+	})
+
+	// 3. Create with alien SeasonID
+	t.Run("Create - alien SeasonID", func(t *testing.T) {
+		c := &domain.SeasonClient{
+			PersonID: "person-A",
+			SeasonID: "season-B", // belongs to tenantB
+		}
+		err := svc.Create(ctx, c, tenantA)
+		if !errors.Is(err, client.ErrSeasonNotFound) {
+			t.Fatalf("expected ErrSeasonNotFound, got %v", err)
+		}
+	})
+
+	// 4. Create with alien PhotographerID in photos
+	t.Run("Create - alien PhotographerID", func(t *testing.T) {
+		c := &domain.SeasonClient{
+			PersonID: "person-A",
+			SeasonID: "season-A",
+			Dogs: []domain.Dog{
+				{
+					Breed: "Poodle",
+					Photos: []domain.Photo{
+						{FileNumber: "IMG_001", PhotographerID: "photo-B"}, // belongs to tenantB
+					},
+				},
+			},
+		}
+		err := svc.Create(ctx, c, tenantA)
+		if !errors.Is(err, client.ErrPhotographerNotFound) {
+			t.Fatalf("expected ErrPhotographerNotFound, got %v", err)
+		}
+	})
+
+	// 5. Successful Create in tenantA
+	validClient := &domain.SeasonClient{
+		ID:       "client-A-1",
+		PersonID: "person-A",
+		SeasonID: "season-A",
+		Dogs: []domain.Dog{
+			{
+				Breed: "Poodle",
+				Photos: []domain.Photo{
+					{FileNumber: "IMG_001", PhotographerID: "photo-A"},
+					{FileNumber: "IMG_002", PhotographerID: ""}, // Empty photographer is valid
+				},
+			},
+		},
+	}
+	if err := svc.Create(ctx, validClient, tenantA); err != nil {
+		t.Fatalf("unexpected error creating valid client: %v", err)
+	}
+
+	// 6. Update - client not found or from alien tenant
+	t.Run("Update - alien tenant client update", func(t *testing.T) {
+		updateAttempt := &domain.SeasonClient{
+			ID:       "client-A-1",
+			PersonID: "person-B",
+			SeasonID: "season-B",
+		}
+		err := svc.Update(ctx, updateAttempt, tenantB) // tenantB trying to update tenantA's client
+		if !errors.Is(err, client.ErrClientNotFound) {
+			t.Fatalf("expected ErrClientNotFound, got %v", err)
+		}
+	})
+
+	// 7. Update - valid client with alien references
+	t.Run("Update - alien PersonID", func(t *testing.T) {
+		updateAttempt := &domain.SeasonClient{
+			ID:       "client-A-1",
+			PersonID: "person-B",
+			SeasonID: "season-A",
+		}
+		err := svc.Update(ctx, updateAttempt, tenantA)
+		if !errors.Is(err, client.ErrPersonNotFound) {
+			t.Fatalf("expected ErrPersonNotFound, got %v", err)
+		}
+	})
+
+	t.Run("Update - alien SeasonID", func(t *testing.T) {
+		updateAttempt := &domain.SeasonClient{
+			ID:       "client-A-1",
+			PersonID: "person-A",
+			SeasonID: "season-B",
+		}
+		err := svc.Update(ctx, updateAttempt, tenantA)
+		if !errors.Is(err, client.ErrSeasonNotFound) {
+			t.Fatalf("expected ErrSeasonNotFound, got %v", err)
+		}
+	})
+
+	t.Run("Update - alien PhotographerID", func(t *testing.T) {
+		updateAttempt := &domain.SeasonClient{
+			ID:       "client-A-1",
+			PersonID: "person-A",
+			SeasonID: "season-A",
+			Dogs: []domain.Dog{
+				{
+					Photos: []domain.Photo{
+						{FileNumber: "IMG_003", PhotographerID: "photo-B"},
+					},
+				},
+			},
+		}
+		err := svc.Update(ctx, updateAttempt, tenantA)
+		if !errors.Is(err, client.ErrPhotographerNotFound) {
+			t.Fatalf("expected ErrPhotographerNotFound, got %v", err)
+		}
+	})
+}
+

--- a/backend/internal/interfaces/rest/handlers/client_handler.go
+++ b/backend/internal/interfaces/rest/handlers/client_handler.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"strconv"
 
@@ -26,7 +27,7 @@ func NewSeasonClientHandler(service *client.Service) *SeasonClientHandler {
 // @Produce      json
 // @Param        client body client.SeasonClient true "Dados do Cliente da Temporada"
 // @Success      201    {object}  client.SeasonClient
-// @Failure      400    {string}  string "Requisição inválida"
+// @Failure      400    {string}  string "Requisição inválida ou referência não pertencente ao tenant"
 // @Failure      401    {string}  string "Não autenticado"
 // @Failure      500    {string}  string "Erro interno"
 // @Router       /api/v1/clients [post]
@@ -39,7 +40,14 @@ func (h *SeasonClientHandler) Create(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.service.Create(r.Context(), &req, tenantID); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		switch {
+		case errors.Is(err, client.ErrPersonNotFound),
+			errors.Is(err, client.ErrSeasonNotFound),
+			errors.Is(err, client.ErrPhotographerNotFound):
+			http.Error(w, err.Error(), http.StatusBadRequest)
+		default:
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
 		return
 	}
 
@@ -134,8 +142,9 @@ func (h *SeasonClientHandler) GetByID(w http.ResponseWriter, r *http.Request) {
 // @Param        id      path      string              true  "ID do Cliente"
 // @Param        client  body      client.SeasonClient true  "Dados do Cliente"
 // @Success      200     {object}  client.SeasonClient
-// @Failure      400     {string}  string "Requisição inválida"
+// @Failure      400     {string}  string "Requisição inválida ou referência não pertencente ao tenant"
 // @Failure      401     {string}  string "Não autenticado"
+// @Failure      404     {string}  string "Cliente não encontrado"
 // @Failure      500     {string}  string "Erro interno"
 // @Router       /api/v1/clients/{id} [put]
 func (h *SeasonClientHandler) Update(w http.ResponseWriter, r *http.Request) {
@@ -154,7 +163,16 @@ func (h *SeasonClientHandler) Update(w http.ResponseWriter, r *http.Request) {
 	req.ID = id
 
 	if err := h.service.Update(r.Context(), &req, tenantID); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		switch {
+		case errors.Is(err, client.ErrClientNotFound):
+			http.Error(w, err.Error(), http.StatusNotFound)
+		case errors.Is(err, client.ErrPersonNotFound),
+			errors.Is(err, client.ErrSeasonNotFound),
+			errors.Is(err, client.ErrPhotographerNotFound):
+			http.Error(w, err.Error(), http.StatusBadRequest)
+		default:
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
 		return
 	}
 

--- a/backend/internal/interfaces/rest/router.go
+++ b/backend/internal/interfaces/rest/router.go
@@ -58,7 +58,7 @@ func NewRouter(
 	seasonSvc := seasonusecase.NewService(seasons)
 	photographerSvc := photographerusecase.NewService(photographers)
 	personSvc := personusecase.NewService(persons)
-	clientSvc := clientusecase.NewService(clients)
+	clientSvc := clientusecase.NewService(clients, persons, seasons, photographers)
 	reportSvc := reportusecase.NewService(clients, persons, photographers, storageProvider, emailSender, cfg.AppBaseURL)
 
 	seasonHandler := handlers.NewSeasonHandler(seasonSvc)


### PR DESCRIPTION
### 🎯 Resumo das Alterações
- Injeção de repositórios de `person`, `season` e `photographer` no use case `client.Service`.
- Implementação de validação defensiva de integridade referencial e isolamento multi-tenant (`validateReferences`):
  - Garante que `PersonID` pertença ao `tenantID` autenticado (via `personRepo.GetByID`).
  - Garante que `SeasonID` pertença ao `tenantID` autenticado (via `seasonRepo.GetByID`).
  - Garante que qualquer `PhotographerID` associado a fotos dos cães pertença ao `tenantID` autenticado (via `photographerRepo.GetByID`).
- Validação de existência do cliente no tenant em operações de `Update` (`ErrClientNotFound`).
- Mapeamento adequado de erros nos endpoints REST (`POST /api/v1/clients` e `PUT /api/v1/clients/{id}`) retornando `400 Bad Request` e `404 Not Found`.
- Adição de testes unitários abrangentes cobrindo tentativas de associação cruzada entre tenants (IDOR indireto) e referências inexistentes.
- Regeneração da documentação OpenAPI/Swagger.

Closes #18

### 📋 Checklist de Validação
- [x] `./scripts/swagger.sh` (Swagger atualizado)
- [x] `./scripts/check.sh all` (Backend vet/tests, Frontend typecheck/lint/tests, Terraform fmt)