### PR TITLE
fix(navigation): prevenir retencao de foco e conflito de aria-hidden na gaveta mobile

### DIFF
--- a/frontend/src/layouts/Sidebar.tsx
+++ b/frontend/src/layouts/Sidebar.tsx
@@ -60,10 +60,10 @@ export function Sidebar({
   const user = useAuthStore((state) => state.user);
 
   const handleNavigation = (path: string) => {
-    navigate(path);
     if (mobileOpen) {
       onDrawerToggle();
     }
+    navigate(path);
   };
 
   const drawerContent = (
@@ -222,7 +222,10 @@ export function Sidebar({
         variant="temporary"
         open={mobileOpen}
         onClose={onDrawerToggle}
-        ModalProps={{ keepMounted: true }}
+        ModalProps={{
+          keepMounted: true,
+          disableRestoreFocus: true,
+        }}
         sx={{
           display: { xs: "block", md: "none" },
           "& .MuiDrawer-paper": {

--- a/frontend/src/layouts/Topbar.tsx
+++ b/frontend/src/layouts/Topbar.tsx
@@ -83,8 +83,12 @@ export function Topbar({ onDrawerToggle }: TopbarProps) {
       <Toolbar>
         <IconButton
           color="inherit"
+          aria-label="abrir menu"
           edge="start"
-          onClick={onDrawerToggle}
+          onClick={(e) => {
+            (e.currentTarget as HTMLElement)?.blur();
+            onDrawerToggle();
+          }}
           sx={{ mr: 2, display: { md: "none" } }}
         >
           <MenuIcon />


### PR DESCRIPTION
### Resumo das Alterações
Este Pull Request complementa as correções de usabilidade mobile corrigindo o aviso de acessibilidade e conflito de foco na transição do menu lateral (Drawer temporário):

1. **`disableRestoreFocus: true` no `Drawer` temporário ([`Sidebar.tsx`](frontend/src/layouts/Sidebar.tsx))**:
   - Evita tentativas indevidas do Modal de restaurar o foco para nós já desmontados ou re-renderizados após navegação de rota.
2. **Liberação Explícita de Foco no Botão Hamburger ([`Topbar.tsx`](frontend/src/layouts/Topbar.tsx))**:
   - Aplicação de `blur()` no clique do botão hamburger da Topbar ao disparar a abertura do Drawer, evitando a mensagem de aviso `Blocked aria-hidden on an element because its descendant retained focus` e impedindo erros no observador de performance/interação do browser.
3. **Sequenciamento de Fechamento da Gaveta**:
   - A gaveta fecha imediatamente antes do disparo da navegação entre rotas.

---

### Validação Executada
- [x] `./scripts/fix.sh`
- [x] `./scripts/check.sh all` (100% de testes e checagens passando)
