### PR TITLE
feat(clients): posicionar novos cachorros e fotos no topo das listas (#38)

### DIFF
--- a/frontend/src/features/clients/components/ClientDetailsModal.tsx
+++ b/frontend/src/features/clients/components/ClientDetailsModal.tsx
@@ -160,7 +160,6 @@ export const ClientDetailsModal = ({
     setClient({
       ...client,
       dogs: [
-        ...(client.dogs || []),
         {
           breed: "",
           judge: "",
@@ -169,6 +168,7 @@ export const ClientDetailsModal = ({
           won_competitions: [],
           photos: [],
         },
+        ...(client.dogs || []),
       ],
     });
   };
@@ -193,7 +193,7 @@ export const ClientDetailsModal = ({
     const photos = newDogs[dogIndex].photos
       ? [...newDogs[dogIndex].photos]
       : [];
-    photos.push({
+    photos.unshift({
       file_number: "",
       photographer_id: "",
       payment_method: "Pix",

--- a/frontend/src/features/clients/components/LinkClientModal.tsx
+++ b/frontend/src/features/clients/components/LinkClientModal.tsx
@@ -98,7 +98,6 @@ export const LinkClientModal = ({
 
   const addDog = () => {
     setDogs([
-      ...dogs,
       {
         breed: "",
         judge: "",
@@ -107,6 +106,7 @@ export const LinkClientModal = ({
         won_competitions: [],
         photos: [],
       },
+      ...dogs,
     ]);
   };
 
@@ -152,12 +152,16 @@ export const LinkClientModal = ({
 
   const addPhoto = (dogIndex: number) => {
     const newDogs = [...dogs];
-    newDogs[dogIndex].photos.push({
+    const photos = newDogs[dogIndex].photos
+      ? [...newDogs[dogIndex].photos]
+      : [];
+    photos.unshift({
       file_number: "",
       photographer_id: "",
       payment_method: "Pix",
       amount_paid: 0,
     });
+    newDogs[dogIndex] = { ...newDogs[dogIndex], photos };
     setDogs(newDogs);
   };
 
@@ -168,16 +172,20 @@ export const LinkClientModal = ({
     value: unknown,
   ) => {
     const newDogs = [...dogs];
-    newDogs[dogIndex].photos[photoIndex] = {
-      ...newDogs[dogIndex].photos[photoIndex],
+    const photos = [...newDogs[dogIndex].photos];
+    photos[photoIndex] = {
+      ...photos[photoIndex],
       [field]: value,
     };
+    newDogs[dogIndex] = { ...newDogs[dogIndex], photos };
     setDogs(newDogs);
   };
 
   const removePhoto = (dogIndex: number, photoIndex: number) => {
     const newDogs = [...dogs];
-    newDogs[dogIndex].photos.splice(photoIndex, 1);
+    const photos = [...newDogs[dogIndex].photos];
+    photos.splice(photoIndex, 1);
+    newDogs[dogIndex] = { ...newDogs[dogIndex], photos };
     setDogs(newDogs);
   };
 

--- a/frontend/src/features/clients/pages/ClientDetailsPage.tsx
+++ b/frontend/src/features/clients/pages/ClientDetailsPage.tsx
@@ -130,7 +130,6 @@ export const ClientDetailsPage = () => {
     setClient({
       ...client,
       dogs: [
-        ...(client.dogs || []),
         {
           breed: "",
           judge: "",
@@ -139,6 +138,7 @@ export const ClientDetailsPage = () => {
           won_competitions: [],
           photos: [],
         },
+        ...(client.dogs || []),
       ],
     });
   };
@@ -189,13 +189,16 @@ export const ClientDetailsPage = () => {
   const addPhoto = (dogIndex: number) => {
     if (!client) return;
     const newDogs = [...client.dogs];
-    newDogs[dogIndex].photos = newDogs[dogIndex].photos || [];
-    newDogs[dogIndex].photos.push({
+    const photos = newDogs[dogIndex].photos
+      ? [...newDogs[dogIndex].photos]
+      : [];
+    photos.unshift({
       file_number: "",
       photographer_id: "",
       payment_method: "Pix",
       amount_paid: 0,
     } as Photo);
+    newDogs[dogIndex] = { ...newDogs[dogIndex], photos };
     setClient({ ...client, dogs: newDogs });
   };
 

--- a/frontend/src/features/clients/pages/ClientsPage.tsx
+++ b/frontend/src/features/clients/pages/ClientsPage.tsx
@@ -116,7 +116,6 @@ export const ClientsPage = () => {
 
   const addDog = () => {
     setDogs([
-      ...dogs,
       {
         breed: "",
         judge: "",
@@ -125,6 +124,7 @@ export const ClientsPage = () => {
         won_competitions: [],
         photos: [],
       },
+      ...dogs,
     ]);
   };
 
@@ -170,12 +170,16 @@ export const ClientsPage = () => {
 
   const addPhoto = (dogIndex: number) => {
     const newDogs = [...dogs];
-    newDogs[dogIndex].photos.push({
+    const photos = newDogs[dogIndex].photos
+      ? [...newDogs[dogIndex].photos]
+      : [];
+    photos.unshift({
       file_number: "",
       photographer_id: "",
       payment_method: "Pix",
       amount_paid: 0,
     } as Photo);
+    newDogs[dogIndex] = { ...newDogs[dogIndex], photos };
     setDogs(newDogs);
   };
 

--- a/frontend/src/features/people/pages/PersonDetailsPage.tsx
+++ b/frontend/src/features/people/pages/PersonDetailsPage.tsx
@@ -336,7 +336,7 @@ export const PersonDetailsPage = () => {
         is_owner: dogForm.is_owner,
       };
     } else {
-      newDogs.push({
+      newDogs.unshift({
         breed: dogForm.breed.trim(),
         judge: dogForm.judge.trim(),
         competitions_won: wonCount,
@@ -344,7 +344,7 @@ export const PersonDetailsPage = () => {
         is_owner: dogForm.is_owner,
         photos: [],
       });
-      setSelectedDogIndex(newDogs.length - 1);
+      setSelectedDogIndex(0);
     }
 
     setDogDialogOpen(false);
@@ -407,21 +407,20 @@ export const PersonDetailsPage = () => {
         return;
       }
 
-      numbers.forEach((num) => {
-        currentPhotos.push({
-          file_number: num,
-          photographer_id: batchPhotoForm.photographer_id,
-          payment_method: batchPhotoForm.payment_method,
-          amount_paid: Number(batchPhotoForm.amount_paid) || 0,
-        });
-      });
+      const newPhotos: Photo[] = numbers.map((num) => ({
+        file_number: num,
+        photographer_id: batchPhotoForm.photographer_id,
+        payment_method: batchPhotoForm.payment_method,
+        amount_paid: Number(batchPhotoForm.amount_paid) || 0,
+      }));
+      currentPhotos.unshift(...newPhotos);
     } else {
       if (!singlePhotoForm.file_number.trim()) {
         showNotification("Digite o número do arquivo da foto.", "warning");
         return;
       }
 
-      currentPhotos.push({
+      currentPhotos.unshift({
         file_number: singlePhotoForm.file_number.trim(),
         photographer_id: singlePhotoForm.photographer_id,
         payment_method: singlePhotoForm.payment_method,


### PR DESCRIPTION
## 📌 Descrição
Ajusta a inserção de novos cachorros e fotos para o topo das respectivas listas em todos os fluxos de clientes e pessoas, facilitando o preenchimento imediato sem necessidade de rolagem da tela.

## 🛠️ Alterações Realizadas
- **Posicionamento de Novos Cães**: Novos registros de cachorro são inseridos no início (`prepend` / `unshift`) ao invés do fim do array em:
  - `LinkClientModal.tsx`
  - `ClientDetailsModal.tsx`
  - `ClientDetailsPage.tsx`
  - `ClientsPage.tsx`
  - `PersonDetailsPage.tsx`
- **Posicionamento de Novas Fotos**: Novas fotos (individuais ou em lote) são inseridas no início da lista de fotos (`unshift`) em todos os formulários e páginas pertinentes.
- **Imutabilidade e Consistência**: Mantida a integridade do estado e atualizações de campos/remoções.

## 🔗 Referência
Resolves #38

## ✅ Checklist de Validação
- [x] `./scripts/check.sh all` aprovado com sucesso (Backend, Frontend Typecheck/Lint/Prettier/Tests, Terraform).