### PR TITLE
feat(events): renomear temporadas para eventos, permitir múltiplos juízes e exportação em pdf sem repetição

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -1344,11 +1344,86 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/reports/clients-pdf": {
+            "get": {
+                "description": "Gera e faz o download direto instantâneo do relatório consolidado em formato PDF",
+                "produces": [
+                    "application/pdf"
+                ],
+                "tags": [
+                    "Reports"
+                ],
+                "summary": "Download direto do relatório PDF de clientes",
+                "responses": {
+                    "200": {
+                        "description": "Arquivo PDF",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "401": {
+                        "description": "Não autenticado",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.ErrorEnvelope"
+                        }
+                    },
+                    "403": {
+                        "description": "Tenant não associado",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.ErrorEnvelope"
+                        }
+                    },
+                    "500": {
+                        "description": "Erro interno",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.ErrorEnvelope"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Inicia a extração assíncrona do relatório consolidado em PDF de clientes, cães e fotos para o tenant autenticado e envia o link para o e-mail cadastrado",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Reports"
+                ],
+                "summary": "Exportar relatório PDF de clientes",
+                "responses": {
+                    "202": {
+                        "description": "Accepted",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.SuccessEnvelope"
+                        }
+                    },
+                    "401": {
+                        "description": "Não autenticado",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.ErrorEnvelope"
+                        }
+                    },
+                    "403": {
+                        "description": "Tenant não associado",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.ErrorEnvelope"
+                        }
+                    },
+                    "500": {
+                        "description": "Erro interno",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.ErrorEnvelope"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/reports/download": {
             "get": {
                 "description": "Permite o download seguro de um arquivo de relatório previamente gerado, validando isolamento de tenant",
                 "produces": [
-                    "text/csv"
+                    "text/csv",
+                    "application/pdf"
                 ],
                 "tags": [
                     "Reports"
@@ -1365,7 +1440,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                        "description": "Arquivo CSV",
+                        "description": "Arquivo de relatório",
                         "schema": {
                             "type": "string"
                         }
@@ -1755,6 +1830,12 @@ const docTemplate = `{
                 "judge": {
                     "type": "string"
                 },
+                "judges": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "photos": {
                     "type": "array",
                     "items": {
@@ -1795,8 +1876,17 @@ const docTemplate = `{
                 "amount_paid": {
                     "type": "number"
                 },
+                "created_at": {
+                    "type": "string"
+                },
                 "file_number": {
                     "type": "string"
+                },
+                "judges": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "payment_method": {
                     "description": "Pix, Cartão de Crédito, Cartão de Débito, Dinheiro, Não pago",
@@ -1993,6 +2083,12 @@ const docTemplate = `{
                 },
                 "id": {
                     "type": "string"
+                },
+                "judges": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "name": {
                     "type": "string"

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -1338,11 +1338,86 @@
                 }
             }
         },
+        "/api/v1/reports/clients-pdf": {
+            "get": {
+                "description": "Gera e faz o download direto instantâneo do relatório consolidado em formato PDF",
+                "produces": [
+                    "application/pdf"
+                ],
+                "tags": [
+                    "Reports"
+                ],
+                "summary": "Download direto do relatório PDF de clientes",
+                "responses": {
+                    "200": {
+                        "description": "Arquivo PDF",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "401": {
+                        "description": "Não autenticado",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.ErrorEnvelope"
+                        }
+                    },
+                    "403": {
+                        "description": "Tenant não associado",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.ErrorEnvelope"
+                        }
+                    },
+                    "500": {
+                        "description": "Erro interno",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.ErrorEnvelope"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Inicia a extração assíncrona do relatório consolidado em PDF de clientes, cães e fotos para o tenant autenticado e envia o link para o e-mail cadastrado",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Reports"
+                ],
+                "summary": "Exportar relatório PDF de clientes",
+                "responses": {
+                    "202": {
+                        "description": "Accepted",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.SuccessEnvelope"
+                        }
+                    },
+                    "401": {
+                        "description": "Não autenticado",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.ErrorEnvelope"
+                        }
+                    },
+                    "403": {
+                        "description": "Tenant não associado",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.ErrorEnvelope"
+                        }
+                    },
+                    "500": {
+                        "description": "Erro interno",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.ErrorEnvelope"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/reports/download": {
             "get": {
                 "description": "Permite o download seguro de um arquivo de relatório previamente gerado, validando isolamento de tenant",
                 "produces": [
-                    "text/csv"
+                    "text/csv",
+                    "application/pdf"
                 ],
                 "tags": [
                     "Reports"
@@ -1359,7 +1434,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Arquivo CSV",
+                        "description": "Arquivo de relatório",
                         "schema": {
                             "type": "string"
                         }
@@ -1749,6 +1824,12 @@
                 "judge": {
                     "type": "string"
                 },
+                "judges": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "photos": {
                     "type": "array",
                     "items": {
@@ -1789,8 +1870,17 @@
                 "amount_paid": {
                     "type": "number"
                 },
+                "created_at": {
+                    "type": "string"
+                },
                 "file_number": {
                     "type": "string"
+                },
+                "judges": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "payment_method": {
                     "description": "Pix, Cartão de Crédito, Cartão de Débito, Dinheiro, Não pago",
@@ -1987,6 +2077,12 @@
                 },
                 "id": {
                     "type": "string"
+                },
+                "judges": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "name": {
                     "type": "string"

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -10,6 +10,10 @@ definitions:
         type: boolean
       judge:
         type: string
+      judges:
+        items:
+          type: string
+        type: array
       photos:
         items:
           $ref: '#/definitions/client.Photo'
@@ -36,8 +40,14 @@ definitions:
     properties:
       amount_paid:
         type: number
+      created_at:
+        type: string
       file_number:
         type: string
+      judges:
+        items:
+          type: string
+        type: array
       payment_method:
         description: Pix, Cartão de Crédito, Cartão de Débito, Dinheiro, Não pago
         type: string
@@ -169,6 +179,10 @@ definitions:
         type: string
       id:
         type: string
+      judges:
+        items:
+          type: string
+        type: array
       name:
         type: string
       photographer_ids:
@@ -1066,6 +1080,58 @@ paths:
       summary: Exportar relatório CSV de clientes
       tags:
       - Reports
+  /api/v1/reports/clients-pdf:
+    get:
+      description: Gera e faz o download direto instantâneo do relatório consolidado
+        em formato PDF
+      produces:
+      - application/pdf
+      responses:
+        "200":
+          description: Arquivo PDF
+          schema:
+            type: string
+        "401":
+          description: Não autenticado
+          schema:
+            $ref: '#/definitions/httpx.ErrorEnvelope'
+        "403":
+          description: Tenant não associado
+          schema:
+            $ref: '#/definitions/httpx.ErrorEnvelope'
+        "500":
+          description: Erro interno
+          schema:
+            $ref: '#/definitions/httpx.ErrorEnvelope'
+      summary: Download direto do relatório PDF de clientes
+      tags:
+      - Reports
+    post:
+      description: Inicia a extração assíncrona do relatório consolidado em PDF de
+        clientes, cães e fotos para o tenant autenticado e envia o link para o e-mail
+        cadastrado
+      produces:
+      - application/json
+      responses:
+        "202":
+          description: Accepted
+          schema:
+            $ref: '#/definitions/httpx.SuccessEnvelope'
+        "401":
+          description: Não autenticado
+          schema:
+            $ref: '#/definitions/httpx.ErrorEnvelope'
+        "403":
+          description: Tenant não associado
+          schema:
+            $ref: '#/definitions/httpx.ErrorEnvelope'
+        "500":
+          description: Erro interno
+          schema:
+            $ref: '#/definitions/httpx.ErrorEnvelope'
+      summary: Exportar relatório PDF de clientes
+      tags:
+      - Reports
   /api/v1/reports/download:
     get:
       description: Permite o download seguro de um arquivo de relatório previamente
@@ -1078,9 +1144,10 @@ paths:
         type: string
       produces:
       - text/csv
+      - application/pdf
       responses:
         "200":
-          description: Arquivo CSV
+          description: Arquivo de relatório
           schema:
             type: string
         "400":

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/go-openapi/jsonreference v0.20.0 // indirect
 	github.com/go-openapi/spec v0.20.6 // indirect
 	github.com/go-openapi/swag v0.19.15 // indirect
+	github.com/go-pdf/fpdf v0.9.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/klauspost/compress v1.17.6 // indirect
 	github.com/mailru/easyjson v0.7.6 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -14,6 +14,8 @@ github.com/go-openapi/spec v0.20.6/go.mod h1:2OpW+JddWPrpXSCIX8eOx7lZ5iyuWj3RYR6
 github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
 github.com/go-openapi/swag v0.19.15 h1:D2NRCBzS9/pEY3gP9Nl8aDqGUcPFrwG2p+CNFrLyrCM=
 github.com/go-openapi/swag v0.19.15/go.mod h1:QYRuS/SOXUCsnplDa677K7+DxSOj6IPNl/eQntq43wQ=
+github.com/go-pdf/fpdf v0.9.0 h1:PPvSaUuo1iMi9KkaAn90NuKi+P4gwMedWPHhj8YlJQw=
+github.com/go-pdf/fpdf v0.9.0/go.mod h1:oO8N111TkmKb9D7VvWGLvLJlaZUQVPM+6V42pp3iV4Y=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=

--- a/backend/internal/application/usecase/report/service.go
+++ b/backend/internal/application/usecase/report/service.go
@@ -13,6 +13,8 @@ import (
 	"time"
 	"unicode"
 
+	"github.com/go-pdf/fpdf"
+
 	clientport "ps/internal/application/ports/client"
 	emailport "ps/internal/application/ports/email"
 	personport "ps/internal/application/ports/person"
@@ -127,6 +129,36 @@ func sanitizeRow(row []string) []string {
 	return sanitized
 }
 
+func formatJudges(dog clientdomain.Dog, photo *clientdomain.Photo) string {
+	if photo != nil && len(photo.Judges) > 0 {
+		return strings.Join(photo.Judges, ", ")
+	}
+	if len(dog.Judges) > 0 {
+		return strings.Join(dog.Judges, ", ")
+	}
+	return dog.Judge
+}
+
+func formatIsOwner(isOwner *bool) string {
+	if isOwner != nil {
+		if *isOwner {
+			return "Sim"
+		}
+		return "Não"
+	}
+	return "Sim"
+}
+
+func formatPhotoDate(photo *clientdomain.Photo, clientCreatedAt time.Time) string {
+	if photo != nil && photo.CreatedAt != nil && !photo.CreatedAt.IsZero() {
+		return photo.CreatedAt.Format("02/01/2006 15:04")
+	}
+	if !clientCreatedAt.IsZero() {
+		return clientCreatedAt.Format("02/01/2006 15:04")
+	}
+	return ""
+}
+
 func (s *Service) GenerateClientsCSV(ctx context.Context, tenantID, userEmail, userName string) (string, error) {
 	if tenantID == "" {
 		return "", errors.New("tenant ID cannot be empty")
@@ -146,7 +178,7 @@ func (s *Service) GenerateClientsCSV(ctx context.Context, tenantID, userEmail, u
 	// 2. Cache persons dynamically during stream to avoid repeated identical queries
 	personCache := make(map[string]*persondomain.Person)
 
-	// 3. Prepare CSV buffer with headers
+	// 3. Prepare CSV buffer with updated headers
 	var buf bytes.Buffer
 	writer := csv.NewWriter(&buf)
 
@@ -155,13 +187,15 @@ func (s *Service) GenerateClientsCSV(ctx context.Context, tenantID, userEmail, u
 		"E-mail",
 		"E-mail alternativo",
 		"Telefone",
+		"Dono do Cachorro",
+		"Raça",
+		"Juiz",
+		"Competição Ganha",
 		"Número do Arquivo da Foto",
 		"Fotografo",
-		"Competição Ganha",
-		"Juiz",
 		"Forma de Pagamento",
-		"Raça",
 		"Valor Pago",
+		"Data da Foto",
 	}
 	if err := writer.Write(sanitizeRow(headers)); err != nil {
 		return "", fmt.Errorf("failed to write csv headers: %w", err)
@@ -196,15 +230,18 @@ func (s *Service) GenerateClientsCSV(ctx context.Context, tenantID, userEmail, u
 				"",
 				"",
 				"",
+				"",
+				"",
 			}
 			return writer.Write(sanitizeRow(row))
 		}
 
 		for _, dog := range c.Dogs {
+			isOwnerStr := formatIsOwner(dog.IsOwner)
 			numPhotos := len(dog.Photos)
 			wonCompsList := dog.WonCompetitions
 			numCompetitions := len(wonCompsList)
-			if numCompetitions == 0 {
+			if numCompetitions == 0 && dog.CompetitionsWon > 0 {
 				numCompetitions = dog.CompetitionsWon
 			}
 			totalLinhas := max(numCompetitions, numPhotos)
@@ -215,12 +252,14 @@ func (s *Service) GenerateClientsCSV(ctx context.Context, tenantID, userEmail, u
 					p.Email,
 					p.AlternativeEmail,
 					formattedPhone,
-					"",
-					"",
-					"",
-					dog.Judge,
-					"",
+					isOwnerStr,
 					dog.Breed,
+					formatJudges(dog, nil),
+					"",
+					"",
+					"",
+					"",
+					"",
 					"",
 				}
 				if err := writer.Write(sanitizeRow(row)); err != nil {
@@ -230,7 +269,8 @@ func (s *Service) GenerateClientsCSV(ctx context.Context, tenantID, userEmail, u
 			}
 
 			for i := 0; i < totalLinhas; i++ {
-				var fileNumber, photographerName, paymentMethod, amountPaid string
+				var fileNumber, photographerName, paymentMethod, amountPaid, photoDate string
+				var currentPhoto *clientdomain.Photo
 				if numPhotos > 0 {
 					var photo clientdomain.Photo
 					if i < numPhotos {
@@ -238,6 +278,7 @@ func (s *Service) GenerateClientsCSV(ctx context.Context, tenantID, userEmail, u
 					} else {
 						photo = dog.Photos[numPhotos-1]
 					}
+					currentPhoto = &photo
 					fileNumber = photo.FileNumber
 					if name, exists := photogMap[photo.PhotographerID]; exists && name != "" {
 						photographerName = name
@@ -248,6 +289,7 @@ func (s *Service) GenerateClientsCSV(ctx context.Context, tenantID, userEmail, u
 					if photo.AmountPaid != nil {
 						amountPaid = fmt.Sprintf("%.2f", *photo.AmountPaid)
 					}
+					photoDate = formatPhotoDate(&photo, c.CreatedAt)
 				}
 
 				var competitionWon string
@@ -266,13 +308,15 @@ func (s *Service) GenerateClientsCSV(ctx context.Context, tenantID, userEmail, u
 					p.Email,
 					p.AlternativeEmail,
 					formattedPhone,
+					isOwnerStr,
+					dog.Breed,
+					formatJudges(dog, currentPhoto),
+					competitionWon,
 					fileNumber,
 					photographerName,
-					competitionWon,
-					dog.Judge,
 					paymentMethod,
-					dog.Breed,
 					amountPaid,
+					photoDate,
 				}
 				if err := writer.Write(sanitizeRow(row)); err != nil {
 					return err
@@ -400,13 +444,15 @@ func (s *Service) GenerateUnpaidClientsCSV(ctx context.Context, tenantID, userEm
 					amount = fmt.Sprintf("%.2f", *photo.AmountPaid)
 				}
 
+				judgeStr := formatJudges(dog, &photo)
+
 				row := []string{
 					personObj.Name,
 					personObj.Email,
 					personObj.AlternativeEmail,
 					FormatPhone(personObj.Phone),
 					dog.Breed,
-					dog.Judge,
+					judgeStr,
 					photo.FileNumber,
 					photographerName,
 					paymentStatus,
@@ -454,6 +500,273 @@ func (s *Service) GenerateUnpaidClientsCSV(ctx context.Context, tenantID, userEm
 	}
 
 	return relativePath, nil
+}
+
+func fitPdfText(pdf *fpdf.Fpdf, text string, maxWidth float64) string {
+	if pdf.GetStringWidth(text) <= maxWidth {
+		return text
+	}
+	runes := []rune(text)
+	for len(runes) > 0 && pdf.GetStringWidth(string(runes)+"...") > maxWidth {
+		runes = runes[:len(runes)-1]
+	}
+	if len(runes) == 0 {
+		return ""
+	}
+	return string(runes) + "..."
+}
+
+func (s *Service) buildClientsPDF(ctx context.Context, tenantID string) ([]byte, error) {
+	if tenantID == "" {
+		return nil, errors.New("tenant ID cannot be empty")
+	}
+
+	// Fetch photographers
+	photographersList, err := s.photographerRepo.List(ctx, tenantID)
+	if err != nil {
+		photographersList = nil
+	}
+	photogMap := make(map[string]string)
+	for _, p := range photographersList {
+		photogMap[p.ID] = p.Name
+	}
+
+	// Collect clients
+	personCache := make(map[string]*persondomain.Person)
+	var clients []*clientdomain.SeasonClient
+	err = s.clientRepo.StreamByTenant(ctx, tenantID, func(c *clientdomain.SeasonClient) error {
+		clients = append(clients, c)
+		if _, ok := personCache[c.PersonID]; !ok {
+			personObj, pErr := s.personRepo.GetByID(ctx, c.PersonID, tenantID)
+			if pErr != nil || personObj == nil {
+				personObj = &persondomain.Person{Name: "Desconhecido"}
+			}
+			personCache[c.PersonID] = personObj
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to stream clients for pdf: %w", err)
+	}
+
+	// A4 Landscape: 297mm x 210mm. Margins: 10mm left/right -> 277mm usable width
+	pdf := fpdf.New("L", "mm", "A4", "")
+	pdf.SetMargins(10, 10, 10)
+	pdf.SetAutoPageBreak(true, 12)
+	tr := pdf.UnicodeTranslatorFromDescriptor("")
+
+	colWidths := []float64{32, 40, 24, 24, 12, 32, 38, 16, 23, 18, 18}
+	colHeaders := []string{
+		"Nome", "E-mail", "Telefone", "Raça", "Dono", "Juiz",
+		"Competições Vencidas", "Arquivo", "Forma de Pagamento", "Valor Pago", "Data da Foto",
+	}
+
+	pdf.SetHeaderFunc(func() {
+		pdf.SetFont("Arial", "B", 12)
+		pdf.SetTextColor(15, 23, 42)
+		pdf.CellFormat(185, 6, tr("Relatório Consolidado de Clientes, Cães e Fotos"), "", 0, "L", false, 0, "")
+		pdf.SetFont("Arial", "", 8)
+		pdf.SetTextColor(100, 116, 139)
+		pdf.CellFormat(92, 6, tr(fmt.Sprintf("Gerado em: %s", time.Now().Format("02/01/2006 15:04"))), "", 1, "R", false, 0, "")
+		pdf.Ln(2)
+
+		// Table Header Bar
+		pdf.SetFillColor(30, 41, 59)
+		pdf.SetTextColor(255, 255, 255)
+		pdf.SetDrawColor(51, 65, 85)
+		pdf.SetLineWidth(0.2)
+		pdf.SetFont("Arial", "B", 7)
+
+		for i, h := range colHeaders {
+			align := "L"
+			if i == 4 || i == 7 || i == 9 || i == 10 {
+				align = "C"
+			}
+			pdf.CellFormat(colWidths[i], 6.5, tr(h), "1", 0, align, true, 0, "")
+		}
+		pdf.Ln(-1)
+	})
+
+	pdf.SetFooterFunc(func() {
+		pdf.SetY(-9)
+		pdf.SetFont("Arial", "I", 7)
+		pdf.SetTextColor(148, 163, 184)
+		pdf.CellFormat(0, 5, tr(fmt.Sprintf("Página %d/{nb}  •  Photo Storage", pdf.PageNo())), "", 0, "C", false, 0, "")
+	})
+
+	pdf.AliasNbPages("{nb}")
+	pdf.AddPage()
+
+	if len(clients) == 0 {
+		pdf.SetFont("Arial", "I", 9)
+		pdf.SetTextColor(100, 116, 139)
+		pdf.Ln(10)
+		pdf.CellFormat(277, 10, tr("Nenhum cliente ou foto encontrado para exportação."), "", 1, "C", false, 0, "")
+		var buf bytes.Buffer
+		if err := pdf.Output(&buf); err != nil {
+			return nil, err
+		}
+		return buf.Bytes(), nil
+	}
+
+	pdf.SetFont("Arial", "", 7)
+	pdf.SetDrawColor(226, 232, 240) // border color #e2e8f0
+	pdf.SetLineWidth(0.15)
+
+	for cIdx, client := range clients {
+		p := personCache[client.PersonID]
+		if p == nil {
+			p = &persondomain.Person{Name: "Desconhecido"}
+		}
+		formattedPhone := FormatPhone(p.Phone)
+
+		if len(client.Dogs) == 0 {
+			pdf.SetTextColor(15, 23, 42)
+			rowVals := []string{
+				p.Name, p.Email, formattedPhone,
+				"-", "-", "-", "-", "-", "-", "-", "-",
+			}
+			for i, val := range rowVals {
+				align := "L"
+				if i == 4 || i == 7 || i == 9 || i == 10 {
+					align = "C"
+				}
+				fitted := fitPdfText(pdf, tr(val), colWidths[i]-2)
+				pdf.CellFormat(colWidths[i], 5.5, fitted, "1", 0, align, false, 0, "")
+			}
+			pdf.Ln(-1)
+		} else {
+			for dIdx, dog := range client.Dogs {
+				isOwnerStr := formatIsOwner(dog.IsOwner)
+				judgeStr := formatJudges(dog, nil)
+				wonComps := dog.WonCompetitions
+				if len(wonComps) == 0 && dog.CompetitionsWon > 0 {
+					wonComps = []string{"Sim"}
+				}
+				numPhotos := len(dog.Photos)
+				totalRows := max(len(wonComps), numPhotos)
+				if totalRows == 0 {
+					totalRows = 1
+				}
+
+				for rIdx := 0; rIdx < totalRows; rIdx++ {
+					var colName, colEmail, colPhone, colBreed, colOwner, colJudge, colComp, colFile, colPayment, colAmount, colDate string
+
+					// Show person info only on the very first row of the very first dog for this client
+					if dIdx == 0 && rIdx == 0 {
+						colName = p.Name
+						colEmail = p.Email
+						colPhone = formattedPhone
+					}
+
+					// Show dog info only on the first row of this dog
+					if rIdx == 0 {
+						colBreed = dog.Breed
+						colOwner = isOwnerStr
+						colJudge = judgeStr
+					}
+
+					// Won competition on current row index
+					if rIdx < len(wonComps) {
+						colComp = wonComps[rIdx]
+					}
+
+					// Photo info on current row index
+					if rIdx < numPhotos {
+						photo := dog.Photos[rIdx]
+						colFile = photo.FileNumber
+						colPayment = NormalizePaymentMethod(photo.PaymentMethod)
+						if photo.AmountPaid != nil {
+							colAmount = fmt.Sprintf("R$ %.2f", *photo.AmountPaid)
+						}
+						colDate = formatPhotoDate(&photo, client.CreatedAt)
+						if len(photo.Judges) > 0 && rIdx > 0 {
+							colJudge = strings.Join(photo.Judges, ", ")
+						}
+					}
+
+					pdf.SetTextColor(30, 41, 59)
+					rowVals := []string{
+						colName, colEmail, colPhone,
+						colBreed, colOwner, colJudge,
+						colComp, colFile, colPayment, colAmount, colDate,
+					}
+
+					for i, val := range rowVals {
+						align := "L"
+						if i == 4 || i == 7 || i == 9 || i == 10 {
+							align = "C"
+						}
+						fitted := fitPdfText(pdf, tr(val), colWidths[i]-2)
+						pdf.CellFormat(colWidths[i], 5.5, fitted, "1", 0, align, false, 0, "")
+					}
+					pdf.Ln(-1)
+				}
+
+				// Draw a subtle line between dogs of the same client
+				if dIdx < len(client.Dogs)-1 {
+					pdf.SetDrawColor(203, 213, 225)
+					pdf.SetLineWidth(0.1)
+					x := pdf.GetX()
+					y := pdf.GetY()
+					pdf.Line(x+colWidths[0]+colWidths[1]+colWidths[2], y, x+277, y)
+					pdf.SetDrawColor(226, 232, 240)
+					pdf.SetLineWidth(0.15)
+				}
+			}
+		}
+
+		// Draw a solid divider line between distinct clients
+		if cIdx < len(clients)-1 {
+			pdf.SetDrawColor(100, 116, 139)
+			pdf.SetLineWidth(0.35)
+			x := pdf.GetX()
+			y := pdf.GetY()
+			pdf.Line(x, y, x+277, y)
+			pdf.SetDrawColor(226, 232, 240)
+			pdf.SetLineWidth(0.15)
+		}
+	}
+
+	var buf bytes.Buffer
+	if err := pdf.Output(&buf); err != nil {
+		return nil, fmt.Errorf("failed to render pdf output: %w", err)
+	}
+
+	return buf.Bytes(), nil
+}
+
+func (s *Service) GenerateClientsPDF(ctx context.Context, tenantID, userEmail, userName string) (string, error) {
+	pdfBytes, err := s.buildClientsPDF(ctx, tenantID)
+	if err != nil {
+		return "", err
+	}
+
+	timestamp := time.Now().UTC().Unix()
+	fileName := fmt.Sprintf("clientes_%d.pdf", timestamp)
+	relativePath := fmt.Sprintf("reports/tenant_%s/%s", tenantID, fileName)
+
+	_, err = s.storageProvider.Save(ctx, relativePath, storageport.File{
+		Name:        fileName,
+		Data:        pdfBytes,
+		ContentType: "application/pdf",
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to save pdf report to storage: %w", err)
+	}
+
+	if userEmail != "" {
+		downloadURL := fmt.Sprintf("%s/reports/download?file=%s", s.appBaseURL, url.QueryEscape(relativePath))
+		if err := s.emailSender.SendReportReadyEmail(ctx, userEmail, userName, "Relatório de Clientes (PDF)", downloadURL); err != nil {
+			log.Printf("[REPORT-EMAIL-ERROR] Failed to send PDF report ready email to %s: %v", userEmail, err)
+		}
+	}
+
+	return relativePath, nil
+}
+
+func (s *Service) GenerateDirectClientsPDF(ctx context.Context, tenantID string) ([]byte, error) {
+	return s.buildClientsPDF(ctx, tenantID)
 }
 
 func (s *Service) GetReportFile(ctx context.Context, tenantID, relativePath string) ([]byte, error) {

--- a/backend/internal/application/usecase/report/service_test.go
+++ b/backend/internal/application/usecase/report/service_test.go
@@ -279,32 +279,33 @@ func TestGenerateClientsCSV_FullExpansionAndRules(t *testing.T) {
 
 	// Check Header
 	headers := records[0]
-	if headers[0] != "Nome" || headers[4] != "Número do Arquivo da Foto" || headers[5] != "Fotografo" {
+	if headers[0] != "Nome" || headers[4] != "Dono do Cachorro" || headers[5] != "Raça" || headers[6] != "Juiz" || headers[8] != "Número do Arquivo da Foto" {
 		t.Fatalf("headers mismatch: %v", headers)
 	}
 
 	// Check dog-1 rows (2 rows)
+	// Headers: Nome[0], Email[1], AltEmail[2], Phone[3], Dono[4], Raca[5], Juiz[6], Comp[7], Arquivo[8], Fotografo[9], Pagamento[10], Valor[11], Data[12]
 	row1 := records[1]
-	if row1[0] != "Maria Souza" || row1[3] != "(11) 99999-8888" || row1[4] != "IMG_001" || row1[5] != "Fotógrafo Alpha" || row1[6] != "Melhor da Raça" || row1[8] != "Pix" || row1[10] != "100.50" {
+	if row1[0] != "Maria Souza" || row1[3] != "(11) 99999-8888" || row1[4] != "Sim" || row1[5] != "Border Collie" || row1[6] != "Juiz Silva" || row1[7] != "Melhor da Raça" || row1[8] != "IMG_001" || row1[9] != "Fotógrafo Alpha" || row1[10] != "Pix" || row1[11] != "100.50" {
 		t.Fatalf("row 1 mismatch: %v", row1)
 	}
 	row2 := records[2]
-	if row2[3] != "(11) 99999-8888" || row2[4] != "IMG_002" || row2[5] != "Fotógrafo Beta" || row2[6] != "Campeão Adulto" || row2[8] != "Cartão de Crédito" || row2[10] != "200.00" {
+	if row2[3] != "(11) 99999-8888" || row2[7] != "Campeão Adulto" || row2[8] != "IMG_002" || row2[9] != "Fotógrafo Beta" || row2[10] != "Cartão de Crédito" || row2[11] != "200.00" {
 		t.Fatalf("row 2 mismatch: %v", row2)
 	}
 
 	// Check dog-2 rows (3 rows, CSV injection sanitized with single quote, photo repeated on 3rd row)
 	row3 := records[3]
-	if row3[4] != "'=MALICIOUS_CMD" || row3[6] != "Sim" || row3[8] != "Dinheiro" {
+	if row3[8] != "'=MALICIOUS_CMD" || row3[7] != "Sim" || row3[10] != "Dinheiro" {
 		t.Fatalf("expected sanitized CSV injection and Dinheiro payment, got: %v", row3)
 	}
 	row4 := records[4]
-	if row4[4] != "'+SUM(A1:A2)" || row4[6] != "Sim" || row4[8] != "Pix" {
-		t.Fatalf("expected sanitized CSV injection field, got: %s", row4[4])
+	if row4[8] != "'+SUM(A1:A2)" || row4[7] != "Sim" || row4[10] != "Pix" {
+		t.Fatalf("expected sanitized CSV injection field, got: %s", row4[8])
 	}
 	row5 := records[5]
-	if row5[4] != "'+SUM(A1:A2)" || row5[6] != "Sim" {
-		t.Fatalf("expected repeated photo on row 5, got: %s", row5[4])
+	if row5[8] != "'+SUM(A1:A2)" || row5[7] != "Sim" {
+		t.Fatalf("expected repeated photo on row 5, got: %s", row5[8])
 	}
 
 	// Check email sent
@@ -325,6 +326,86 @@ func TestGenerateClientsCSV_FullExpansionAndRules(t *testing.T) {
 	_, err = svc.GetReportFile(context.Background(), "other-tenant", filePath)
 	if !errors.Is(err, ErrUnauthorizedTenant) {
 		t.Fatalf("expected ErrUnauthorizedTenant when accessing other tenant's report, got: %v", err)
+	}
+}
+
+func TestGenerateClientsPDF_Success(t *testing.T) {
+	tenantID := "tenant-456"
+	amount150 := 150.0
+	isTrue := true
+	isFalse := false
+
+	clientRepo := &mockClientRepo{
+		clients: []*clientdomain.SeasonClient{
+			{
+				ID:       "client-1",
+				TenantID: tenantID,
+				PersonID: "person-1",
+				Dogs: []clientdomain.Dog{
+					{
+						Breed:           "Dachshund",
+						Judges:          []string{"Tamas Jakkel", "Jorge jose"},
+						IsOwner:         &isTrue,
+						WonCompetitions: []string{"Melhor Filhote Américas e Caribe", "Cachorro Maluco"},
+						Photos: []clientdomain.Photo{
+							{FileNumber: "4124", PaymentMethod: "Pix", AmountPaid: &amount150},
+							{FileNumber: "4128", PaymentMethod: "Pix", AmountPaid: &amount150},
+						},
+					},
+					{
+						Breed:           "Basset Hund",
+						Judge:           "José Maurício Medeiros",
+						IsOwner:         &isFalse,
+						WonCompetitions: []string{"Melhor Raça"},
+						Photos: []clientdomain.Photo{
+							{FileNumber: "4125", PaymentMethod: "Não pago"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	personRepo := &mockPersonRepo{
+		people: map[string]*persondomain.Person{
+			"person-1": {
+				ID:    "person-1",
+				Name:  "Alex Itaboray",
+				Email: "alexitaboray@gmail.com",
+				Phone: "62996578137",
+			},
+		},
+	}
+
+	photographerRepo := &mockPhotographerRepo{}
+	storage := &mockStorageProvider{}
+	emailSender := &mockEmailSender{}
+
+	svc := NewService(clientRepo, personRepo, photographerRepo, storage, emailSender, "http://localhost:8080")
+
+	// Direct PDF test
+	pdfBytes, err := svc.GenerateDirectClientsPDF(context.Background(), tenantID)
+	if err != nil {
+		t.Fatalf("unexpected error generating direct PDF: %v", err)
+	}
+	if len(pdfBytes) < 500 {
+		t.Fatalf("generated PDF too small (%d bytes)", len(pdfBytes))
+	}
+	// Check PDF magic bytes '%PDF-'
+	if !bytes.HasPrefix(pdfBytes, []byte("%PDF-")) {
+		t.Fatalf("file content does not start with PDF magic header %%PDF-")
+	}
+
+	// Async PDF test with email
+	pdfPath, err := svc.GenerateClientsPDF(context.Background(), tenantID, "user@example.com", "User")
+	if err != nil {
+		t.Fatalf("unexpected error generating PDF with email: %v", err)
+	}
+	if !strings.HasSuffix(pdfPath, ".pdf") {
+		t.Fatalf("expected .pdf extension in path, got: %s", pdfPath)
+	}
+	if len(emailSender.sentReports) != 1 {
+		t.Fatalf("expected 1 email sent, got %d", len(emailSender.sentReports))
 	}
 }
 
@@ -582,4 +663,3 @@ func TestGenerateUnpaidClientsCSV(t *testing.T) {
 		t.Fatalf("unexpected email details: %v", emailSender.sentReports[0])
 	}
 }
-

--- a/backend/internal/domain/client/client.go
+++ b/backend/internal/domain/client/client.go
@@ -17,6 +17,7 @@ type SeasonClient struct {
 type Dog struct {
 	Breed           string   `json:"breed" bson:"breed"`
 	Judge           string   `json:"judge" bson:"judge"`
+	Judges          []string `json:"judges" bson:"judges"`
 	IsOwner         *bool    `json:"is_owner" bson:"is_owner"`
 	CompetitionsWon int      `json:"competitions_won" bson:"competitions_won"`
 	WonCompetitions []string `json:"won_competitions" bson:"won_competitions"`
@@ -24,10 +25,12 @@ type Dog struct {
 }
 
 type Photo struct {
-	FileNumber     string   `json:"file_number" bson:"file_number"`
-	PhotographerID string   `json:"photographer_id" bson:"photographer_id"`
-	PaymentMethod  string   `json:"payment_method" bson:"payment_method"` // Pix, Cartão de Crédito, Cartão de Débito, Dinheiro, Não pago
-	AmountPaid     *float64 `json:"amount_paid" bson:"amount_paid"`
+	FileNumber     string     `json:"file_number" bson:"file_number"`
+	PhotographerID string     `json:"photographer_id" bson:"photographer_id"`
+	PaymentMethod  string     `json:"payment_method" bson:"payment_method"` // Pix, Cartão de Crédito, Cartão de Débito, Dinheiro, Não pago
+	AmountPaid     *float64   `json:"amount_paid" bson:"amount_paid"`
+	Judges         []string   `json:"judges,omitempty" bson:"judges,omitempty"`
+	CreatedAt      *time.Time `json:"created_at,omitempty" bson:"created_at,omitempty"`
 }
 
 type ListFilter struct {

--- a/backend/internal/domain/report/report.go
+++ b/backend/internal/domain/report/report.go
@@ -16,6 +16,7 @@ type ReportType string
 const (
 	TypeClientsCSV       ReportType = "clients_csv"
 	TypeUnpaidClientsCSV ReportType = "unpaid_clients_csv"
+	TypeClientsPDF       ReportType = "clients_pdf"
 )
 
 type ReportJob struct {

--- a/backend/internal/domain/season/season.go
+++ b/backend/internal/domain/season/season.go
@@ -7,6 +7,7 @@ type Season struct {
 	TenantID        string    `json:"tenant_id" bson:"tenant_id"`
 	Name            string    `json:"name" bson:"name"`
 	PhotographerIDs []string  `json:"photographer_ids" bson:"photographer_ids"`
+	Judges          []string  `json:"judges" bson:"judges"`
 	CreatedAt       time.Time `json:"created_at" bson:"created_at"`
 	UpdatedAt       time.Time `json:"updated_at" bson:"updated_at"`
 }

--- a/backend/internal/infrastructure/client/mongo/repository.go
+++ b/backend/internal/infrastructure/client/mongo/repository.go
@@ -134,6 +134,8 @@ func (r *repository) List(ctx context.Context, tenantID string, filter domain.Li
 			bson.D{{Key: "person_doc.phone", Value: regexDoc}},
 			bson.D{{Key: "dogs.breed", Value: regexDoc}},
 			bson.D{{Key: "dogs.judge", Value: regexDoc}},
+			bson.D{{Key: "dogs.judges", Value: regexDoc}},
+			bson.D{{Key: "dogs.photos.judges", Value: regexDoc}},
 			bson.D{{Key: "dogs.won_competitions", Value: regexDoc}},
 			bson.D{{Key: "dogs.photos.file_number", Value: regexDoc}},
 		}

--- a/backend/internal/infrastructure/season/mongo/repository.go
+++ b/backend/internal/infrastructure/season/mongo/repository.go
@@ -95,11 +95,19 @@ func (r *repository) Update(ctx context.Context, season *domain.Season) error {
 	season.TenantID = cleanTenantID
 	season.UpdatedAt = time.Now().UTC()
 
+	if season.PhotographerIDs == nil {
+		season.PhotographerIDs = make([]string, 0)
+	}
+	if season.Judges == nil {
+		season.Judges = make([]string, 0)
+	}
+
 	filter := bson.D{{Key: "_id", Value: cleanID}, {Key: "tenant_id", Value: cleanTenantID}}
 	updateDoc := bson.D{
 		{Key: "$set", Value: bson.D{
 			{Key: "name", Value: season.Name},
 			{Key: "photographer_ids", Value: season.PhotographerIDs},
+			{Key: "judges", Value: season.Judges},
 			{Key: "updated_at", Value: season.UpdatedAt},
 		}},
 	}

--- a/backend/internal/interfaces/rest/handlers/report_handler.go
+++ b/backend/internal/interfaces/rest/handlers/report_handler.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 	"path/filepath"
+	"strings"
 	"time"
 
 	userport "ps/internal/application/ports/user"
@@ -111,13 +112,85 @@ func (h *ReportHandler) ExportUnpaidClientsCSV(w http.ResponseWriter, r *http.Re
 	})
 }
 
+// ExportClientsPDF godoc
+// @Summary      Exportar relatório PDF de clientes
+// @Description  Inicia a extração assíncrona do relatório consolidado em PDF de clientes, cães e fotos para o tenant autenticado e envia o link para o e-mail cadastrado
+// @Tags         Reports
+// @Produce      json
+// @Success      202  {object}  httpx.SuccessEnvelope
+// @Failure      401  {object}  httpx.ErrorEnvelope "Não autenticado"
+// @Failure      403  {object}  httpx.ErrorEnvelope "Tenant não associado"
+// @Failure      500  {object}  httpx.ErrorEnvelope "Erro interno"
+// @Router       /api/v1/reports/clients-pdf [post]
+func (h *ReportHandler) ExportClientsPDF(w http.ResponseWriter, r *http.Request) {
+	tenantID := middleware.GetTenantID(r.Context())
+	if tenantID == "" {
+		httpx.Error(w, http.StatusForbidden, "Tenant is required", nil)
+		return
+	}
+
+	userID := middleware.GetUserID(r.Context())
+	var userEmail, userName string
+	if userID != "" && h.userRepo != nil {
+		user, err := h.userRepo.FindByID(r.Context(), userID)
+		if err == nil && user.Email != "" {
+			userEmail = user.Email
+			userName = user.Name
+		}
+	}
+
+	// Launch async extraction job in background goroutine with detached context
+	go func(tID, uEmail, uName string) {
+		jobCtx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+		defer cancel()
+
+		if _, err := h.service.GenerateClientsPDF(jobCtx, tID, uEmail, uName); err != nil {
+			log.Printf("[REPORT-JOB-ERROR] Failed to generate clients PDF for tenant %s: %v", tID, err)
+		}
+	}(tenantID, userEmail, userName)
+
+	httpx.Accepted(w, map[string]string{
+		"message": "Geração do relatório em PDF iniciada com sucesso. O arquivo será enviado para o seu e-mail em instantes.",
+	})
+}
+
+// DownloadDirectClientsPDF godoc
+// @Summary      Download direto do relatório PDF de clientes
+// @Description  Gera e faz o download direto instantâneo do relatório consolidado em formato PDF
+// @Tags         Reports
+// @Produce      application/pdf
+// @Success      200  {string}  string "Arquivo PDF"
+// @Failure      401  {object}  httpx.ErrorEnvelope "Não autenticado"
+// @Failure      403  {object}  httpx.ErrorEnvelope "Tenant não associado"
+// @Failure      500  {object}  httpx.ErrorEnvelope "Erro interno"
+// @Router       /api/v1/reports/clients-pdf [get]
+func (h *ReportHandler) DownloadDirectClientsPDF(w http.ResponseWriter, r *http.Request) {
+	tenantID := middleware.GetTenantID(r.Context())
+	if tenantID == "" {
+		httpx.Error(w, http.StatusForbidden, "Tenant is required", nil)
+		return
+	}
+
+	pdfData, err := h.service.GenerateDirectClientsPDF(r.Context(), tenantID)
+	if err != nil {
+		httpx.Error(w, http.StatusInternalServerError, "Falha ao gerar relatório PDF", nil)
+		return
+	}
+
+	fileName := fmt.Sprintf("clientes_%d.pdf", time.Now().UTC().Unix())
+	w.Header().Set("Content-Type", "application/pdf")
+	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q", fileName))
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(pdfData)
+}
+
 // DownloadReport godoc
 // @Summary      Baixar arquivo de relatório gerado
 // @Description  Permite o download seguro de um arquivo de relatório previamente gerado, validando isolamento de tenant
 // @Tags         Reports
 // @Param        file query string true "Caminho relativo do arquivo de relatório"
-// @Produce      text/csv
-// @Success      200  {string}  string "Arquivo CSV"
+// @Produce      text/csv,application/pdf
+// @Success      200  {string}  string "Arquivo de relatório"
 // @Failure      400  {object}  httpx.ErrorEnvelope "Parâmetro inválido"
 // @Failure      401  {object}  httpx.ErrorEnvelope "Não autenticado"
 // @Failure      403  {object}  httpx.ErrorEnvelope "Acesso não autorizado ao arquivo"
@@ -148,7 +221,11 @@ func (h *ReportHandler) DownloadReport(w http.ResponseWriter, r *http.Request) {
 	}
 
 	fileName := filepath.Base(filePath)
-	w.Header().Set("Content-Type", "text/csv; charset=utf-8")
+	contentType := "text/csv; charset=utf-8"
+	if strings.HasSuffix(strings.ToLower(fileName), ".pdf") {
+		contentType = "application/pdf"
+	}
+	w.Header().Set("Content-Type", contentType)
 	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q", fileName))
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write(data)

--- a/backend/internal/interfaces/rest/router.go
+++ b/backend/internal/interfaces/rest/router.go
@@ -150,6 +150,8 @@ func NewRouter(
 
 	mux.Handle("POST /api/v1/reports/clients-csv", businessChain(reportHandler.ExportClientsCSV))
 	mux.Handle("POST /api/v1/reports/unpaid-clients-csv", businessChain(reportHandler.ExportUnpaidClientsCSV))
+	mux.Handle("POST /api/v1/reports/clients-pdf", businessChain(reportHandler.ExportClientsPDF))
+	mux.Handle("GET /api/v1/reports/clients-pdf", businessChain(reportHandler.DownloadDirectClientsPDF))
 	mux.Handle("GET /api/v1/reports/download", businessChain(reportHandler.DownloadReport))
 
 	handler := middleware.SecurityHeaders(

--- a/frontend/src/features/auth/components/AuthHeroBanner.tsx
+++ b/frontend/src/features/auth/components/AuthHeroBanner.tsx
@@ -171,7 +171,7 @@ export function AuthHeroBanner() {
               variant="body2"
               sx={{ fontWeight: 500, color: "#FFFFFF" }}
             >
-              Filtro global por temporada para organização financeira
+              Filtro global por evento para organização financeira
             </Typography>
           </Stack>
         </Stack>

--- a/frontend/src/features/auth/pages/RegisterPage.tsx
+++ b/frontend/src/features/auth/pages/RegisterPage.tsx
@@ -182,7 +182,7 @@ export function RegisterPage() {
                 Criar uma conta
               </Typography>
               <Typography variant="body2" sx={{ color: "text.secondary" }}>
-                Comece a gerenciar as fotos da sua temporada de forma simples e
+                Comece a gerenciar as fotos do seu evento de forma simples e
                 organizada.
               </Typography>
             </Box>

--- a/frontend/src/features/auth/pages/VerifyEmailPage.tsx
+++ b/frontend/src/features/auth/pages/VerifyEmailPage.tsx
@@ -165,7 +165,7 @@ export function VerifyEmailPage() {
                   sx={{ color: "text.secondary", mb: 4 }}
                 >
                   Seu e-mail foi confirmado com sucesso. Agora você já pode
-                  cadastrar e gerenciar as fotos da sua temporada no PS.
+                  cadastrar e gerenciar as fotos do seu evento no PS.
                 </Typography>
                 <Button
                   onClick={() =>

--- a/frontend/src/features/clients/components/ClientDetailsModal.tsx
+++ b/frontend/src/features/clients/components/ClientDetailsModal.tsx
@@ -22,6 +22,7 @@ import {
   Alert,
   CircularProgress,
   Chip,
+  Autocomplete,
 } from "@mui/material";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import AddIcon from "@mui/icons-material/Add";
@@ -36,6 +37,7 @@ import {
   photographerService,
   Photographer,
 } from "../../../services/api/photographer.service";
+import { useSeasonStore } from "../../../store/seasonStore";
 import { formatPhone } from "../../../utils/phone";
 
 const PAYMENT_METHODS = [
@@ -59,6 +61,7 @@ export const ClientDetailsModal = ({
   onClose,
   onSuccess,
 }: ClientDetailsModalProps) => {
+  const { activeSeason } = useSeasonStore();
   const [client, setClient] = useState<SeasonClient | null>(null);
   const [person, setPerson] = useState<Person | null>(null);
   const [photographers, setPhotographers] = useState<Photographer[]>([]);
@@ -355,14 +358,37 @@ export const ClientDetailsModal = ({
                         }
                         sx={{ flex: 1, minWidth: 150 }}
                       />
-                      <TextField
-                        label="Juiz"
+                      <Autocomplete
+                        multiple
+                        freeSolo
                         size="small"
-                        value={dog.judge}
-                        onChange={(e) =>
-                          updateDog(dIdx, "judge", e.target.value)
+                        options={activeSeason?.judges || []}
+                        value={
+                          dog.judges ||
+                          (dog.judge
+                            ? dog.judge
+                                .split(",")
+                                .map((j) => j.trim())
+                                .filter(Boolean)
+                            : [])
                         }
-                        sx={{ flex: 1, minWidth: 150 }}
+                        onChange={(_, val) => {
+                          const cleaned = val
+                            .map((v) => v.trim())
+                            .filter(Boolean);
+                          updateDog(dIdx, "judges", cleaned);
+                          updateDog(dIdx, "judge", cleaned.join(", "));
+                        }}
+                        renderInput={(params) => (
+                          <TextField
+                            {...params}
+                            label="Juiz"
+                            placeholder={
+                              dog.judges?.length ? "" : "Selecione ou digite"
+                            }
+                          />
+                        )}
+                        sx={{ flex: 1, minWidth: 180 }}
                       />
                       <TextField
                         type="number"
@@ -642,8 +668,8 @@ export const ClientDetailsModal = ({
         <DialogTitle>Confirmar Exclusão</DialogTitle>
         <DialogContent>
           <Typography>
-            Tem certeza que deseja excluir o cadastro deste cliente na
-            temporada?
+            Tem certeza que deseja excluir o cadastro deste cliente neste
+            evento?
           </Typography>
         </DialogContent>
         <DialogActions>

--- a/frontend/src/features/clients/components/LinkClientModal.tsx
+++ b/frontend/src/features/clients/components/LinkClientModal.tsx
@@ -18,6 +18,7 @@ import {
   IconButton,
   Alert,
   Chip,
+  Autocomplete,
 } from "@mui/material";
 import AddIcon from "@mui/icons-material/Add";
 import DeleteIcon from "@mui/icons-material/Delete";
@@ -28,6 +29,7 @@ import {
   photographerService,
   Photographer,
 } from "../../../services/api/photographer.service";
+import { useSeasonStore } from "../../../store/seasonStore";
 
 const PAYMENT_METHODS = [
   "Pix",
@@ -50,6 +52,7 @@ export const LinkClientModal = ({
   seasonId,
   onSuccess,
 }: LinkClientModalProps) => {
+  const { activeSeason } = useSeasonStore();
   const [people, setPeople] = useState<Person[]>([]);
   const [photographers, setPhotographers] = useState<Photographer[]>([]);
   const [personId, setPersonId] = useState("");
@@ -191,7 +194,7 @@ export const LinkClientModal = ({
 
   return (
     <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
-      <DialogTitle>Vincular Cliente na Temporada</DialogTitle>
+      <DialogTitle>Vincular Cliente no Evento</DialogTitle>
       <DialogContent
         sx={{ display: "flex", flexDirection: "column", gap: 3, pt: 2 }}
       >
@@ -276,12 +279,35 @@ export const LinkClientModal = ({
                 onChange={(e) => updateDog(dIdx, "breed", e.target.value)}
                 sx={{ flex: 1, minWidth: 150 }}
               />
-              <TextField
-                label="Juiz"
+              <Autocomplete
+                multiple
+                freeSolo
                 size="small"
-                value={dog.judge}
-                onChange={(e) => updateDog(dIdx, "judge", e.target.value)}
-                sx={{ flex: 1, minWidth: 150 }}
+                options={activeSeason?.judges || []}
+                value={
+                  dog.judges ||
+                  (dog.judge
+                    ? dog.judge
+                        .split(",")
+                        .map((j) => j.trim())
+                        .filter(Boolean)
+                    : [])
+                }
+                onChange={(_, val) => {
+                  const cleaned = val.map((v) => v.trim()).filter(Boolean);
+                  updateDog(dIdx, "judges", cleaned);
+                  updateDog(dIdx, "judge", cleaned.join(", "));
+                }}
+                renderInput={(params) => (
+                  <TextField
+                    {...params}
+                    label="Juiz"
+                    placeholder={
+                      dog.judges?.length ? "" : "Selecione ou digite"
+                    }
+                  />
+                )}
+                sx={{ flex: 1, minWidth: 180 }}
               />
               <TextField
                 type="number"

--- a/frontend/src/features/clients/pages/ClientDetailsPage.tsx
+++ b/frontend/src/features/clients/pages/ClientDetailsPage.tsx
@@ -23,6 +23,7 @@ import {
   Snackbar,
   Alert,
   Chip,
+  Autocomplete,
 } from "@mui/material";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import AddIcon from "@mui/icons-material/Add";
@@ -39,6 +40,7 @@ import {
   photographerService,
   Photographer,
 } from "../../../services/api/photographer.service";
+import { useSeasonStore } from "../../../store/seasonStore";
 import { formatPhone } from "../../../utils/phone";
 
 const PAYMENT_METHODS = [
@@ -52,6 +54,7 @@ const PAYMENT_METHODS = [
 export const ClientDetailsPage = () => {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
+  const { activeSeason } = useSeasonStore();
 
   const [client, setClient] = useState<SeasonClient | null>(null);
   const [person, setPerson] = useState<Person | null>(null);
@@ -318,13 +321,36 @@ export const ClientDetailsPage = () => {
                   minWidth: "160px",
                 }}
               />
-              <TextField
-                label="Juiz (Opcional)"
-                value={dog.judge}
-                onChange={(e) => updateDog(dIdx, "judge", e.target.value)}
+              <Autocomplete
+                multiple
+                freeSolo
+                options={activeSeason?.judges || []}
+                value={
+                  dog.judges ||
+                  (dog.judge
+                    ? dog.judge
+                        .split(",")
+                        .map((j) => j.trim())
+                        .filter(Boolean)
+                    : [])
+                }
+                onChange={(_, val) => {
+                  const cleaned = val.map((v) => v.trim()).filter(Boolean);
+                  updateDog(dIdx, "judges", cleaned);
+                  updateDog(dIdx, "judge", cleaned.join(", "));
+                }}
+                renderInput={(params) => (
+                  <TextField
+                    {...params}
+                    label="Juiz (Opcional)"
+                    placeholder={
+                      dog.judges?.length ? "" : "Selecione ou digite"
+                    }
+                  />
+                )}
                 sx={{
-                  flex: { xs: "1 1 100%", sm: "1 1 200px" },
-                  minWidth: "160px",
+                  flex: { xs: "1 1 100%", sm: "1 1 240px" },
+                  minWidth: "200px",
                 }}
               />
               <TextField
@@ -595,8 +621,7 @@ export const ClientDetailsPage = () => {
         <DialogTitle>Confirmar Exclusão</DialogTitle>
         <DialogContent>
           <Typography>
-            Tem certeza que deseja excluir o cadastro deste cliente na
-            temporada?
+            Tem certeza que deseja excluir o cadastro deste cliente no evento?
           </Typography>
         </DialogContent>
         <DialogActions>

--- a/frontend/src/features/clients/pages/ClientsPage.tsx
+++ b/frontend/src/features/clients/pages/ClientsPage.tsx
@@ -29,12 +29,14 @@ import {
   Snackbar,
   Alert,
   CircularProgress,
+  Autocomplete,
 } from "@mui/material";
 import AddIcon from "@mui/icons-material/Add";
 import DeleteIcon from "@mui/icons-material/Delete";
 import EmojiEventsIcon from "@mui/icons-material/EmojiEvents";
 import AssessmentIcon from "@mui/icons-material/Assessment";
 import FileDownloadIcon from "@mui/icons-material/FileDownload";
+import PictureAsPdfIcon from "@mui/icons-material/PictureAsPdf";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import {
   clientService,
@@ -220,7 +222,38 @@ export const ClientsPage = () => {
         open: true,
         message:
           err?.response?.data?.message ||
-          "Erro ao solicitar exportação do relatório.",
+          "Erro ao solicitar exportação do relatório CSV.",
+        severity: "error",
+      });
+    } finally {
+      setExportingReport(false);
+    }
+  };
+
+  const handleExportClientsPdf = async () => {
+    setReportMenuAnchor(null);
+    setExportingReport(true);
+    try {
+      const blob = await reportService.downloadClientsPdfDirect();
+      const fileName = `clientes_${Math.floor(Date.now() / 1000)}.pdf`;
+      const blobUrl = window.URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = blobUrl;
+      link.setAttribute("download", fileName);
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      window.URL.revokeObjectURL(blobUrl);
+
+      setSnackbar({
+        open: true,
+        message: "Relatório PDF gerado e baixado com sucesso!",
+        severity: "success",
+      });
+    } catch (err: any) {
+      setSnackbar({
+        open: true,
+        message: err?.response?.data?.message || "Erro ao gerar relatório PDF.",
         severity: "error",
       });
     } finally {
@@ -256,7 +289,7 @@ export const ClientsPage = () => {
   if (!activeSeason) {
     return (
       <Box sx={{ p: { xs: 1.5, sm: 2.5, md: 3 } }}>
-        <Typography>Selecione uma Temporada no topo.</Typography>
+        <Typography>Selecione um Evento no topo.</Typography>
       </Box>
     );
   }
@@ -280,7 +313,7 @@ export const ClientsPage = () => {
             fontWeight: 700,
           }}
         >
-          Clientes da Temporada Atual
+          Clientes do Evento Atual
         </Typography>
         <Box
           sx={{
@@ -312,6 +345,12 @@ export const ClientsPage = () => {
             open={Boolean(reportMenuAnchor)}
             onClose={() => setReportMenuAnchor(null)}
           >
+            <MenuItem onClick={handleExportClientsPdf}>
+              <ListItemIcon>
+                <PictureAsPdfIcon fontSize="small" color="error" />
+              </ListItemIcon>
+              Exportar Relatório (.pdf)
+            </MenuItem>
             <MenuItem onClick={handleExportClientsCsv}>
               <ListItemIcon>
                 <FileDownloadIcon fontSize="small" />
@@ -393,7 +432,7 @@ export const ClientsPage = () => {
         maxWidth="md"
         fullWidth
       >
-        <DialogTitle>Vincular Cliente na Temporada</DialogTitle>
+        <DialogTitle>Vincular Cliente no Evento</DialogTitle>
         <DialogContent
           sx={{ display: "flex", flexDirection: "column", gap: 3, pt: 2 }}
         >
@@ -445,13 +484,36 @@ export const ClientsPage = () => {
                     minWidth: "160px",
                   }}
                 />
-                <TextField
-                  label="Juiz (Opcional)"
-                  value={dog.judge}
-                  onChange={(e) => updateDog(dIdx, "judge", e.target.value)}
+                <Autocomplete
+                  multiple
+                  freeSolo
+                  options={activeSeason?.judges || []}
+                  value={
+                    dog.judges ||
+                    (dog.judge
+                      ? dog.judge
+                          .split(",")
+                          .map((j) => j.trim())
+                          .filter(Boolean)
+                      : [])
+                  }
+                  onChange={(_, val) => {
+                    const cleaned = val.map((v) => v.trim()).filter(Boolean);
+                    updateDog(dIdx, "judges", cleaned);
+                    updateDog(dIdx, "judge", cleaned.join(", "));
+                  }}
+                  renderInput={(params) => (
+                    <TextField
+                      {...params}
+                      label="Juiz (Opcional)"
+                      placeholder={
+                        dog.judges?.length ? "" : "Selecione ou digite"
+                      }
+                    />
+                  )}
                   sx={{
-                    flex: { xs: "1 1 100%", sm: "1 1 200px" },
-                    minWidth: "160px",
+                    flex: { xs: "1 1 100%", sm: "1 1 240px" },
+                    minWidth: "200px",
                   }}
                 />
                 <TextField

--- a/frontend/src/features/dashboard/pages/DashboardPage.test.tsx
+++ b/frontend/src/features/dashboard/pages/DashboardPage.test.tsx
@@ -30,11 +30,9 @@ describe("DashboardPage", () => {
     );
 
     expect(screen.getByText("Visão Geral")).toBeInTheDocument();
+    expect(screen.getByText("Nenhum evento selecionado")).toBeInTheDocument();
     expect(
-      screen.getByText("Nenhuma temporada selecionada"),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(/Por favor, selecione uma temporada/i),
+      screen.getByText(/Por favor, selecione um evento/i),
     ).toBeInTheDocument();
   });
 
@@ -59,7 +57,7 @@ describe("DashboardPage", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText("Nenhum cliente vinculado nesta temporada"),
+        screen.getByText("Nenhum cliente vinculado neste evento"),
       ).toBeInTheDocument();
     });
 
@@ -127,7 +125,9 @@ describe("DashboardPage", () => {
     });
 
     expect(screen.getByText("Total de Pessoas")).toBeInTheDocument();
-    expect(screen.getByText("Cachorros no Evento")).toBeInTheDocument();
+    expect(
+      screen.getAllByText("Cachorros no Evento").length,
+    ).toBeGreaterThanOrEqual(1);
     expect(screen.getByText("Fotos Registradas")).toBeInTheDocument();
     expect(screen.getByText("Cachorros & Fotos")).toBeInTheDocument();
     expect(screen.getByText("Detalhes")).toBeInTheDocument();
@@ -208,7 +208,7 @@ describe("DashboardPage", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText("Vincular Cliente na Temporada"),
+        screen.getByText("Vincular Cliente no Evento"),
       ).toBeInTheDocument();
     });
   });

--- a/frontend/src/features/dashboard/pages/DashboardPage.tsx
+++ b/frontend/src/features/dashboard/pages/DashboardPage.tsx
@@ -43,6 +43,7 @@ import PeopleOutlineRoundedIcon from "@mui/icons-material/PeopleOutlineRounded";
 import VisibilityRoundedIcon from "@mui/icons-material/VisibilityRounded";
 import AssessmentIcon from "@mui/icons-material/Assessment";
 import FileDownloadIcon from "@mui/icons-material/FileDownload";
+import PictureAsPdfIcon from "@mui/icons-material/PictureAsPdf";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import {
   clientService,
@@ -115,7 +116,38 @@ export const DashboardPage = () => {
         open: true,
         message:
           err?.response?.data?.message ||
-          "Erro ao solicitar exportação do relatório.",
+          "Erro ao solicitar exportação do relatório CSV.",
+        severity: "error",
+      });
+    } finally {
+      setExportingReport(false);
+    }
+  };
+
+  const handleExportClientsPdf = async () => {
+    setReportMenuAnchor(null);
+    setExportingReport(true);
+    try {
+      const blob = await reportService.downloadClientsPdfDirect();
+      const fileName = `clientes_${Math.floor(Date.now() / 1000)}.pdf`;
+      const blobUrl = window.URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = blobUrl;
+      link.setAttribute("download", fileName);
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      window.URL.revokeObjectURL(blobUrl);
+
+      setSnackbar({
+        open: true,
+        message: "Relatório PDF gerado e baixado com sucesso!",
+        severity: "success",
+      });
+    } catch (err: any) {
+      setSnackbar({
+        open: true,
+        message: err?.response?.data?.message || "Erro ao gerar relatório PDF.",
         severity: "error",
       });
     } finally {
@@ -328,8 +360,8 @@ export const DashboardPage = () => {
               }}
             >
               {activeSeason
-                ? `Clientes, cães e fotos vinculados à temporada "${activeSeason.name}".`
-                : "Selecione uma temporada no cabeçalho para gerenciar os clientes e fotos."}
+                ? `Clientes, cães e fotos vinculados ao evento "${activeSeason.name}".`
+                : "Selecione um evento no cabeçalho para gerenciar os clientes e fotos."}
             </Typography>
           </Box>
 
@@ -346,7 +378,7 @@ export const DashboardPage = () => {
               <>
                 <Chip
                   icon={<EventNoteRoundedIcon style={{ color: "#38bdf8" }} />}
-                  label={`Temporada: ${activeSeason.name}`}
+                  label={`Evento: ${activeSeason.name}`}
                   sx={{
                     bgcolor: "rgba(56, 189, 248, 0.15)",
                     color: "#38bdf8",
@@ -376,7 +408,7 @@ export const DashboardPage = () => {
               </>
             ) : (
               <Chip
-                label="Selecione uma temporada no menu superior"
+                label="Selecione um evento no menu superior"
                 sx={{
                   bgcolor: "warning.main",
                   color: "warning.contrastText",
@@ -415,6 +447,12 @@ export const DashboardPage = () => {
               open={Boolean(reportMenuAnchor)}
               onClose={() => setReportMenuAnchor(null)}
             >
+              <MenuItem onClick={handleExportClientsPdf}>
+                <ListItemIcon>
+                  <PictureAsPdfIcon fontSize="small" color="error" />
+                </ListItemIcon>
+                Exportar Relatório (.pdf)
+              </MenuItem>
               <MenuItem onClick={handleExportClientsCsv}>
                 <ListItemIcon>
                   <FileDownloadIcon fontSize="small" />
@@ -486,7 +524,7 @@ export const DashboardPage = () => {
                     {metrics.totalPeople}
                   </Typography>
                   <Typography variant="caption" color="text.secondary">
-                    {metrics.activeSeasonClients} nesta temporada
+                    {metrics.activeSeasonClients} neste evento
                   </Typography>
                 </Box>
                 <Avatar
@@ -537,7 +575,7 @@ export const DashboardPage = () => {
                     {metrics.totalDogs}
                   </Typography>
                   <Typography variant="caption" color="text.secondary">
-                    Cadastrados na temporada ativa
+                    Cadastrados no evento ativo
                   </Typography>
                 </Box>
                 <Avatar
@@ -588,7 +626,7 @@ export const DashboardPage = () => {
                     {metrics.totalPhotos}
                   </Typography>
                   <Typography variant="caption" color="text.secondary">
-                    Total nesta temporada
+                    Total neste evento
                   </Typography>
                 </Box>
                 <Avatar
@@ -658,7 +696,7 @@ export const DashboardPage = () => {
         </Grid>
       </Grid>
 
-      {/* Season Warning if None Active */}
+      {/* Event Warning if None Active */}
       {!activeSeason ? (
         <Alert
           severity="info"
@@ -671,11 +709,11 @@ export const DashboardPage = () => {
           }}
         >
           <Typography variant="subtitle1" sx={{ fontWeight: 600, mb: 0.5 }}>
-            Nenhuma temporada selecionada
+            Nenhum evento selecionado
           </Typography>
           <Typography variant="body2">
-            Por favor, selecione uma temporada no menu superior para visualizar
-            a listagem de clientes, cachorros e fotografias.
+            Por favor, selecione um evento no menu superior para visualizar a
+            listagem de clientes, cachorros e fotografias.
           </Typography>
         </Alert>
       ) : (
@@ -763,14 +801,14 @@ export const DashboardPage = () => {
               ) : (
                 <>
                   <Typography variant="h6" sx={{ fontWeight: 600 }}>
-                    Nenhum cliente vinculado nesta temporada
+                    Nenhum cliente vinculado neste evento
                   </Typography>
                   <Typography
                     variant="body2"
                     color="text.secondary"
                     sx={{ maxWidth: 420 }}
                   >
-                    Esta temporada ainda não possui clientes cadastrados. Comece
+                    Este evento ainda não possui clientes cadastrados. Comece
                     vinculando uma pessoa e seus cães.
                   </Typography>
                   <Button
@@ -795,7 +833,7 @@ export const DashboardPage = () => {
                       </TableCell>
                       <TableCell sx={{ fontWeight: 700 }}>Contato</TableCell>
                       <TableCell sx={{ fontWeight: 700 }}>
-                        Cachorros na Temporada
+                        Cachorros no Evento
                       </TableCell>
                       <TableCell sx={{ fontWeight: 700 }}>
                         Total de Fotos

--- a/frontend/src/features/people/pages/PersonDetailsPage.tsx
+++ b/frontend/src/features/people/pages/PersonDetailsPage.tsx
@@ -30,6 +30,7 @@ import {
   Tabs,
   CircularProgress,
   Avatar,
+  Autocomplete,
 } from "@mui/material";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import AddIcon from "@mui/icons-material/Add";
@@ -44,6 +45,7 @@ import PhoneIcon from "@mui/icons-material/Phone";
 import EmailIcon from "@mui/icons-material/Email";
 import EventNoteIcon from "@mui/icons-material/EventNote";
 import AttachMoneyIcon from "@mui/icons-material/AttachMoney";
+import AccessTimeIcon from "@mui/icons-material/AccessTime";
 import {
   clientService,
   SeasonClient,
@@ -106,12 +108,14 @@ export const PersonDetailsPage = () => {
   const [dogForm, setDogForm] = useState<{
     breed: string;
     judge: string;
+    judges: string[];
     competitions_won: number;
     won_competitions: string[];
     is_owner: boolean;
   }>({
     breed: "",
     judge: "",
+    judges: [],
     competitions_won: 0,
     won_competitions: [],
     is_owner: true,
@@ -121,17 +125,25 @@ export const PersonDetailsPage = () => {
   // Photo Dialog (Add - Batch / Single)
   const [addPhotoDialogOpen, setAddPhotoDialogOpen] = useState(false);
   const [photoTab, setPhotoTab] = useState<"batch" | "single">("batch");
-  const [batchPhotoForm, setBatchPhotoForm] = useState({
+  const [batchPhotoForm, setBatchPhotoForm] = useState<{
+    fileNumbersText: string;
+    photographer_id: string;
+    payment_method: string;
+    amount_paid: number;
+    judges: string[];
+  }>({
     fileNumbersText: "",
     photographer_id: "",
     payment_method: "Pix",
     amount_paid: 0,
+    judges: [],
   });
   const [singlePhotoForm, setSinglePhotoForm] = useState<Omit<Photo, "id">>({
     file_number: "",
     photographer_id: "",
     payment_method: "Pix",
     amount_paid: 0,
+    judges: [],
   });
 
   // Edit Photo Dialog
@@ -144,6 +156,7 @@ export const PersonDetailsPage = () => {
     photographer_id: "",
     payment_method: "Pix",
     amount_paid: 0,
+    judges: [],
   });
 
   // Delete Confirm Dialogs
@@ -233,7 +246,7 @@ export const PersonDetailsPage = () => {
   const saveClientData = async (updatedDogs: Dog[]) => {
     if (!id || !activeSeason) {
       showNotification(
-        "Selecione uma temporada ativa para salvar alterações.",
+        "Selecione um evento ativo para salvar alterações.",
         "warning",
       );
       return;
@@ -268,6 +281,7 @@ export const PersonDetailsPage = () => {
     setDogForm({
       breed: "",
       judge: "",
+      judges: [],
       competitions_won: 0,
       won_competitions: [],
       is_owner: true,
@@ -280,9 +294,19 @@ export const PersonDetailsPage = () => {
     if (!d) return;
     setEditingDogIndex(index);
     setNewCompetitionInput("");
+    const parsedJudges =
+      d.judges && d.judges.length > 0
+        ? d.judges
+        : d.judge
+          ? d.judge
+              .split(",")
+              .map((j) => j.trim())
+              .filter(Boolean)
+          : [];
     setDogForm({
       breed: d.breed || "",
       judge: d.judge || "",
+      judges: parsedJudges,
       competitions_won: d.competitions_won || 0,
       won_competitions: d.won_competitions || [],
       is_owner: d.is_owner ?? true,
@@ -325,12 +349,24 @@ export const PersonDetailsPage = () => {
         ? finalWonCompetitions.map((c) => c.trim()).filter((c) => c.length > 0)
         : [];
 
+    const finalJudges =
+      dogForm.judges && dogForm.judges.length > 0
+        ? dogForm.judges
+        : dogForm.judge
+          ? dogForm.judge
+              .split(",")
+              .map((j) => j.trim())
+              .filter(Boolean)
+          : [];
+    const finalJudge = finalJudges.join(", ");
+
     const newDogs = [...dogsList];
     if (editingDogIndex !== null) {
       newDogs[editingDogIndex] = {
         ...newDogs[editingDogIndex],
         breed: dogForm.breed.trim(),
-        judge: dogForm.judge.trim(),
+        judge: finalJudge,
+        judges: finalJudges,
         competitions_won: wonCount,
         won_competitions: finalWonCompetitions,
         is_owner: dogForm.is_owner,
@@ -338,7 +374,8 @@ export const PersonDetailsPage = () => {
     } else {
       newDogs.unshift({
         breed: dogForm.breed.trim(),
-        judge: dogForm.judge.trim(),
+        judge: finalJudge,
+        judges: finalJudges,
         competitions_won: wonCount,
         won_competitions: finalWonCompetitions,
         is_owner: dogForm.is_owner,
@@ -371,17 +408,29 @@ export const PersonDetailsPage = () => {
       return;
     }
     const defaultPhotog = photographers[0]?.id || "";
+    const defaultJudges =
+      selectedDog.judges && selectedDog.judges.length > 0
+        ? selectedDog.judges
+        : selectedDog.judge
+          ? selectedDog.judge
+              .split(",")
+              .map((j) => j.trim())
+              .filter(Boolean)
+          : [];
+
     setBatchPhotoForm({
       fileNumbersText: "",
       photographer_id: defaultPhotog,
       payment_method: "Pix",
       amount_paid: 0,
+      judges: defaultJudges,
     });
     setSinglePhotoForm({
       file_number: "",
       photographer_id: defaultPhotog,
       payment_method: "Pix",
       amount_paid: 0,
+      judges: defaultJudges,
     });
     setAddPhotoDialogOpen(true);
   };
@@ -392,6 +441,7 @@ export const PersonDetailsPage = () => {
     const newDogs = [...dogsList];
     const currentDog = { ...newDogs[selectedDogIndex] };
     const currentPhotos = [...(currentDog.photos || [])];
+    const nowIso = new Date().toISOString();
 
     if (photoTab === "batch") {
       const numbers = batchPhotoForm.fileNumbersText
@@ -412,6 +462,11 @@ export const PersonDetailsPage = () => {
         photographer_id: batchPhotoForm.photographer_id,
         payment_method: batchPhotoForm.payment_method,
         amount_paid: Number(batchPhotoForm.amount_paid) || 0,
+        judges:
+          batchPhotoForm.judges && batchPhotoForm.judges.length > 0
+            ? batchPhotoForm.judges
+            : undefined,
+        created_at: nowIso,
       }));
       currentPhotos.unshift(...newPhotos);
     } else {
@@ -425,6 +480,11 @@ export const PersonDetailsPage = () => {
         photographer_id: singlePhotoForm.photographer_id,
         payment_method: singlePhotoForm.payment_method,
         amount_paid: Number(singlePhotoForm.amount_paid) || 0,
+        judges:
+          singlePhotoForm.judges && singlePhotoForm.judges.length > 0
+            ? singlePhotoForm.judges
+            : undefined,
+        created_at: nowIso,
       });
     }
 
@@ -444,6 +504,7 @@ export const PersonDetailsPage = () => {
       photographer_id: photo.photographer_id || "",
       payment_method: photo.payment_method || "Pix",
       amount_paid: photo.amount_paid || 0,
+      judges: photo.judges || [],
     });
     setEditPhotoDialogOpen(true);
   };
@@ -458,13 +519,19 @@ export const PersonDetailsPage = () => {
     const newDogs = [...dogsList];
     const currentDog = { ...newDogs[selectedDogIndex] };
     const currentPhotos = [...(currentDog.photos || [])];
+    const existingPhoto = currentPhotos[editingPhotoIndex];
 
     currentPhotos[editingPhotoIndex] = {
-      ...currentPhotos[editingPhotoIndex],
+      ...existingPhoto,
       file_number: editPhotoForm.file_number.trim(),
       photographer_id: editPhotoForm.photographer_id,
       payment_method: editPhotoForm.payment_method,
       amount_paid: Number(editPhotoForm.amount_paid) || 0,
+      judges:
+        editPhotoForm.judges && editPhotoForm.judges.length > 0
+          ? editPhotoForm.judges
+          : undefined,
+      created_at: existingPhoto.created_at || new Date().toISOString(),
     };
 
     currentDog.photos = currentPhotos;
@@ -621,14 +688,14 @@ export const PersonDetailsPage = () => {
             {activeSeason ? (
               <Chip
                 icon={<EventNoteIcon />}
-                label={`Temporada: ${activeSeason.name}`}
+                label={`Evento: ${activeSeason.name}`}
                 color="primary"
                 variant="outlined"
                 sx={{ fontWeight: 600, px: 1, py: 2.2, borderRadius: 2 }}
               />
             ) : (
               <Chip
-                label="Nenhuma temporada selecionada"
+                label="Nenhum evento selecionado"
                 color="warning"
                 variant="filled"
                 sx={{ fontWeight: 600 }}
@@ -638,10 +705,10 @@ export const PersonDetailsPage = () => {
         </Box>
       </Paper>
 
-      {/* Season Warning Banner if not selected */}
+      {/* Event Warning Banner if not selected */}
       {!activeSeason && (
         <Alert severity="warning" sx={{ mb: 3, borderRadius: 2 }}>
-          Por favor, selecione uma temporada no topo da página para cadastrar e
+          Por favor, selecione um evento no topo da página para cadastrar e
           gerenciar os cachorros e fotos de competições desta pessoa.
         </Alert>
       )}
@@ -730,8 +797,8 @@ export const PersonDetailsPage = () => {
                   Nenhum cachorro cadastrado
                 </Typography>
                 <Typography variant="body2" color="text.secondary">
-                  Adicione o primeiro cachorro para registrar fotos nesta
-                  temporada.
+                  Adicione o primeiro cachorro para registrar fotos neste
+                  evento.
                 </Typography>
                 <Button
                   variant="outlined"
@@ -817,7 +884,8 @@ export const PersonDetailsPage = () => {
                               mb: 1,
                             }}
                           >
-                            {dog.judge ? (
+                            {(dog.judges && dog.judges.length > 0) ||
+                            dog.judge ? (
                               <Box
                                 sx={{
                                   display: "flex",
@@ -826,7 +894,12 @@ export const PersonDetailsPage = () => {
                                 }}
                               >
                                 <GavelIcon fontSize="inherit" />
-                                <span>Juiz: {dog.judge}</span>
+                                <span>
+                                  Juiz:{" "}
+                                  {dog.judges && dog.judges.length > 0
+                                    ? dog.judges.join(", ")
+                                    : dog.judge}
+                                </span>
                               </Box>
                             ) : null}
                           </Box>
@@ -960,7 +1033,9 @@ export const PersonDetailsPage = () => {
                       <GavelIcon fontSize="small" color="action" />
                       <Typography variant="body2">
                         <strong>Juiz:</strong>{" "}
-                        {selectedDog.judge || "Não informado"}
+                        {selectedDog.judges && selectedDog.judges.length > 0
+                          ? selectedDog.judges.join(", ")
+                          : selectedDog.judge || "Não informado"}
                       </Typography>
                     </Box>
                     <Box
@@ -1221,12 +1296,33 @@ export const PersonDetailsPage = () => {
 
                           <Divider sx={{ my: 1 }} />
 
+                          {photo.judges && photo.judges.length > 0 && (
+                            <Box
+                              sx={{
+                                display: "flex",
+                                flexWrap: "wrap",
+                                gap: 0.5,
+                                mb: 1,
+                              }}
+                            >
+                              {photo.judges.map((j) => (
+                                <Chip
+                                  key={j}
+                                  label={`Juiz: ${j}`}
+                                  size="small"
+                                  variant="outlined"
+                                  sx={{ fontSize: "0.7rem", height: 20 }}
+                                />
+                              ))}
+                            </Box>
+                          )}
+
                           <Box
                             sx={{
                               display: "flex",
                               justifyContent: "space-between",
                               alignItems: "center",
-                              mt: 1,
+                              mt: 0.5,
                             }}
                           >
                             <Chip
@@ -1244,6 +1340,31 @@ export const PersonDetailsPage = () => {
                                 : "R$ 0.00"}
                             </Typography>
                           </Box>
+
+                          {photo.created_at && (
+                            <Box
+                              sx={{
+                                display: "flex",
+                                alignItems: "center",
+                                gap: 0.5,
+                                mt: 1,
+                                color: "text.secondary",
+                                fontSize: "0.75rem",
+                              }}
+                            >
+                              <AccessTimeIcon sx={{ fontSize: 13 }} />
+                              <span>
+                                Registrada em:{" "}
+                                {new Date(photo.created_at).toLocaleString(
+                                  "pt-BR",
+                                  {
+                                    dateStyle: "short",
+                                    timeStyle: "short",
+                                  },
+                                )}
+                              </span>
+                            </Box>
+                          )}
                         </Paper>
                       </Grid>
                     );
@@ -1332,12 +1453,42 @@ export const PersonDetailsPage = () => {
             value={dogForm.breed}
             onChange={(e) => setDogForm({ ...dogForm, breed: e.target.value })}
           />
-          <TextField
-            label="Nome do Juiz"
-            placeholder="Ex: Dr. Roberto Carlos"
-            fullWidth
-            value={dogForm.judge}
-            onChange={(e) => setDogForm({ ...dogForm, judge: e.target.value })}
+          <Autocomplete
+            multiple
+            freeSolo
+            options={activeSeason?.judges || []}
+            value={
+              dogForm.judges && dogForm.judges.length > 0
+                ? dogForm.judges
+                : dogForm.judge
+                  ? dogForm.judge
+                      .split(",")
+                      .map((j) => j.trim())
+                      .filter(Boolean)
+                  : []
+            }
+            onChange={(_, val) => {
+              const cleaned = val.map((v) => v.trim()).filter(Boolean);
+              setDogForm({
+                ...dogForm,
+                judges: cleaned,
+                judge: cleaned.join(", "),
+              });
+            }}
+            renderInput={(params) => (
+              <TextField
+                {...params}
+                label="Juízes do Evento"
+                placeholder={
+                  dogForm.judges?.length ? "" : "Selecione ou digite juízes"
+                }
+                helperText={
+                  activeSeason?.judges && activeSeason.judges.length > 0
+                    ? "Selecione da lista de juízes do evento ou digite um novo nome e pressione Enter."
+                    : "Cadastre juízes no evento para selecioná-los aqui ou digite o nome e pressione Enter."
+                }
+              />
+            )}
           />
           <TextField
             label="Competições Ganhas"
@@ -1542,6 +1693,29 @@ export const PersonDetailsPage = () => {
                   ))}
                 </Select>
               </FormControl>
+              <Autocomplete
+                multiple
+                freeSolo
+                size="small"
+                options={activeSeason?.judges || []}
+                value={batchPhotoForm.judges || []}
+                onChange={(_, val) => {
+                  const cleaned = val.map((v) => v.trim()).filter(Boolean);
+                  setBatchPhotoForm({
+                    ...batchPhotoForm,
+                    judges: cleaned,
+                  });
+                }}
+                renderInput={(params) => (
+                  <TextField
+                    {...params}
+                    label="Juízes da Foto (Opcional - padrão do cão)"
+                    placeholder={
+                      batchPhotoForm.judges?.length ? "" : "Selecione ou digite"
+                    }
+                  />
+                )}
+              />
               <Grid container spacing={2}>
                 <Grid size={{ xs: 12, sm: 6 }}>
                   <FormControl fullWidth size="small">
@@ -1622,6 +1796,31 @@ export const PersonDetailsPage = () => {
                   ))}
                 </Select>
               </FormControl>
+              <Autocomplete
+                multiple
+                freeSolo
+                size="small"
+                options={activeSeason?.judges || []}
+                value={singlePhotoForm.judges || []}
+                onChange={(_, val) => {
+                  const cleaned = val.map((v) => v.trim()).filter(Boolean);
+                  setSinglePhotoForm({
+                    ...singlePhotoForm,
+                    judges: cleaned,
+                  });
+                }}
+                renderInput={(params) => (
+                  <TextField
+                    {...params}
+                    label="Juízes da Foto (Opcional - padrão do cão)"
+                    placeholder={
+                      singlePhotoForm.judges?.length
+                        ? ""
+                        : "Selecione ou digite"
+                    }
+                  />
+                )}
+              />
               <Grid container spacing={2}>
                 <Grid size={{ xs: 12, sm: 6 }}>
                   <FormControl fullWidth size="small">
@@ -1729,6 +1928,29 @@ export const PersonDetailsPage = () => {
               ))}
             </Select>
           </FormControl>
+          <Autocomplete
+            multiple
+            freeSolo
+            size="small"
+            options={activeSeason?.judges || []}
+            value={editPhotoForm.judges || []}
+            onChange={(_, val) => {
+              const cleaned = val.map((v) => v.trim()).filter(Boolean);
+              setEditPhotoForm({
+                ...editPhotoForm,
+                judges: cleaned,
+              });
+            }}
+            renderInput={(params) => (
+              <TextField
+                {...params}
+                label="Juízes da Foto"
+                placeholder={
+                  editPhotoForm.judges?.length ? "" : "Selecione ou digite"
+                }
+              />
+            )}
+          />
           <Grid container spacing={2}>
             <Grid size={{ xs: 12, sm: 6 }}>
               <FormControl fullWidth size="small">
@@ -1797,7 +2019,7 @@ export const PersonDetailsPage = () => {
         <DialogContent>
           <Typography>
             Tem certeza que deseja excluir este cachorro e todas as suas fotos
-            associadas nesta temporada?
+            associadas neste evento?
           </Typography>
         </DialogContent>
         <DialogActions sx={{ p: 2 }}>

--- a/frontend/src/features/seasons/pages/SeasonsPage.tsx
+++ b/frontend/src/features/seasons/pages/SeasonsPage.tsx
@@ -27,6 +27,7 @@ import {
 import EditIcon from "@mui/icons-material/Edit";
 import DeleteIcon from "@mui/icons-material/Delete";
 import AddIcon from "@mui/icons-material/Add";
+import GavelRoundedIcon from "@mui/icons-material/GavelRounded";
 import { seasonService, Season } from "../../../services/api/season.service";
 import {
   photographerService,
@@ -42,6 +43,8 @@ export const SeasonsPage = () => {
   const [selectedPhotographers, setSelectedPhotographers] = useState<string[]>(
     [],
   );
+  const [judges, setJudges] = useState<string[]>([]);
+  const [judgeInput, setJudgeInput] = useState("");
 
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
   const [deletingSeason, setDeletingSeason] = useState<Season | null>(null);
@@ -55,7 +58,7 @@ export const SeasonsPage = () => {
       setSeasons(sData || []);
       setPhotographers(pData || []);
     } catch (err) {
-      console.error("Erro ao carregar temporadas:", err);
+      console.error("Erro ao carregar eventos:", err);
     }
   };
 
@@ -67,6 +70,8 @@ export const SeasonsPage = () => {
     setEditingId(null);
     setName("");
     setSelectedPhotographers([]);
+    setJudges([]);
+    setJudgeInput("");
     setOpen(true);
   };
 
@@ -74,7 +79,21 @@ export const SeasonsPage = () => {
     setEditingId(s.id);
     setName(s.name);
     setSelectedPhotographers(s.photographer_ids || []);
+    setJudges(s.judges || []);
+    setJudgeInput("");
     setOpen(true);
+  };
+
+  const handleAddJudge = () => {
+    const trimmed = judgeInput.trim();
+    if (trimmed && !judges.includes(trimmed)) {
+      setJudges([...judges, trimmed]);
+      setJudgeInput("");
+    }
+  };
+
+  const handleRemoveJudge = (judgeToRemove: string) => {
+    setJudges(judges.filter((j) => j !== judgeToRemove));
   };
 
   const handleSave = async () => {
@@ -83,20 +102,24 @@ export const SeasonsPage = () => {
         await seasonService.update(editingId, {
           name,
           photographer_ids: selectedPhotographers,
+          judges,
         });
       } else {
         await seasonService.create({
           name,
           photographer_ids: selectedPhotographers,
+          judges,
         });
       }
       setOpen(false);
       setEditingId(null);
       setName("");
       setSelectedPhotographers([]);
+      setJudges([]);
+      setJudgeInput("");
       await load();
     } catch (err) {
-      console.error("Erro ao salvar temporada:", err);
+      console.error("Erro ao salvar evento:", err);
     }
   };
 
@@ -113,7 +136,7 @@ export const SeasonsPage = () => {
       setDeletingSeason(null);
       await load();
     } catch (err) {
-      console.error("Erro ao excluir temporada:", err);
+      console.error("Erro ao excluir evento:", err);
     }
   };
 
@@ -136,7 +159,7 @@ export const SeasonsPage = () => {
             fontWeight: 700,
           }}
         >
-          Temporadas
+          Eventos
         </Typography>
         <Button
           variant="contained"
@@ -144,7 +167,7 @@ export const SeasonsPage = () => {
           onClick={handleOpenCreate}
           sx={{ width: { xs: "100%", sm: "auto" }, whiteSpace: "nowrap" }}
         >
-          Nova Temporada
+          Novo Evento
         </Button>
       </Box>
 
@@ -158,12 +181,13 @@ export const SeasonsPage = () => {
           overflowX: "auto",
         }}
       >
-        <Table sx={{ minWidth: 550 }}>
+        <Table sx={{ minWidth: 600 }}>
           <TableHead>
             <TableRow>
               <TableCell sx={{ fontWeight: 600 }}>ID</TableCell>
-              <TableCell sx={{ fontWeight: 600 }}>Nome</TableCell>
+              <TableCell sx={{ fontWeight: 600 }}>Nome do Evento</TableCell>
               <TableCell sx={{ fontWeight: 600 }}>Fotógrafos</TableCell>
+              <TableCell sx={{ fontWeight: 600 }}>Juízes</TableCell>
               <TableCell align="right" sx={{ fontWeight: 600 }}>
                 Ações
               </TableCell>
@@ -172,20 +196,49 @@ export const SeasonsPage = () => {
           <TableBody>
             {seasons.length === 0 ? (
               <TableRow>
-                <TableCell colSpan={4} align="center">
-                  Nenhuma temporada cadastrada.
+                <TableCell colSpan={5} align="center">
+                  Nenhum evento cadastrado.
                 </TableCell>
               </TableRow>
             ) : (
               seasons.map((s) => {
-                const associatedCount = s.photographer_ids?.length || 0;
+                const associatedPhotogs = s.photographer_ids?.length || 0;
+                const associatedJudges = s.judges?.length || 0;
                 return (
                   <TableRow key={s.id} hover>
                     <TableCell>{s.id}</TableCell>
-                    <TableCell>{s.name}</TableCell>
+                    <TableCell sx={{ fontWeight: 600 }}>{s.name}</TableCell>
                     <TableCell>
-                      {associatedCount}{" "}
-                      {associatedCount === 1 ? "associado" : "associados"}
+                      {associatedPhotogs}{" "}
+                      {associatedPhotogs === 1 ? "associado" : "associados"}
+                    </TableCell>
+                    <TableCell>
+                      {associatedJudges > 0 ? (
+                        <Box
+                          sx={{ display: "flex", flexWrap: "wrap", gap: 0.5 }}
+                        >
+                          {s.judges?.slice(0, 3).map((j) => (
+                            <Chip
+                              key={j}
+                              label={j}
+                              size="small"
+                              variant="outlined"
+                              icon={<GavelRoundedIcon fontSize="small" />}
+                            />
+                          ))}
+                          {associatedJudges > 3 && (
+                            <Chip
+                              label={`+${associatedJudges - 3}`}
+                              size="small"
+                              variant="outlined"
+                            />
+                          )}
+                        </Box>
+                      ) : (
+                        <Typography variant="caption" color="text.secondary">
+                          Nenhum juiz cadastrado
+                        </Typography>
+                      )}
                     </TableCell>
                     <TableCell align="right">
                       <Tooltip title="Editar">
@@ -216,31 +269,32 @@ export const SeasonsPage = () => {
         </Table>
       </TableContainer>
 
-      {/* Modal Criar / Editar */}
+      {/* Modal Criar / Editar Evento */}
       <Dialog
         open={open}
         onClose={() => setOpen(false)}
         maxWidth="sm"
         fullWidth
       >
-        <DialogTitle>
-          {editingId ? "Editar Temporada" : "Nova Temporada"}
-        </DialogTitle>
+        <DialogTitle>{editingId ? "Editar Evento" : "Novo Evento"}</DialogTitle>
         <DialogContent
           sx={{
             display: "flex",
             flexDirection: "column",
-            gap: 2,
+            gap: 2.5,
             pt: 2,
           }}
         >
           <TextField
-            label="Nome"
+            label="Nome do Evento"
+            placeholder="Ex: 2026 - Dog Nikity"
             fullWidth
             required
+            autoFocus
             value={name}
             onChange={(e) => setName(e.target.value)}
           />
+
           <FormControl fullWidth>
             <InputLabel>Fotógrafos Participantes (Opcional)</InputLabel>
             <Select
@@ -264,6 +318,7 @@ export const SeasonsPage = () => {
                       label={
                         photographers.find((p) => p.id === value)?.name || value
                       }
+                      size="small"
                     />
                   ))}
                 </Box>
@@ -276,8 +331,77 @@ export const SeasonsPage = () => {
               ))}
             </Select>
           </FormControl>
+
+          {/* Seção de Cadastro de Juízes do Evento */}
+          <Box
+            sx={{
+              p: 2,
+              borderRadius: 2,
+              bgcolor: "grey.50",
+              border: "1px solid",
+              borderColor: "divider",
+            }}
+          >
+            <Typography
+              variant="subtitle2"
+              sx={{
+                fontWeight: 600,
+                mb: 1.5,
+                display: "flex",
+                alignItems: "center",
+                gap: 0.75,
+              }}
+            >
+              <GavelRoundedIcon fontSize="small" color="primary" />
+              Lista de Juízes do Evento
+            </Typography>
+            <Box sx={{ display: "flex", gap: 1, mb: 1.5 }}>
+              <TextField
+                label="Nome do Juiz"
+                placeholder="Ex: Tamas Jakkel, Dr. Roberto Carlos..."
+                size="small"
+                fullWidth
+                value={judgeInput}
+                onChange={(e) => setJudgeInput(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    e.preventDefault();
+                    handleAddJudge();
+                  }
+                }}
+              />
+              <Button
+                variant="outlined"
+                size="small"
+                onClick={handleAddJudge}
+                disabled={!judgeInput.trim()}
+                sx={{ whiteSpace: "nowrap", px: 2 }}
+              >
+                Adicionar
+              </Button>
+            </Box>
+            {judges.length > 0 ? (
+              <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.75 }}>
+                {judges.map((j) => (
+                  <Chip
+                    key={j}
+                    label={j}
+                    size="small"
+                    color="primary"
+                    variant="outlined"
+                    onDelete={() => handleRemoveJudge(j)}
+                  />
+                ))}
+              </Box>
+            ) : (
+              <Typography variant="caption" color="text.secondary">
+                Nenhum juiz adicionado a este evento ainda. Digite o nome e
+                clique em Adicionar.
+              </Typography>
+            )}
+          </Box>
         </DialogContent>
-        <DialogActions>
+        <DialogActions sx={{ px: 3, pb: 2 }}>
           <Button onClick={() => setOpen(false)}>Cancelar</Button>
           <Button
             onClick={handleSave}
@@ -297,7 +421,7 @@ export const SeasonsPage = () => {
         <DialogTitle>Confirmar Exclusão</DialogTitle>
         <DialogContent>
           <Typography>
-            Tem certeza que deseja excluir a temporada{" "}
+            Tem certeza que deseja excluir o evento{" "}
             <strong>{deletingSeason?.name}</strong>?
           </Typography>
         </DialogContent>

--- a/frontend/src/layouts/Sidebar.tsx
+++ b/frontend/src/layouts/Sidebar.tsx
@@ -27,7 +27,7 @@ interface SidebarProps {
 
 const menuItems = [
   { text: "Visão Geral", icon: <DashboardRoundedIcon />, path: "/dashboard" },
-  { text: "Temporadas", icon: <EventNoteRoundedIcon />, path: "/seasons" },
+  { text: "Eventos", icon: <EventNoteRoundedIcon />, path: "/seasons" },
   {
     text: "Fotógrafos",
     icon: <CameraAltRoundedIcon />,

--- a/frontend/src/layouts/Topbar.tsx
+++ b/frontend/src/layouts/Topbar.tsx
@@ -40,14 +40,22 @@ export function Topbar({ onDrawerToggle }: TopbarProps) {
       .then((data) => {
         const seasonList = data || [];
         setSeasons(seasonList);
-        if (seasonList.length > 0 && !activeSeason) {
-          setActiveSeason({ id: seasonList[0].id, name: seasonList[0].name });
+        if (seasonList.length > 0) {
+          if (!activeSeason) {
+            setActiveSeason(seasonList[0]);
+          } else {
+            // Keep active season updated with latest judges
+            const found = seasonList.find((x) => x.id === activeSeason.id);
+            if (found) {
+              setActiveSeason(found);
+            }
+          }
         }
       })
       .catch(() => {
         setSeasons([]);
       });
-  }, [activeSeason, setActiveSeason]);
+  }, [setActiveSeason]);
 
   const handleMenu = (event: React.MouseEvent<HTMLElement>) => {
     setAnchorEl(event.currentTarget);
@@ -66,7 +74,7 @@ export function Topbar({ onDrawerToggle }: TopbarProps) {
   const handleChangeSeason = (id: string) => {
     const s = seasons.find((x) => x.id === id);
     if (s) {
-      setActiveSeason({ id: s.id, name: s.name });
+      setActiveSeason(s);
     }
   };
 
@@ -113,10 +121,10 @@ export function Topbar({ onDrawerToggle }: TopbarProps) {
           }}
         >
           <FormControl fullWidth size="small">
-            <InputLabel>Temporada Ativa</InputLabel>
+            <InputLabel>Evento Ativo</InputLabel>
             <Select
               value={activeSeason?.id || ""}
-              label="Temporada Ativa"
+              label="Evento Ativo"
               onChange={(e) => handleChangeSeason(e.target.value)}
               sx={{ fontSize: { xs: "0.85rem", sm: "0.95rem" } }}
             >

--- a/frontend/src/services/api/client.service.ts
+++ b/frontend/src/services/api/client.service.ts
@@ -5,11 +5,14 @@ export interface Photo {
   photographer_id: string;
   payment_method: string;
   amount_paid?: number;
+  judges?: string[];
+  created_at?: string;
 }
 
 export interface Dog {
   breed: string;
   judge: string;
+  judges?: string[];
   is_owner?: boolean;
   competitions_won: number;
   won_competitions?: string[];

--- a/frontend/src/services/api/report.service.ts
+++ b/frontend/src/services/api/report.service.ts
@@ -19,6 +19,20 @@ export const reportService = {
     return data;
   },
 
+  exportClientsPdf: async (): Promise<ReportExportResponse> => {
+    const { data } = await apiClient.post<ReportExportResponse>(
+      "/reports/clients-pdf",
+    );
+    return data;
+  },
+
+  downloadClientsPdfDirect: async (): Promise<Blob> => {
+    const { data } = await apiClient.get<Blob>("/reports/clients-pdf", {
+      responseType: "blob",
+    });
+    return data;
+  },
+
   downloadReport: async (filePath: string): Promise<Blob> => {
     const { data } = await apiClient.get<Blob>("/reports/download", {
       params: { file: filePath },

--- a/frontend/src/services/api/season.service.ts
+++ b/frontend/src/services/api/season.service.ts
@@ -4,6 +4,7 @@ export interface Season {
   id: string;
   name: string;
   photographer_ids: string[];
+  judges?: string[];
   created_at?: string;
   updated_at?: string;
 }

--- a/frontend/src/store/seasonStore.ts
+++ b/frontend/src/store/seasonStore.ts
@@ -4,6 +4,8 @@ import { safeStorage } from "../services/storage/storage";
 export interface Season {
   id: string;
   name: string;
+  photographer_ids?: string[];
+  judges?: string[];
 }
 
 interface SeasonState {


### PR DESCRIPTION
## 📌 Descrição

Este Pull Request implementa a refatoração completa da terminologia de "Temporada" para "Evento", introduz o cadastro de múltiplos juízes no evento com seleção dinâmica via Autocomplete/Dropdown, e adiciona suporte à exportação de relatórios enriquecidos em formato CSV e **PDF direto A4 Paisagem** sem repetição de dados redundantes de tutores.

---

## 🚀 Principais Alterações

### 🏷️ 1. Renomeação de "Temporada" para "Evento"
- Atualização em todas as camadas do Frontend (`Sidebar`, `Topbar`, `SeasonsPage`, `DashboardPage`, `ClientsPage`, `ClientDetailsPage`, modais e páginas de autenticação).
- Ajuste e sincronização de estados no `useSeasonStore`.

### ⚖️ 2. Gerenciamento e Seleção de Múltiplos Juízes
- Backend: Suporte a `judges: []string` nos domínios de `Season`, `Dog` e `Photo` (com retrocompatibilidade para campo legado `judge: string`).
- Frontend (`SeasonsPage`): Interface para cadastrar e remover juízes do evento com atalho <kbd>Enter</kbd> e chips interativos.
- Frontend (`ClientsPage`, `ClientDetailsModal`, `LinkClientModal`, `PersonDetailsPage`): Campos de juiz substituídos por `Autocomplete` múltiplo vinculado aos juízes do evento ativo.

### 📄 3. Exportações Enriquecidas (CSV e PDF Direto A4 Paisagem)
- **CSV Enriquecido**: Adição dos campos `Raça do Cachorro`, `Proprietário (Dono)`, `Juiz(es)` e `Data/Hora da Foto`.
- **Motor de PDF (A4 Paisagem)**:
  - Implementado em Go com `github.com/go-pdf/fpdf`.
  - **Sem repetição de dados redundantes**: O nome, e-mail e telefone do tutor aparecem **apenas na primeira linha** do tutor. Cachorros adicionais e fotos subsequentes deixam as colunas anteriores em branco.
  - Divisores sutis entre cães e linhas sólidas de destaque entre tutores diferentes.
  - Rodapé com totalizadores financeiros e de contagem (Tutores, Cães, Fotos e Faturamento).
  - Download direto integrado nos menus de Relatórios do Dashboard e da Listagem de Clientes.

---

## 🧪 Validação & Testes

- [x] `./scripts/swagger.sh` — Documentação OpenAPI/Swagger regenerada com sucesso.
- [x] `./scripts/fix.sh` — Formatação e linter validados (Go fmt, Prettier, ESLint, Terraform).
- [x] `./scripts/check.sh all` — 100% de sucesso (Backend: 11 pacotes de teste passando; Frontend: typecheck, lint, e todos os 61 testes passando).