### PR TITLE
feat(reports): exportação de relatório csv de pessoas/clientes com pagamentos não pagos (#40)

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -1403,6 +1403,44 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/reports/unpaid-clients-csv": {
+            "post": {
+                "description": "Inicia a extração assíncrona do relatório de clientes e fotos com pagamentos não quitados ou pendentes do tenant autenticado e envia o link para o e-mail cadastrado",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Reports"
+                ],
+                "summary": "Exportar relatório CSV de clientes com pagamentos não pagos",
+                "responses": {
+                    "202": {
+                        "description": "Accepted",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.SuccessEnvelope"
+                        }
+                    },
+                    "401": {
+                        "description": "Não autenticado",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.ErrorEnvelope"
+                        }
+                    },
+                    "403": {
+                        "description": "Tenant não associado",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.ErrorEnvelope"
+                        }
+                    },
+                    "500": {
+                        "description": "Erro interno",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.ErrorEnvelope"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/seasons": {
             "get": {
                 "description": "Retorna a lista de temporadas do tenant autenticado",

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -1397,6 +1397,44 @@
                 }
             }
         },
+        "/api/v1/reports/unpaid-clients-csv": {
+            "post": {
+                "description": "Inicia a extração assíncrona do relatório de clientes e fotos com pagamentos não quitados ou pendentes do tenant autenticado e envia o link para o e-mail cadastrado",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Reports"
+                ],
+                "summary": "Exportar relatório CSV de clientes com pagamentos não pagos",
+                "responses": {
+                    "202": {
+                        "description": "Accepted",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.SuccessEnvelope"
+                        }
+                    },
+                    "401": {
+                        "description": "Não autenticado",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.ErrorEnvelope"
+                        }
+                    },
+                    "403": {
+                        "description": "Tenant não associado",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.ErrorEnvelope"
+                        }
+                    },
+                    "500": {
+                        "description": "Erro interno",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.ErrorEnvelope"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/seasons": {
             "get": {
                 "description": "Retorna a lista de temporadas do tenant autenticado",

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -1106,6 +1106,33 @@ paths:
       summary: Baixar arquivo de relatório gerado
       tags:
       - Reports
+  /api/v1/reports/unpaid-clients-csv:
+    post:
+      description: Inicia a extração assíncrona do relatório de clientes e fotos com
+        pagamentos não quitados ou pendentes do tenant autenticado e envia o link
+        para o e-mail cadastrado
+      produces:
+      - application/json
+      responses:
+        "202":
+          description: Accepted
+          schema:
+            $ref: '#/definitions/httpx.SuccessEnvelope'
+        "401":
+          description: Não autenticado
+          schema:
+            $ref: '#/definitions/httpx.ErrorEnvelope'
+        "403":
+          description: Tenant não associado
+          schema:
+            $ref: '#/definitions/httpx.ErrorEnvelope'
+        "500":
+          description: Erro interno
+          schema:
+            $ref: '#/definitions/httpx.ErrorEnvelope'
+      summary: Exportar relatório CSV de clientes com pagamentos não pagos
+      tags:
+      - Reports
   /api/v1/seasons:
     get:
       description: Retorna a lista de temporadas do tenant autenticado

--- a/backend/internal/application/usecase/report/service.go
+++ b/backend/internal/application/usecase/report/service.go
@@ -318,6 +318,144 @@ func (s *Service) GenerateClientsCSV(ctx context.Context, tenantID, userEmail, u
 	return relativePath, nil
 }
 
+func (s *Service) GenerateUnpaidClientsCSV(ctx context.Context, tenantID, userEmail, userName string) (string, error) {
+	if tenantID == "" {
+		return "", errors.New("tenant ID cannot be empty")
+	}
+
+	// 1. Fetch photographers to map IDs to names
+	photographersList, err := s.photographerRepo.List(ctx, tenantID)
+	if err != nil {
+		log.Printf("[REPORT] Failed to list photographers for tenant %s: %v", tenantID, err)
+		photographersList = nil
+	}
+	photogMap := make(map[string]string)
+	for _, p := range photographersList {
+		photogMap[p.ID] = p.Name
+	}
+
+	// 2. Cache persons dynamically during stream to avoid repeated identical queries
+	personCache := make(map[string]*persondomain.Person)
+
+	// 3. Prepare CSV buffer with headers
+	var buf bytes.Buffer
+	writer := csv.NewWriter(&buf)
+
+	headers := []string{
+		"Nome",
+		"E-mail",
+		"E-mail alternativo",
+		"Telefone",
+		"Raça",
+		"Juiz",
+		"Número do Arquivo da Foto",
+		"Fotografo",
+		"Status do Pagamento",
+		"Valor Devido / Pago",
+	}
+	if err := writer.Write(sanitizeRow(headers)); err != nil {
+		return "", fmt.Errorf("failed to write csv headers: %w", err)
+	}
+
+	// 4. Stream clients from MongoDB and filter unpaid photos
+	streamErr := s.clientRepo.StreamByTenant(ctx, tenantID, func(c *clientdomain.SeasonClient) error {
+		var personObj *persondomain.Person
+		var ok bool
+
+		for _, dog := range c.Dogs {
+			for _, photo := range dog.Photos {
+				normPay := NormalizePaymentMethod(photo.PaymentMethod)
+				if normPay != "Não pago" && normPay != "" {
+					continue
+				}
+
+				if personObj == nil {
+					personObj, ok = personCache[c.PersonID]
+					if !ok {
+						p, err := s.personRepo.GetByID(ctx, c.PersonID, tenantID)
+						if err != nil || p == nil {
+							p = &persondomain.Person{
+								Name: "Desconhecido",
+							}
+						}
+						personCache[c.PersonID] = p
+						personObj = p
+					}
+				}
+
+				var photographerName string
+				if name, exists := photogMap[photo.PhotographerID]; exists && name != "" {
+					photographerName = name
+				} else {
+					photographerName = photo.PhotographerID
+				}
+
+				paymentStatus := normPay
+				if paymentStatus == "" {
+					paymentStatus = "Não pago"
+				}
+
+				var amount string
+				if photo.AmountPaid != nil {
+					amount = fmt.Sprintf("%.2f", *photo.AmountPaid)
+				}
+
+				row := []string{
+					personObj.Name,
+					personObj.Email,
+					personObj.AlternativeEmail,
+					FormatPhone(personObj.Phone),
+					dog.Breed,
+					dog.Judge,
+					photo.FileNumber,
+					photographerName,
+					paymentStatus,
+					amount,
+				}
+				if err := writer.Write(sanitizeRow(row)); err != nil {
+					return err
+				}
+			}
+		}
+
+		writer.Flush()
+		return writer.Error()
+	})
+
+	if streamErr != nil {
+		return "", fmt.Errorf("error during client streaming: %w", streamErr)
+	}
+
+	writer.Flush()
+	if err := writer.Error(); err != nil {
+		return "", fmt.Errorf("error finishing csv writer: %w", err)
+	}
+
+	// 5. Store generated CSV in Storage Provider with isolated tenant path
+	timestamp := time.Now().UTC().Unix()
+	fileName := fmt.Sprintf("clientes_nao_pagos_%d.csv", timestamp)
+	relativePath := fmt.Sprintf("reports/tenant_%s/%s", tenantID, fileName)
+
+	_, err = s.storageProvider.Save(ctx, relativePath, storageport.File{
+		Name:        fileName,
+		Data:        buf.Bytes(),
+		ContentType: "text/csv; charset=utf-8",
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to save report to storage: %w", err)
+	}
+
+	// 6. Send notification email with download link if userEmail is provided
+	if userEmail != "" {
+		downloadURL := fmt.Sprintf("%s/reports/download?file=%s", s.appBaseURL, url.QueryEscape(relativePath))
+		if err := s.emailSender.SendReportReadyEmail(ctx, userEmail, userName, "Relatório de Clientes Não Pagos", downloadURL); err != nil {
+			log.Printf("[REPORT-EMAIL-ERROR] Failed to send report ready email to %s: %v", userEmail, err)
+		}
+	}
+
+	return relativePath, nil
+}
+
 func (s *Service) GetReportFile(ctx context.Context, tenantID, relativePath string) ([]byte, error) {
 	cleanPath := filepath.Clean(strings.TrimPrefix(relativePath, "/"))
 	if strings.Contains(cleanPath, "..") {

--- a/backend/internal/application/usecase/report/service_test.go
+++ b/backend/internal/application/usecase/report/service_test.go
@@ -397,3 +397,189 @@ func TestNormalizePaymentMethod(t *testing.T) {
 		}
 	}
 }
+
+func TestGenerateUnpaidClientsCSV(t *testing.T) {
+	tenantID := "tenant-456"
+	amount50 := 50.0
+	amount150 := 150.0
+	amount200 := 200.0
+
+	clientRepo := &mockClientRepo{
+		clients: []*clientdomain.SeasonClient{
+			{
+				ID:       "client-1",
+				TenantID: tenantID,
+				PersonID: "person-1",
+				Dogs: []clientdomain.Dog{
+					{
+						Breed: "Golden",
+						Judge: "Juiz A",
+						Photos: []clientdomain.Photo{
+							{
+								FileNumber:     "IMG_101",
+								PhotographerID: "photog-1",
+								PaymentMethod:  "Pix",
+								AmountPaid:     &amount50,
+							},
+							{
+								FileNumber:     "=CMD_INJECTION",
+								PhotographerID: "photog-2",
+								PaymentMethod:  "Não pago",
+								AmountPaid:     &amount150,
+							},
+						},
+					},
+					{
+						Breed: "Poodle",
+						Judge: "Juiz B",
+						Photos: []clientdomain.Photo{
+							{
+								FileNumber:     "IMG_103",
+								PhotographerID: "photog-1",
+								PaymentMethod:  "pendente",
+								AmountPaid:     nil,
+							},
+						},
+					},
+				},
+			},
+			{
+				ID:       "client-2",
+				TenantID: tenantID,
+				PersonID: "person-2",
+				Dogs: []clientdomain.Dog{
+					{
+						Breed: "Bulldog",
+						Judge: "Juiz C",
+						Photos: []clientdomain.Photo{
+							{
+								FileNumber:     "IMG_201",
+								PhotographerID: "photog-1",
+								PaymentMethod:  "Cartão de Crédito",
+								AmountPaid:     &amount200,
+							},
+						},
+					},
+				},
+			},
+			{
+				ID:       "client-3",
+				TenantID: tenantID,
+				PersonID: "person-3",
+				Dogs: []clientdomain.Dog{
+					{
+						Breed: "Shih Tzu",
+						Judge: "Juiz D",
+						Photos: []clientdomain.Photo{
+							{
+								FileNumber:     "IMG_301",
+								PhotographerID: "photog-unknown",
+								PaymentMethod:  "",
+								AmountPaid:     nil,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	personRepo := &mockPersonRepo{
+		people: map[string]*persondomain.Person{
+			"person-1": {
+				ID:               "person-1",
+				Name:             "Carlos Lima",
+				Email:            "carlos@test.com",
+				AlternativeEmail: "carlos.alt@test.com",
+				Phone:            "11988887777",
+			},
+			"person-2": {
+				ID:    "person-2",
+				Name:  "Renata Costa",
+				Email: "renata@test.com",
+				Phone: "21977776666",
+			},
+			"person-3": {
+				ID:    "person-3",
+				Name:  "Marcos Souza",
+				Email: "marcos@test.com",
+				Phone: "81966665555",
+			},
+		},
+	}
+
+	photographerRepo := &mockPhotographerRepo{
+		photographers: []*photographerdomain.Photographer{
+			{ID: "photog-1", Name: "Fotógrafo Alpha"},
+			{ID: "photog-2", Name: "Fotógrafo Beta"},
+		},
+	}
+
+	storage := &mockStorageProvider{}
+	emailSender := &mockEmailSender{}
+
+	svc := NewService(clientRepo, personRepo, photographerRepo, storage, emailSender, "http://localhost:8080")
+
+	filePath, err := svc.GenerateUnpaidClientsCSV(context.Background(), tenantID, "user@test.com", "Tester")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.HasPrefix(filePath, "reports/tenant_tenant-456/clientes_nao_pagos_") {
+		t.Fatalf("unexpected file path: %s", filePath)
+	}
+
+	csvData, ok := storage.files[filePath]
+	if !ok || len(csvData) == 0 {
+		t.Fatalf("CSV not saved in storage")
+	}
+
+	reader := csv.NewReader(bytes.NewReader(csvData))
+	records, err := reader.ReadAll()
+	if err != nil {
+		t.Fatalf("failed to parse CSV: %v", err)
+	}
+
+	// 1 Header + 2 rows from client-1 + 0 from client-2 + 1 from client-3 = 4 rows
+	if len(records) != 4 {
+		t.Fatalf("expected 4 rows, got %d", len(records))
+	}
+
+	// Header check
+	expectedHeaders := []string{
+		"Nome", "E-mail", "E-mail alternativo", "Telefone", "Raça", "Juiz",
+		"Número do Arquivo da Foto", "Fotografo", "Status do Pagamento", "Valor Devido / Pago",
+	}
+	for i, h := range expectedHeaders {
+		if records[0][i] != h {
+			t.Fatalf("header mismatch at %d: got %s, want %s", i, records[0][i], h)
+		}
+	}
+
+	// Row 1: client-1 photo 2
+	row1 := records[1]
+	if row1[0] != "Carlos Lima" || row1[3] != "(11) 98888-7777" || row1[4] != "Golden" || row1[5] != "Juiz A" || row1[6] != "'=CMD_INJECTION" || row1[7] != "Fotógrafo Beta" || row1[8] != "Não pago" || row1[9] != "150.00" {
+		t.Fatalf("row 1 mismatch: %v", row1)
+	}
+
+	// Row 2: client-1 photo 3
+	row2 := records[2]
+	if row2[0] != "Carlos Lima" || row2[4] != "Poodle" || row2[5] != "Juiz B" || row2[6] != "IMG_103" || row2[7] != "Fotógrafo Alpha" || row2[8] != "Não pago" || row2[9] != "" {
+		t.Fatalf("row 2 mismatch: %v", row2)
+	}
+
+	// Row 3: client-3 photo 1
+	row3 := records[3]
+	if row3[0] != "Marcos Souza" || row3[3] != "(81) 96666-5555" || row3[4] != "Shih Tzu" || row3[5] != "Juiz D" || row3[6] != "IMG_301" || row3[7] != "photog-unknown" || row3[8] != "Não pago" || row3[9] != "" {
+		t.Fatalf("row 3 mismatch: %v", row3)
+	}
+
+	// Check email notification
+	if len(emailSender.sentReports) != 1 {
+		t.Fatalf("expected 1 email sent, got %d", len(emailSender.sentReports))
+	}
+	if emailSender.sentReports[0].Email != "user@test.com" || emailSender.sentReports[0].ReportName != "Relatório de Clientes Não Pagos" {
+		t.Fatalf("unexpected email details: %v", emailSender.sentReports[0])
+	}
+}
+

--- a/backend/internal/domain/report/report.go
+++ b/backend/internal/domain/report/report.go
@@ -14,7 +14,8 @@ const (
 type ReportType string
 
 const (
-	TypeClientsCSV ReportType = "clients_csv"
+	TypeClientsCSV       ReportType = "clients_csv"
+	TypeUnpaidClientsCSV ReportType = "unpaid_clients_csv"
 )
 
 type ReportJob struct {

--- a/backend/internal/interfaces/rest/handlers/report_handler.go
+++ b/backend/internal/interfaces/rest/handlers/report_handler.go
@@ -69,6 +69,48 @@ func (h *ReportHandler) ExportClientsCSV(w http.ResponseWriter, r *http.Request)
 	})
 }
 
+// ExportUnpaidClientsCSV godoc
+// @Summary      Exportar relatório CSV de clientes com pagamentos não pagos
+// @Description  Inicia a extração assíncrona do relatório de clientes e fotos com pagamentos não quitados ou pendentes do tenant autenticado e envia o link para o e-mail cadastrado
+// @Tags         Reports
+// @Produce      json
+// @Success      202  {object}  httpx.SuccessEnvelope
+// @Failure      401  {object}  httpx.ErrorEnvelope "Não autenticado"
+// @Failure      403  {object}  httpx.ErrorEnvelope "Tenant não associado"
+// @Failure      500  {object}  httpx.ErrorEnvelope "Erro interno"
+// @Router       /api/v1/reports/unpaid-clients-csv [post]
+func (h *ReportHandler) ExportUnpaidClientsCSV(w http.ResponseWriter, r *http.Request) {
+	tenantID := middleware.GetTenantID(r.Context())
+	if tenantID == "" {
+		httpx.Error(w, http.StatusForbidden, "Tenant is required", nil)
+		return
+	}
+
+	userID := middleware.GetUserID(r.Context())
+	var userEmail, userName string
+	if userID != "" && h.userRepo != nil {
+		user, err := h.userRepo.FindByID(r.Context(), userID)
+		if err == nil && user.Email != "" {
+			userEmail = user.Email
+			userName = user.Name
+		}
+	}
+
+	// Launch async extraction job in background goroutine with detached context
+	go func(tID, uEmail, uName string) {
+		jobCtx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+		defer cancel()
+
+		if _, err := h.service.GenerateUnpaidClientsCSV(jobCtx, tID, uEmail, uName); err != nil {
+			log.Printf("[REPORT-JOB-ERROR] Failed to generate unpaid clients CSV for tenant %s: %v", tID, err)
+		}
+	}(tenantID, userEmail, userName)
+
+	httpx.Accepted(w, map[string]string{
+		"message": "Geração do relatório iniciada com sucesso. O arquivo CSV será enviado para o seu e-mail em instantes.",
+	})
+}
+
 // DownloadReport godoc
 // @Summary      Baixar arquivo de relatório gerado
 // @Description  Permite o download seguro de um arquivo de relatório previamente gerado, validando isolamento de tenant

--- a/backend/internal/interfaces/rest/router.go
+++ b/backend/internal/interfaces/rest/router.go
@@ -149,6 +149,7 @@ func NewRouter(
 	mux.Handle("DELETE /api/v1/clients/{id}", businessChain(clientHandler.Delete))
 
 	mux.Handle("POST /api/v1/reports/clients-csv", businessChain(reportHandler.ExportClientsCSV))
+	mux.Handle("POST /api/v1/reports/unpaid-clients-csv", businessChain(reportHandler.ExportUnpaidClientsCSV))
 	mux.Handle("GET /api/v1/reports/download", businessChain(reportHandler.DownloadReport))
 
 	handler := middleware.SecurityHeaders(

--- a/frontend/src/features/clients/pages/ClientsPage.tsx
+++ b/frontend/src/features/clients/pages/ClientsPage.tsx
@@ -228,6 +228,31 @@ export const ClientsPage = () => {
     }
   };
 
+  const handleExportUnpaidClientsCsv = async () => {
+    setReportMenuAnchor(null);
+    setExportingReport(true);
+    try {
+      const resp = await reportService.exportUnpaidClientsCsv();
+      setSnackbar({
+        open: true,
+        message:
+          resp?.message ||
+          "Processamento do relatório iniciado! O link do arquivo será enviado para o seu e-mail cadastrado.",
+        severity: "success",
+      });
+    } catch (err: any) {
+      setSnackbar({
+        open: true,
+        message:
+          err?.response?.data?.message ||
+          "Erro ao solicitar exportação do relatório.",
+        severity: "error",
+      });
+    } finally {
+      setExportingReport(false);
+    }
+  };
+
   if (!activeSeason) {
     return (
       <Box sx={{ p: { xs: 1.5, sm: 2.5, md: 3 } }}>
@@ -292,6 +317,12 @@ export const ClientsPage = () => {
                 <FileDownloadIcon fontSize="small" />
               </ListItemIcon>
               Exportar Clientes (.csv)
+            </MenuItem>
+            <MenuItem onClick={handleExportUnpaidClientsCsv}>
+              <ListItemIcon>
+                <FileDownloadIcon fontSize="small" />
+              </ListItemIcon>
+              Exportar Não Pagos (.csv)
             </MenuItem>
           </Menu>
 

--- a/frontend/src/features/dashboard/pages/DashboardPage.test.tsx
+++ b/frontend/src/features/dashboard/pages/DashboardPage.test.tsx
@@ -6,6 +6,7 @@ import { useSeasonStore } from "../../../store/seasonStore";
 import { clientService } from "../../../services/api/client.service";
 import { personService } from "../../../services/api/person.service";
 import { photographerService } from "../../../services/api/photographer.service";
+import { reportService } from "../../../services/api/report.service";
 
 describe("DashboardPage", () => {
   beforeEach(() => {
@@ -208,6 +209,62 @@ describe("DashboardPage", () => {
     await waitFor(() => {
       expect(
         screen.getByText("Vincular Cliente na Temporada"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("triggers export of clients csv report from report menu", async () => {
+    useSeasonStore.setState({
+      activeSeason: { id: "season-1", name: "Temporada 2026" },
+    });
+
+    const exportSpy = vi
+      .spyOn(reportService, "exportClientsCsv")
+      .mockResolvedValue({ message: "Exportação iniciada!" });
+
+    render(
+      <BrowserRouter>
+        <DashboardPage />
+      </BrowserRouter>,
+    );
+
+    const reportBtn = screen.getByRole("button", { name: /Relatórios/i });
+    fireEvent.click(reportBtn);
+
+    const exportOption = await screen.findByText("Exportar Clientes (.csv)");
+    fireEvent.click(exportOption);
+
+    await waitFor(() => {
+      expect(exportSpy).toHaveBeenCalled();
+      expect(screen.getByText("Exportação iniciada!")).toBeInTheDocument();
+    });
+  });
+
+  it("triggers export of unpaid clients csv report from report menu", async () => {
+    useSeasonStore.setState({
+      activeSeason: { id: "season-1", name: "Temporada 2026" },
+    });
+
+    const exportSpy = vi
+      .spyOn(reportService, "exportUnpaidClientsCsv")
+      .mockResolvedValue({ message: "Exportação de não pagos iniciada!" });
+
+    render(
+      <BrowserRouter>
+        <DashboardPage />
+      </BrowserRouter>,
+    );
+
+    const reportBtn = screen.getByRole("button", { name: /Relatórios/i });
+    fireEvent.click(reportBtn);
+
+    const exportOption = await screen.findByText("Exportar Não Pagos (.csv)");
+    fireEvent.click(exportOption);
+
+    await waitFor(() => {
+      expect(exportSpy).toHaveBeenCalled();
+      expect(
+        screen.getByText("Exportação de não pagos iniciada!"),
       ).toBeInTheDocument();
     });
   });

--- a/frontend/src/features/dashboard/pages/DashboardPage.tsx
+++ b/frontend/src/features/dashboard/pages/DashboardPage.tsx
@@ -123,6 +123,31 @@ export const DashboardPage = () => {
     }
   };
 
+  const handleExportUnpaidClientsCsv = async () => {
+    setReportMenuAnchor(null);
+    setExportingReport(true);
+    try {
+      const resp = await reportService.exportUnpaidClientsCsv();
+      setSnackbar({
+        open: true,
+        message:
+          resp?.message ||
+          "Processamento do relatório iniciado! O link do arquivo será enviado para o seu e-mail cadastrado.",
+        severity: "success",
+      });
+    } catch (err: any) {
+      setSnackbar({
+        open: true,
+        message:
+          err?.response?.data?.message ||
+          "Erro ao solicitar exportação do relatório.",
+        severity: "error",
+      });
+    } finally {
+      setExportingReport(false);
+    }
+  };
+
   // Debounce search input
   useEffect(() => {
     const timer = setTimeout(() => {
@@ -395,6 +420,12 @@ export const DashboardPage = () => {
                   <FileDownloadIcon fontSize="small" />
                 </ListItemIcon>
                 Exportar Clientes (.csv)
+              </MenuItem>
+              <MenuItem onClick={handleExportUnpaidClientsCsv}>
+                <ListItemIcon>
+                  <FileDownloadIcon fontSize="small" />
+                </ListItemIcon>
+                Exportar Não Pagos (.csv)
               </MenuItem>
             </Menu>
 

--- a/frontend/src/services/api/report.service.ts
+++ b/frontend/src/services/api/report.service.ts
@@ -12,6 +12,13 @@ export const reportService = {
     return data;
   },
 
+  exportUnpaidClientsCsv: async (): Promise<ReportExportResponse> => {
+    const { data } = await apiClient.post<ReportExportResponse>(
+      "/reports/unpaid-clients-csv",
+    );
+    return data;
+  },
+
   downloadReport: async (filePath: string): Promise<Blob> => {
     const { data } = await apiClient.get<Blob>("/reports/download", {
       params: { file: filePath },


### PR DESCRIPTION
### Resumo das Alterações

Implementação da geração assíncrona e exportação de relatório CSV com filtro exclusivo para pessoas/clientes com fotos e pagamentos não pagos ou pendentes.

- **Domínio (`backend/internal/domain/report/report.go`)**:
  - Adicionado o tipo de relatório `TypeUnpaidClientsCSV`.
- **Casos de Uso (`backend/internal/application/usecase/report/service.go`)**:
  - Implementado `GenerateUnpaidClientsCSV` com streaming direto via MongoDB (`StreamByTenant`), filtragem rigorosa de fotos com status não quitado/pendente, formatação padronizada de telefone e sanitização obrigatória contra formula injection (CWE-1236).
  - Adicionados testes unitários em `service_test.go` cobrindo cenários de filtragem, múltiplos cães/fotos, injeção CSV e envio de e-mails com links de download.
- **REST & Swagger (`backend/internal/interfaces/rest/`)**:
  - Criado handler `ExportUnpaidClientsCSV` retornando `202 Accepted` e mapeada a rota `POST /api/v1/reports/unpaid-clients-csv`.
  - Regenerada documentação Swagger via `./scripts/swagger.sh`.
- **Frontend (`frontend/src/`)**:
  - Adicionado método `exportUnpaidClientsCsv` no `report.service.ts`.
  - Adicionada opção "Exportar Não Pagos (.csv)" nos menus de relatórios em `ClientsPage.tsx` e `DashboardPage.tsx`.
  - Adicionados testes unitários no `DashboardPage.test.tsx` cobrindo o acionamento do fluxo de exportação.

Closes #40

### Checklist de Validação
- [x] `./scripts/swagger.sh`
- [x] `./scripts/check.sh all` (Backend, Frontend e Terraform aprovados com 100% de sucesso)
