### PR TITLE
fix(frontend): responsividade mobile e quebra de layout na listagem de pessoas e tabelas (#42)

### DIFF
--- a/backend/internal/application/usecase/client/service_test.go
+++ b/backend/internal/application/usecase/client/service_test.go
@@ -466,4 +466,3 @@ func TestClientService_CrossTenantValidation(t *testing.T) {
 		}
 	})
 }
-

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -55,6 +55,7 @@
 
     <!-- PWA & Mobile Theme -->
     <meta name="theme-color" content="#392782" />
+    <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta
       name="apple-mobile-web-app-status-bar-style"

--- a/frontend/src/features/admin/pages/AdminTenantsPage.tsx
+++ b/frontend/src/features/admin/pages/AdminTenantsPage.tsx
@@ -119,7 +119,13 @@ export const AdminTenantsPage = () => {
         }}
       >
         <Box>
-          <Typography variant="h4" sx={{ fontWeight: 700 }}>
+          <Typography
+            variant="h4"
+            sx={{
+              fontWeight: 700,
+              fontSize: { xs: "1.5rem", sm: "2rem" },
+            }}
+          >
             Organizações
           </Typography>
           <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
@@ -131,7 +137,7 @@ export const AdminTenantsPage = () => {
           variant="contained"
           startIcon={<AddIcon />}
           onClick={handleOpenCreate}
-          sx={{ fontWeight: 600 }}
+          sx={{ fontWeight: 600, width: { xs: "100%", sm: "auto" } }}
         >
           Nova Organização
         </Button>
@@ -210,9 +216,14 @@ export const AdminTenantsPage = () => {
       <TableContainer
         component={Paper}
         elevation={0}
-        sx={{ border: "1px solid #E2E8F0", borderRadius: 2 }}
+        sx={{
+          border: "1px solid #E2E8F0",
+          borderRadius: 2,
+          width: "100%",
+          overflowX: "auto",
+        }}
       >
-        <Table>
+        <Table sx={{ minWidth: 500 }}>
           <TableHead sx={{ bgcolor: "grey.50" }}>
             <TableRow>
               <TableCell sx={{ fontWeight: 600 }}>

--- a/frontend/src/features/admin/pages/AdminUsersPage.tsx
+++ b/frontend/src/features/admin/pages/AdminUsersPage.tsx
@@ -152,7 +152,13 @@ export const AdminUsersPage = () => {
         }}
       >
         <Box>
-          <Typography variant="h4" sx={{ fontWeight: 700 }}>
+          <Typography
+            variant="h4"
+            sx={{
+              fontWeight: 700,
+              fontSize: { xs: "1.5rem", sm: "2rem" },
+            }}
+          >
             Gestão de Usuários
           </Typography>
           <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
@@ -296,9 +302,14 @@ export const AdminUsersPage = () => {
       <TableContainer
         component={Paper}
         elevation={0}
-        sx={{ border: "1px solid #E2E8F0", borderRadius: 2 }}
+        sx={{
+          border: "1px solid #E2E8F0",
+          borderRadius: 2,
+          width: "100%",
+          overflowX: "auto",
+        }}
       >
-        <Table>
+        <Table sx={{ minWidth: 680 }}>
           <TableHead sx={{ bgcolor: "grey.50" }}>
             <TableRow>
               <TableCell sx={{ fontWeight: 600 }}>Usuário</TableCell>

--- a/frontend/src/features/clients/pages/ClientDetailsPage.tsx
+++ b/frontend/src/features/clients/pages/ClientDetailsPage.tsx
@@ -227,23 +227,48 @@ export const ClientDetailsPage = () => {
   if (!client) return <Typography>Carregando...</Typography>;
 
   return (
-    <Box sx={{ p: 3 }}>
-      <Box sx={{ display: "flex", alignItems: "center", mb: 3, gap: 2 }}>
-        <IconButton onClick={() => navigate("/clients")}>
-          <ArrowBackIcon />
-        </IconButton>
-        <Typography variant="h4">Detalhes do Cliente</Typography>
-        <Box sx={{ flexGrow: 1 }} />
-        <Button
-          variant="outlined"
-          color="error"
-          onClick={() => setDeleteDialogOpen(true)}
-        >
-          Excluir Cliente
-        </Button>
-        <Button variant="contained" onClick={handleSave}>
-          Salvar Alterações
-        </Button>
+    <Box sx={{ p: { xs: 1.5, sm: 2.5, md: 3 } }}>
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: { xs: "column", sm: "row" },
+          alignItems: { xs: "stretch", sm: "center" },
+          mb: 3,
+          gap: 2,
+        }}
+      >
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+          <IconButton onClick={() => navigate("/clients")}>
+            <ArrowBackIcon />
+          </IconButton>
+          <Typography
+            variant="h4"
+            sx={{
+              fontSize: { xs: "1.4rem", sm: "2rem" },
+              fontWeight: 700,
+            }}
+          >
+            Detalhes do Cliente
+          </Typography>
+        </Box>
+        <Box sx={{ flexGrow: { sm: 1 } }} />
+        <Box sx={{ display: "flex", gap: 1.5, flexWrap: "wrap" }}>
+          <Button
+            variant="outlined"
+            color="error"
+            onClick={() => setDeleteDialogOpen(true)}
+            sx={{ flex: { xs: 1, sm: "initial" }, whiteSpace: "nowrap" }}
+          >
+            Excluir Cliente
+          </Button>
+          <Button
+            variant="contained"
+            onClick={handleSave}
+            sx={{ flex: { xs: 1, sm: "initial" }, whiteSpace: "nowrap" }}
+          >
+            Salvar Alterações
+          </Button>
+        </Box>
       </Box>
 
       <Paper sx={{ p: 3, mb: 3 }}>

--- a/frontend/src/features/clients/pages/ClientsPage.tsx
+++ b/frontend/src/features/clients/pages/ClientsPage.tsx
@@ -228,18 +228,44 @@ export const ClientsPage = () => {
     }
   };
 
-  if (!activeSeason)
+  if (!activeSeason) {
     return (
-      <Box sx={{ p: 3 }}>
+      <Box sx={{ p: { xs: 1.5, sm: 2.5, md: 3 } }}>
         <Typography>Selecione uma Temporada no topo.</Typography>
       </Box>
     );
+  }
 
   return (
-    <Box sx={{ p: 3 }}>
-      <Box sx={{ display: "flex", justifyContent: "space-between", mb: 3 }}>
-        <Typography variant="h4">Clientes da Temporada Atual</Typography>
-        <Box sx={{ display: "flex", gap: 2, alignItems: "center" }}>
+    <Box sx={{ p: { xs: 1.5, sm: 2.5, md: 3 } }}>
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: { xs: "column", sm: "row" },
+          justifyContent: "space-between",
+          alignItems: { xs: "stretch", sm: "center" },
+          gap: 2,
+          mb: 3,
+        }}
+      >
+        <Typography
+          variant="h4"
+          sx={{
+            fontSize: { xs: "1.5rem", sm: "2rem" },
+            fontWeight: 700,
+          }}
+        >
+          Clientes da Temporada Atual
+        </Typography>
+        <Box
+          sx={{
+            display: "flex",
+            flexWrap: "wrap",
+            gap: 1.5,
+            alignItems: "center",
+            width: { xs: "100%", sm: "auto" },
+          }}
+        >
           <Button
             variant="outlined"
             startIcon={
@@ -252,6 +278,7 @@ export const ClientsPage = () => {
             endIcon={<ExpandMoreIcon />}
             onClick={(e) => setReportMenuAnchor(e.currentTarget)}
             disabled={exportingReport}
+            sx={{ flex: { xs: 1, sm: "initial" }, whiteSpace: "nowrap" }}
           >
             {exportingReport ? "Gerando..." : "Relatórios"}
           </Button>
@@ -268,21 +295,35 @@ export const ClientsPage = () => {
             </MenuItem>
           </Menu>
 
-          <Button variant="contained" onClick={() => setOpen(true)}>
+          <Button
+            variant="contained"
+            onClick={() => setOpen(true)}
+            sx={{ flex: { xs: 1, sm: "initial" }, whiteSpace: "nowrap" }}
+          >
             Vincular Cliente
           </Button>
         </Box>
       </Box>
 
-      <Paper sx={{ width: "100%", overflow: "hidden" }}>
-        <TableContainer>
-          <Table>
-            <TableHead>
+      <Paper
+        sx={{
+          width: "100%",
+          overflow: "hidden",
+          border: "1px solid #E2E8F0",
+          borderRadius: 2,
+        }}
+        elevation={0}
+      >
+        <TableContainer sx={{ width: "100%", overflowX: "auto" }}>
+          <Table sx={{ minWidth: 600 }}>
+            <TableHead sx={{ bgcolor: "grey.50" }}>
               <TableRow>
-                <TableCell>Pessoa</TableCell>
-                <TableCell>Cachorros</TableCell>
-                <TableCell>Total de Fotos</TableCell>
-                <TableCell align="right">Ações</TableCell>
+                <TableCell sx={{ fontWeight: 600 }}>Pessoa</TableCell>
+                <TableCell sx={{ fontWeight: 600 }}>Cachorros</TableCell>
+                <TableCell sx={{ fontWeight: 600 }}>Total de Fotos</TableCell>
+                <TableCell align="right" sx={{ fontWeight: 600 }}>
+                  Ações
+                </TableCell>
               </TableRow>
             </TableHead>
             <TableBody>

--- a/frontend/src/features/dashboard/pages/DashboardPage.tsx
+++ b/frontend/src/features/dashboard/pages/DashboardPage.tsx
@@ -287,20 +287,36 @@ export const DashboardPage = () => {
               variant="h4"
               sx={{
                 fontWeight: 800,
+                fontSize: { xs: "1.5rem", sm: "2.125rem" },
                 letterSpacing: "-0.5px",
                 color: "#ffffff",
               }}
             >
               Visão Geral
             </Typography>
-            <Typography variant="body1" sx={{ color: "grey.300", mt: 0.5 }}>
+            <Typography
+              variant="body1"
+              sx={{
+                color: "grey.300",
+                mt: 0.5,
+                fontSize: { xs: "0.85rem", sm: "1rem" },
+              }}
+            >
               {activeSeason
                 ? `Clientes, cães e fotos vinculados à temporada "${activeSeason.name}".`
                 : "Selecione uma temporada no cabeçalho para gerenciar os clientes e fotos."}
             </Typography>
           </Box>
 
-          <Box sx={{ display: "flex", alignItems: "center", gap: 2 }}>
+          <Box
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              flexWrap: "wrap",
+              gap: 1.5,
+              width: { xs: "100%", md: "auto" },
+            }}
+          >
             {activeSeason ? (
               <>
                 <Chip
@@ -739,8 +755,8 @@ export const DashboardPage = () => {
             </Box>
           ) : (
             <>
-              <TableContainer>
-                <Table>
+              <TableContainer sx={{ width: "100%", overflowX: "auto" }}>
+                <Table sx={{ minWidth: 650 }}>
                   <TableHead sx={{ bgcolor: "grey.50" }}>
                     <TableRow>
                       <TableCell sx={{ fontWeight: 700 }}>

--- a/frontend/src/features/people/pages/PeoplePage.tsx
+++ b/frontend/src/features/people/pages/PeoplePage.tsx
@@ -105,27 +105,56 @@ export const PeoplePage = () => {
   };
 
   return (
-    <Box sx={{ p: 3 }}>
-      <Box sx={{ display: "flex", justifyContent: "space-between", mb: 3 }}>
-        <Typography variant="h4">Pessoas (Cadastro Único)</Typography>
+    <Box sx={{ p: { xs: 1.5, sm: 2.5, md: 3 } }}>
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: { xs: "column", sm: "row" },
+          justifyContent: "space-between",
+          alignItems: { xs: "stretch", sm: "center" },
+          gap: 2,
+          mb: 3,
+        }}
+      >
+        <Typography
+          variant="h4"
+          sx={{
+            fontSize: { xs: "1.5rem", sm: "2rem" },
+            fontWeight: 700,
+          }}
+        >
+          Pessoas (Cadastro Único)
+        </Typography>
         <Button
           variant="contained"
           startIcon={<AddIcon />}
           onClick={handleOpenCreate}
+          sx={{ width: { xs: "100%", sm: "auto" }, whiteSpace: "nowrap" }}
         >
           Nova Pessoa
         </Button>
       </Box>
 
-      <TableContainer component={Paper}>
-        <Table>
+      <TableContainer
+        component={Paper}
+        elevation={0}
+        sx={{
+          border: "1px solid #E2E8F0",
+          borderRadius: 2,
+          width: "100%",
+          overflowX: "auto",
+        }}
+      >
+        <Table sx={{ minWidth: 650 }}>
           <TableHead>
             <TableRow>
-              <TableCell>Nome</TableCell>
-              <TableCell>E-mail</TableCell>
-              <TableCell>E-mail Alternativo</TableCell>
-              <TableCell>Telefone</TableCell>
-              <TableCell align="right">Ações</TableCell>
+              <TableCell sx={{ fontWeight: 600 }}>Nome</TableCell>
+              <TableCell sx={{ fontWeight: 600 }}>E-mail</TableCell>
+              <TableCell sx={{ fontWeight: 600 }}>E-mail Alternativo</TableCell>
+              <TableCell sx={{ fontWeight: 600 }}>Telefone</TableCell>
+              <TableCell align="right" sx={{ fontWeight: 600 }}>
+                Ações
+              </TableCell>
             </TableRow>
           </TableHead>
           <TableBody>

--- a/frontend/src/features/photographers/pages/PhotographersPage.tsx
+++ b/frontend/src/features/photographers/pages/PhotographersPage.tsx
@@ -95,25 +95,54 @@ export const PhotographersPage = () => {
   };
 
   return (
-    <Box sx={{ p: 3 }}>
-      <Box sx={{ display: "flex", justifyContent: "space-between", mb: 3 }}>
-        <Typography variant="h4">Fotógrafos</Typography>
+    <Box sx={{ p: { xs: 1.5, sm: 2.5, md: 3 } }}>
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: { xs: "column", sm: "row" },
+          justifyContent: "space-between",
+          alignItems: { xs: "stretch", sm: "center" },
+          gap: 2,
+          mb: 3,
+        }}
+      >
+        <Typography
+          variant="h4"
+          sx={{
+            fontSize: { xs: "1.5rem", sm: "2rem" },
+            fontWeight: 700,
+          }}
+        >
+          Fotógrafos
+        </Typography>
         <Button
           variant="contained"
           startIcon={<AddIcon />}
           onClick={handleOpenCreate}
+          sx={{ width: { xs: "100%", sm: "auto" }, whiteSpace: "nowrap" }}
         >
           Novo Fotógrafo
         </Button>
       </Box>
 
-      <TableContainer component={Paper}>
-        <Table>
+      <TableContainer
+        component={Paper}
+        elevation={0}
+        sx={{
+          border: "1px solid #E2E8F0",
+          borderRadius: 2,
+          width: "100%",
+          overflowX: "auto",
+        }}
+      >
+        <Table sx={{ minWidth: 450 }}>
           <TableHead>
             <TableRow>
-              <TableCell>ID</TableCell>
-              <TableCell>Nome</TableCell>
-              <TableCell align="right">Ações</TableCell>
+              <TableCell sx={{ fontWeight: 600 }}>ID</TableCell>
+              <TableCell sx={{ fontWeight: 600 }}>Nome</TableCell>
+              <TableCell align="right" sx={{ fontWeight: 600 }}>
+                Ações
+              </TableCell>
             </TableRow>
           </TableHead>
           <TableBody>

--- a/frontend/src/features/seasons/pages/SeasonsPage.tsx
+++ b/frontend/src/features/seasons/pages/SeasonsPage.tsx
@@ -118,26 +118,55 @@ export const SeasonsPage = () => {
   };
 
   return (
-    <Box sx={{ p: 3 }}>
-      <Box sx={{ display: "flex", justifyContent: "space-between", mb: 3 }}>
-        <Typography variant="h4">Temporadas</Typography>
+    <Box sx={{ p: { xs: 1.5, sm: 2.5, md: 3 } }}>
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: { xs: "column", sm: "row" },
+          justifyContent: "space-between",
+          alignItems: { xs: "stretch", sm: "center" },
+          gap: 2,
+          mb: 3,
+        }}
+      >
+        <Typography
+          variant="h4"
+          sx={{
+            fontSize: { xs: "1.5rem", sm: "2rem" },
+            fontWeight: 700,
+          }}
+        >
+          Temporadas
+        </Typography>
         <Button
           variant="contained"
           startIcon={<AddIcon />}
           onClick={handleOpenCreate}
+          sx={{ width: { xs: "100%", sm: "auto" }, whiteSpace: "nowrap" }}
         >
           Nova Temporada
         </Button>
       </Box>
 
-      <TableContainer component={Paper}>
-        <Table>
+      <TableContainer
+        component={Paper}
+        elevation={0}
+        sx={{
+          border: "1px solid #E2E8F0",
+          borderRadius: 2,
+          width: "100%",
+          overflowX: "auto",
+        }}
+      >
+        <Table sx={{ minWidth: 550 }}>
           <TableHead>
             <TableRow>
-              <TableCell>ID</TableCell>
-              <TableCell>Nome</TableCell>
-              <TableCell>Fotógrafos</TableCell>
-              <TableCell align="right">Ações</TableCell>
+              <TableCell sx={{ fontWeight: 600 }}>ID</TableCell>
+              <TableCell sx={{ fontWeight: 600 }}>Nome</TableCell>
+              <TableCell sx={{ fontWeight: 600 }}>Fotógrafos</TableCell>
+              <TableCell align="right" sx={{ fontWeight: 600 }}>
+                Ações
+              </TableCell>
             </TableRow>
           </TableHead>
           <TableBody>

--- a/frontend/src/layouts/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout.tsx
@@ -33,14 +33,24 @@ export function AppLayout() {
         sx={{
           flexGrow: 1,
           width: { md: `calc(100% - ${drawerWidth}px)` },
+          minWidth: 0,
+          maxWidth: "100%",
           minHeight: "100vh",
           display: "flex",
           flexDirection: "column",
+          overflowX: "hidden",
         }}
       >
         <Topbar onDrawerToggle={handleDrawerToggle} />
 
-        <Box sx={{ flex: 1, p: { xs: 2, sm: 3, md: 4 } }}>
+        <Box
+          sx={{
+            flex: 1,
+            p: { xs: 1.5, sm: 2.5, md: 3 },
+            minWidth: 0,
+            maxWidth: "100%",
+          }}
+        >
           <Outlet />
         </Box>
       </Box>

--- a/frontend/src/layouts/Topbar.tsx
+++ b/frontend/src/layouts/Topbar.tsx
@@ -101,13 +101,20 @@ export function Topbar({ onDrawerToggle }: TopbarProps) {
           </Typography>
         </Box>
 
-        <Box sx={{ minWidth: 200, mr: 3 }}>
+        <Box
+          sx={{
+            minWidth: { xs: 130, sm: 180, md: 220 },
+            maxWidth: { xs: 170, sm: 260 },
+            mr: { xs: 1, sm: 2, md: 3 },
+          }}
+        >
           <FormControl fullWidth size="small">
             <InputLabel>Temporada Ativa</InputLabel>
             <Select
               value={activeSeason?.id || ""}
               label="Temporada Ativa"
               onChange={(e) => handleChangeSeason(e.target.value)}
+              sx={{ fontSize: { xs: "0.85rem", sm: "0.95rem" } }}
             >
               {(seasons || []).map((s) => (
                 <MenuItem key={s.id} value={s.id}>


### PR DESCRIPTION
### Resumo das Alterações
Este Pull Request soluciona a quebra de layout e problemas de responsividade em telas de dispositivos móveis e viewports estreitos em toda a aplicação web (especialmente na listagem de pessoas, clientes e tabelas do painel).

#### 🛠️ Principais Modificações
1. **Contenção Global de Layout (`AppLayout.tsx`)**:
   - Adicionada propriedade `minWidth: 0`, `maxWidth: "100%"` e `overflowX: "hidden"` ao container flex principal (`main`) e ao box de conteúdo (`Outlet`), impedindo o estouro horizontal de largura no viewport mobile.
2. **Topbar Mobile Adaptável (`Topbar.tsx`)**:
   - Ajustada a largura do seletor de temporada ativa com `minWidth: { xs: 130, sm: 180, md: 220 }` e margens responsivas, evitando esmagar ou sobrepor o botão de menu e avatar do usuário.
3. **Página de Pessoas (`PeoplePage.tsx`)**:
   - Cabeçalho responsivo com `flexDirection: { xs: "column", sm: "row" }`, ajuste da tipografia do título para mobile e botão de ação ocupando largura total em telas pequenas.
   - `TableContainer` com `width: "100%"`, `overflowX: "auto"` e `Table` com `minWidth: 650`, permitindo rolagem horizontal suave sem desfigurar ou esmagar o texto das colunas.
4. **Demais Telas e Tabelas (`ClientsPage.tsx`, `ClientDetailsPage.tsx`, `DashboardPage.tsx`, `AdminUsersPage.tsx`, `AdminTenantsPage.tsx`, `SeasonsPage.tsx`, `PhotographersPage.tsx`)**:
   - Padronização de cabeçalhos fluidos com `flexWrap: "wrap"` e botões adaptáveis.
   - Confinamento de todas as tabelas em containers com rolagem horizontal independente (`minWidth`).
5. **Meta Tag Mobile (`index.html`)**:
   - Inclusão da tag `<meta name="mobile-web-app-capable" content="yes" />` para conformidade com padrões PWA móveis atualizados e eliminação do aviso de depreciação do console.

---

### Validação Executada
- [x] `./scripts/fix.sh` (Formatação e linting aplicados sem erros)
- [x] `./scripts/check.sh all` (100% de testes unitários backend/frontend e typecheck passando)
- [x] Validação visual via Puppeteer em viewport mobile (375x667) nas rotas `/people`, `/dashboard`, `/clients` e `/admin/users`

Closes #42
