### PR TITLE
fix(judges): tornar juízes selecionáveis por foto a partir do evento e ajustar exportações

### DIFF
--- a/backend/internal/application/usecase/report/service.go
+++ b/backend/internal/application/usecase/report/service.go
@@ -129,14 +129,11 @@ func sanitizeRow(row []string) []string {
 	return sanitized
 }
 
-func formatJudges(dog clientdomain.Dog, photo *clientdomain.Photo) string {
-	if photo != nil && len(photo.Judges) > 0 {
-		return strings.Join(photo.Judges, ", ")
+func formatJudges(photo *clientdomain.Photo) string {
+	if photo == nil || len(photo.Judges) == 0 {
+		return ""
 	}
-	if len(dog.Judges) > 0 {
-		return strings.Join(dog.Judges, ", ")
-	}
-	return dog.Judge
+	return strings.Join(photo.Judges, ", ")
 }
 
 func formatIsOwner(isOwner *bool) string {
@@ -254,7 +251,7 @@ func (s *Service) GenerateClientsCSV(ctx context.Context, tenantID, userEmail, u
 					formattedPhone,
 					isOwnerStr,
 					dog.Breed,
-					formatJudges(dog, nil),
+					"",
 					"",
 					"",
 					"",
@@ -269,8 +266,7 @@ func (s *Service) GenerateClientsCSV(ctx context.Context, tenantID, userEmail, u
 			}
 
 			for i := 0; i < totalLinhas; i++ {
-				var fileNumber, photographerName, paymentMethod, amountPaid, photoDate string
-				var currentPhoto *clientdomain.Photo
+				var fileNumber, photographerName, paymentMethod, amountPaid, photoDate, judgeStr string
 				if numPhotos > 0 {
 					var photo clientdomain.Photo
 					if i < numPhotos {
@@ -278,7 +274,6 @@ func (s *Service) GenerateClientsCSV(ctx context.Context, tenantID, userEmail, u
 					} else {
 						photo = dog.Photos[numPhotos-1]
 					}
-					currentPhoto = &photo
 					fileNumber = photo.FileNumber
 					if name, exists := photogMap[photo.PhotographerID]; exists && name != "" {
 						photographerName = name
@@ -290,6 +285,9 @@ func (s *Service) GenerateClientsCSV(ctx context.Context, tenantID, userEmail, u
 						amountPaid = fmt.Sprintf("%.2f", *photo.AmountPaid)
 					}
 					photoDate = formatPhotoDate(&photo, c.CreatedAt)
+					if i < numPhotos {
+						judgeStr = formatJudges(&photo)
+					}
 				}
 
 				var competitionWon string
@@ -310,7 +308,7 @@ func (s *Service) GenerateClientsCSV(ctx context.Context, tenantID, userEmail, u
 					formattedPhone,
 					isOwnerStr,
 					dog.Breed,
-					formatJudges(dog, currentPhoto),
+					judgeStr,
 					competitionWon,
 					fileNumber,
 					photographerName,
@@ -444,7 +442,7 @@ func (s *Service) GenerateUnpaidClientsCSV(ctx context.Context, tenantID, userEm
 					amount = fmt.Sprintf("%.2f", *photo.AmountPaid)
 				}
 
-				judgeStr := formatJudges(dog, &photo)
+				judgeStr := formatJudges(&photo)
 
 				row := []string{
 					personObj.Name,
@@ -638,7 +636,6 @@ func (s *Service) buildClientsPDF(ctx context.Context, tenantID string) ([]byte,
 		} else {
 			for dIdx, dog := range client.Dogs {
 				isOwnerStr := formatIsOwner(dog.IsOwner)
-				judgeStr := formatJudges(dog, nil)
 				wonComps := dog.WonCompetitions
 				if len(wonComps) == 0 && dog.CompetitionsWon > 0 {
 					wonComps = []string{"Sim"}
@@ -663,7 +660,6 @@ func (s *Service) buildClientsPDF(ctx context.Context, tenantID string) ([]byte,
 					if rIdx == 0 {
 						colBreed = dog.Breed
 						colOwner = isOwnerStr
-						colJudge = judgeStr
 					}
 
 					// Won competition on current row index
@@ -680,9 +676,7 @@ func (s *Service) buildClientsPDF(ctx context.Context, tenantID string) ([]byte,
 							colAmount = fmt.Sprintf("R$ %.2f", *photo.AmountPaid)
 						}
 						colDate = formatPhotoDate(&photo, client.CreatedAt)
-						if len(photo.Judges) > 0 && rIdx > 0 {
-							colJudge = strings.Join(photo.Judges, ", ")
-						}
+						colJudge = formatJudges(&photo)
 					}
 
 					pdf.SetTextColor(30, 41, 59)

--- a/backend/internal/application/usecase/report/service_test.go
+++ b/backend/internal/application/usecase/report/service_test.go
@@ -157,7 +157,6 @@ func TestGenerateClientsCSV_FullExpansionAndRules(t *testing.T) {
 				Dogs: []clientdomain.Dog{
 					{
 						Breed:           "Border Collie",
-						Judge:           "Juiz Silva",
 						WonCompetitions: []string{"Melhor da Raça", "Campeão Adulto"}, // 2 won comps, 2 photos -> total lines = 2
 						Photos: []clientdomain.Photo{
 							{
@@ -165,18 +164,19 @@ func TestGenerateClientsCSV_FullExpansionAndRules(t *testing.T) {
 								PhotographerID: "photog-1",
 								PaymentMethod:  "Pix",
 								AmountPaid:     &amount100,
+								Judges:         []string{"Juiz Silva"},
 							},
 							{
 								FileNumber:     "IMG_002",
 								PhotographerID: "photog-2",
 								PaymentMethod:  "Credit Card",
 								AmountPaid:     &amount200,
+								Judges:         []string{"Juiz Silva"},
 							},
 						},
 					},
 					{
 						Breed:           "Golden Retriever",
-						Judge:           "Juiz Santos",
 						CompetitionsWon: 3, // 3 competitions won, 2 photos -> total lines = 3 (photo 2 repeated)
 						Photos: []clientdomain.Photo{
 							{
@@ -184,12 +184,14 @@ func TestGenerateClientsCSV_FullExpansionAndRules(t *testing.T) {
 								PhotographerID: "photog-1",
 								PaymentMethod:  "Cash",
 								AmountPaid:     nil,
+								Judges:         []string{"Juiz Santos"},
 							},
 							{
 								FileNumber:     "+SUM(A1:A2)",
 								PhotographerID: "photog-2",
 								PaymentMethod:  "Pix",
 								AmountPaid:     &amount100,
+								Judges:         []string{"Juiz Santos"},
 							},
 						},
 					},
@@ -494,31 +496,32 @@ func TestGenerateUnpaidClientsCSV(t *testing.T) {
 				Dogs: []clientdomain.Dog{
 					{
 						Breed: "Golden",
-						Judge: "Juiz A",
 						Photos: []clientdomain.Photo{
 							{
 								FileNumber:     "IMG_101",
 								PhotographerID: "photog-1",
 								PaymentMethod:  "Pix",
 								AmountPaid:     &amount50,
+								Judges:         []string{"Juiz A"},
 							},
 							{
 								FileNumber:     "=CMD_INJECTION",
 								PhotographerID: "photog-2",
 								PaymentMethod:  "Não pago",
 								AmountPaid:     &amount150,
+								Judges:         []string{"Juiz A"},
 							},
 						},
 					},
 					{
 						Breed: "Poodle",
-						Judge: "Juiz B",
 						Photos: []clientdomain.Photo{
 							{
 								FileNumber:     "IMG_103",
 								PhotographerID: "photog-1",
 								PaymentMethod:  "pendente",
 								AmountPaid:     nil,
+								Judges:         []string{"Juiz B"},
 							},
 						},
 					},
@@ -531,13 +534,13 @@ func TestGenerateUnpaidClientsCSV(t *testing.T) {
 				Dogs: []clientdomain.Dog{
 					{
 						Breed: "Bulldog",
-						Judge: "Juiz C",
 						Photos: []clientdomain.Photo{
 							{
 								FileNumber:     "IMG_201",
 								PhotographerID: "photog-1",
 								PaymentMethod:  "Cartão de Crédito",
 								AmountPaid:     &amount200,
+								Judges:         []string{"Juiz C"},
 							},
 						},
 					},
@@ -550,13 +553,13 @@ func TestGenerateUnpaidClientsCSV(t *testing.T) {
 				Dogs: []clientdomain.Dog{
 					{
 						Breed: "Shih Tzu",
-						Judge: "Juiz D",
 						Photos: []clientdomain.Photo{
 							{
 								FileNumber:     "IMG_301",
 								PhotographerID: "photog-unknown",
 								PaymentMethod:  "",
 								AmountPaid:     nil,
+								Judges:         []string{"Juiz D"},
 							},
 						},
 					},

--- a/frontend/src/features/clients/components/ClientDetailsModal.tsx
+++ b/frontend/src/features/clients/components/ClientDetailsModal.tsx
@@ -358,38 +358,6 @@ export const ClientDetailsModal = ({
                         }
                         sx={{ flex: 1, minWidth: 150 }}
                       />
-                      <Autocomplete
-                        multiple
-                        freeSolo
-                        size="small"
-                        options={activeSeason?.judges || []}
-                        value={
-                          dog.judges ||
-                          (dog.judge
-                            ? dog.judge
-                                .split(",")
-                                .map((j) => j.trim())
-                                .filter(Boolean)
-                            : [])
-                        }
-                        onChange={(_, val) => {
-                          const cleaned = val
-                            .map((v) => v.trim())
-                            .filter(Boolean);
-                          updateDog(dIdx, "judges", cleaned);
-                          updateDog(dIdx, "judge", cleaned.join(", "));
-                        }}
-                        renderInput={(params) => (
-                          <TextField
-                            {...params}
-                            label="Juiz"
-                            placeholder={
-                              dog.judges?.length ? "" : "Selecione ou digite"
-                            }
-                          />
-                        )}
-                        sx={{ flex: 1, minWidth: 180 }}
-                      />
                       <TextField
                         type="number"
                         label="Competições Ganhas"
@@ -586,6 +554,29 @@ export const ClientDetailsModal = ({
                             ))}
                           </Select>
                         </FormControl>
+                        <Autocomplete
+                          multiple
+                          size="small"
+                          options={activeSeason?.judges || []}
+                          value={photo.judges || []}
+                          onChange={(_, val) => {
+                            updatePhoto(dIdx, pIdx, "judges", val);
+                          }}
+                          renderInput={(params) => (
+                            <TextField
+                              {...params}
+                              label="Juízes"
+                              placeholder={
+                                photo.judges?.length
+                                  ? ""
+                                  : activeSeason?.judges?.length
+                                    ? "Selecione juízes"
+                                    : "Nenhum juiz no evento"
+                              }
+                            />
+                          )}
+                          sx={{ minWidth: 180, flex: 1 }}
+                        />
                         <FormControl
                           size="small"
                           sx={{ minWidth: 140, flex: 1 }}

--- a/frontend/src/features/clients/components/LinkClientModal.tsx
+++ b/frontend/src/features/clients/components/LinkClientModal.tsx
@@ -279,36 +279,6 @@ export const LinkClientModal = ({
                 onChange={(e) => updateDog(dIdx, "breed", e.target.value)}
                 sx={{ flex: 1, minWidth: 150 }}
               />
-              <Autocomplete
-                multiple
-                freeSolo
-                size="small"
-                options={activeSeason?.judges || []}
-                value={
-                  dog.judges ||
-                  (dog.judge
-                    ? dog.judge
-                        .split(",")
-                        .map((j) => j.trim())
-                        .filter(Boolean)
-                    : [])
-                }
-                onChange={(_, val) => {
-                  const cleaned = val.map((v) => v.trim()).filter(Boolean);
-                  updateDog(dIdx, "judges", cleaned);
-                  updateDog(dIdx, "judge", cleaned.join(", "));
-                }}
-                renderInput={(params) => (
-                  <TextField
-                    {...params}
-                    label="Juiz"
-                    placeholder={
-                      dog.judges?.length ? "" : "Selecione ou digite"
-                    }
-                  />
-                )}
-                sx={{ flex: 1, minWidth: 180 }}
-              />
               <TextField
                 type="number"
                 label="Competições Ganhas"
@@ -483,6 +453,29 @@ export const LinkClientModal = ({
                     ))}
                   </Select>
                 </FormControl>
+                <Autocomplete
+                  multiple
+                  size="small"
+                  options={activeSeason?.judges || []}
+                  value={photo.judges || []}
+                  onChange={(_, val) => {
+                    updatePhoto(dIdx, pIdx, "judges", val);
+                  }}
+                  renderInput={(params) => (
+                    <TextField
+                      {...params}
+                      label="Juízes"
+                      placeholder={
+                        photo.judges?.length
+                          ? ""
+                          : activeSeason?.judges?.length
+                            ? "Selecione juízes"
+                            : "Nenhum juiz no evento"
+                      }
+                    />
+                  )}
+                  sx={{ minWidth: 180, flex: 1 }}
+                />
                 <FormControl size="small" sx={{ minWidth: 140, flex: 1 }}>
                   <InputLabel id={`payment-label-${dIdx}-${pIdx}`}>
                     Pagamento

--- a/frontend/src/features/clients/pages/ClientDetailsPage.tsx
+++ b/frontend/src/features/clients/pages/ClientDetailsPage.tsx
@@ -321,38 +321,6 @@ export const ClientDetailsPage = () => {
                   minWidth: "160px",
                 }}
               />
-              <Autocomplete
-                multiple
-                freeSolo
-                options={activeSeason?.judges || []}
-                value={
-                  dog.judges ||
-                  (dog.judge
-                    ? dog.judge
-                        .split(",")
-                        .map((j) => j.trim())
-                        .filter(Boolean)
-                    : [])
-                }
-                onChange={(_, val) => {
-                  const cleaned = val.map((v) => v.trim()).filter(Boolean);
-                  updateDog(dIdx, "judges", cleaned);
-                  updateDog(dIdx, "judge", cleaned.join(", "));
-                }}
-                renderInput={(params) => (
-                  <TextField
-                    {...params}
-                    label="Juiz (Opcional)"
-                    placeholder={
-                      dog.judges?.length ? "" : "Selecione ou digite"
-                    }
-                  />
-                )}
-                sx={{
-                  flex: { xs: "1 1 100%", sm: "1 1 240px" },
-                  minWidth: "200px",
-                }}
-              />
               <TextField
                 type="number"
                 label="Competições Ganhas"
@@ -550,6 +518,32 @@ export const ClientDetailsPage = () => {
                     ))}
                   </Select>
                 </FormControl>
+                <Autocomplete
+                  multiple
+                  size="small"
+                  options={activeSeason?.judges || []}
+                  value={photo.judges || []}
+                  onChange={(_, val) => {
+                    updatePhoto(dIdx, pIdx, "judges", val);
+                  }}
+                  renderInput={(params) => (
+                    <TextField
+                      {...params}
+                      label="Juízes"
+                      placeholder={
+                        photo.judges?.length
+                          ? ""
+                          : activeSeason?.judges?.length
+                            ? "Selecione juízes"
+                            : "Nenhum juiz no evento"
+                      }
+                    />
+                  )}
+                  sx={{
+                    flex: { xs: "1 1 100%", sm: "1 1 200px" },
+                    minWidth: "180px",
+                  }}
+                />
                 <FormControl
                   size="small"
                   required

--- a/frontend/src/features/clients/pages/ClientsPage.tsx
+++ b/frontend/src/features/clients/pages/ClientsPage.tsx
@@ -484,38 +484,6 @@ export const ClientsPage = () => {
                     minWidth: "160px",
                   }}
                 />
-                <Autocomplete
-                  multiple
-                  freeSolo
-                  options={activeSeason?.judges || []}
-                  value={
-                    dog.judges ||
-                    (dog.judge
-                      ? dog.judge
-                          .split(",")
-                          .map((j) => j.trim())
-                          .filter(Boolean)
-                      : [])
-                  }
-                  onChange={(_, val) => {
-                    const cleaned = val.map((v) => v.trim()).filter(Boolean);
-                    updateDog(dIdx, "judges", cleaned);
-                    updateDog(dIdx, "judge", cleaned.join(", "));
-                  }}
-                  renderInput={(params) => (
-                    <TextField
-                      {...params}
-                      label="Juiz (Opcional)"
-                      placeholder={
-                        dog.judges?.length ? "" : "Selecione ou digite"
-                      }
-                    />
-                  )}
-                  sx={{
-                    flex: { xs: "1 1 100%", sm: "1 1 240px" },
-                    minWidth: "200px",
-                  }}
-                />
                 <TextField
                   type="number"
                   label="Competições Ganhas"
@@ -717,6 +685,32 @@ export const ClientsPage = () => {
                       ))}
                     </Select>
                   </FormControl>
+                  <Autocomplete
+                    multiple
+                    size="small"
+                    options={activeSeason?.judges || []}
+                    value={photo.judges || []}
+                    onChange={(_, val) => {
+                      updatePhoto(dIdx, pIdx, "judges", val);
+                    }}
+                    renderInput={(params) => (
+                      <TextField
+                        {...params}
+                        label="Juízes"
+                        placeholder={
+                          photo.judges?.length
+                            ? ""
+                            : activeSeason?.judges?.length
+                              ? "Selecione juízes"
+                              : "Nenhum juiz no evento"
+                        }
+                      />
+                    )}
+                    sx={{
+                      flex: { xs: "1 1 100%", sm: "1 1 200px" },
+                      minWidth: "180px",
+                    }}
+                  />
                   <FormControl
                     size="small"
                     required

--- a/frontend/src/features/people/pages/PersonDetailsPage.tsx
+++ b/frontend/src/features/people/pages/PersonDetailsPage.tsx
@@ -39,7 +39,6 @@ import DeleteIcon from "@mui/icons-material/Delete";
 import PetsIcon from "@mui/icons-material/Pets";
 import PhotoCameraIcon from "@mui/icons-material/PhotoCamera";
 import EmojiEventsIcon from "@mui/icons-material/EmojiEvents";
-import GavelIcon from "@mui/icons-material/Gavel";
 import PersonIcon from "@mui/icons-material/Person";
 import PhoneIcon from "@mui/icons-material/Phone";
 import EmailIcon from "@mui/icons-material/Email";
@@ -107,15 +106,11 @@ export const PersonDetailsPage = () => {
   const [editingDogIndex, setEditingDogIndex] = useState<number | null>(null);
   const [dogForm, setDogForm] = useState<{
     breed: string;
-    judge: string;
-    judges: string[];
     competitions_won: number;
     won_competitions: string[];
     is_owner: boolean;
   }>({
     breed: "",
-    judge: "",
-    judges: [],
     competitions_won: 0,
     won_competitions: [],
     is_owner: true,
@@ -280,8 +275,6 @@ export const PersonDetailsPage = () => {
     setNewCompetitionInput("");
     setDogForm({
       breed: "",
-      judge: "",
-      judges: [],
       competitions_won: 0,
       won_competitions: [],
       is_owner: true,
@@ -294,19 +287,8 @@ export const PersonDetailsPage = () => {
     if (!d) return;
     setEditingDogIndex(index);
     setNewCompetitionInput("");
-    const parsedJudges =
-      d.judges && d.judges.length > 0
-        ? d.judges
-        : d.judge
-          ? d.judge
-              .split(",")
-              .map((j) => j.trim())
-              .filter(Boolean)
-          : [];
     setDogForm({
       breed: d.breed || "",
-      judge: d.judge || "",
-      judges: parsedJudges,
       competitions_won: d.competitions_won || 0,
       won_competitions: d.won_competitions || [],
       is_owner: d.is_owner ?? true,
@@ -349,24 +331,11 @@ export const PersonDetailsPage = () => {
         ? finalWonCompetitions.map((c) => c.trim()).filter((c) => c.length > 0)
         : [];
 
-    const finalJudges =
-      dogForm.judges && dogForm.judges.length > 0
-        ? dogForm.judges
-        : dogForm.judge
-          ? dogForm.judge
-              .split(",")
-              .map((j) => j.trim())
-              .filter(Boolean)
-          : [];
-    const finalJudge = finalJudges.join(", ");
-
     const newDogs = [...dogsList];
     if (editingDogIndex !== null) {
       newDogs[editingDogIndex] = {
         ...newDogs[editingDogIndex],
         breed: dogForm.breed.trim(),
-        judge: finalJudge,
-        judges: finalJudges,
         competitions_won: wonCount,
         won_competitions: finalWonCompetitions,
         is_owner: dogForm.is_owner,
@@ -374,8 +343,6 @@ export const PersonDetailsPage = () => {
     } else {
       newDogs.unshift({
         breed: dogForm.breed.trim(),
-        judge: finalJudge,
-        judges: finalJudges,
         competitions_won: wonCount,
         won_competitions: finalWonCompetitions,
         is_owner: dogForm.is_owner,
@@ -408,29 +375,20 @@ export const PersonDetailsPage = () => {
       return;
     }
     const defaultPhotog = photographers[0]?.id || "";
-    const defaultJudges =
-      selectedDog.judges && selectedDog.judges.length > 0
-        ? selectedDog.judges
-        : selectedDog.judge
-          ? selectedDog.judge
-              .split(",")
-              .map((j) => j.trim())
-              .filter(Boolean)
-          : [];
 
     setBatchPhotoForm({
       fileNumbersText: "",
       photographer_id: defaultPhotog,
       payment_method: "Pix",
       amount_paid: 0,
-      judges: defaultJudges,
+      judges: [],
     });
     setSinglePhotoForm({
       file_number: "",
       photographer_id: defaultPhotog,
       payment_method: "Pix",
       amount_paid: 0,
-      judges: defaultJudges,
+      judges: [],
     });
     setAddPhotoDialogOpen(true);
   };
@@ -877,36 +835,6 @@ export const PersonDetailsPage = () => {
                           <Box
                             sx={{
                               display: "flex",
-                              alignItems: "center",
-                              gap: 1,
-                              color: "text.secondary",
-                              fontSize: "0.8rem",
-                              mb: 1,
-                            }}
-                          >
-                            {(dog.judges && dog.judges.length > 0) ||
-                            dog.judge ? (
-                              <Box
-                                sx={{
-                                  display: "flex",
-                                  alignItems: "center",
-                                  gap: 0.5,
-                                }}
-                              >
-                                <GavelIcon fontSize="inherit" />
-                                <span>
-                                  Juiz:{" "}
-                                  {dog.judges && dog.judges.length > 0
-                                    ? dog.judges.join(", ")
-                                    : dog.judge}
-                                </span>
-                              </Box>
-                            ) : null}
-                          </Box>
-
-                          <Box
-                            sx={{
-                              display: "flex",
                               justifyContent: "space-between",
                               alignItems: "center",
                               mt: 1,
@@ -1017,27 +945,12 @@ export const PersonDetailsPage = () => {
                     sx={{
                       display: "flex",
                       alignItems: "center",
-                      gap: 3,
+                      gap: 2,
                       flexWrap: "wrap",
                       color: "text.secondary",
                       mt: 1,
                     }}
                   >
-                    <Box
-                      sx={{
-                        display: "flex",
-                        alignItems: "center",
-                        gap: 0.5,
-                      }}
-                    >
-                      <GavelIcon fontSize="small" color="action" />
-                      <Typography variant="body2">
-                        <strong>Juiz:</strong>{" "}
-                        {selectedDog.judges && selectedDog.judges.length > 0
-                          ? selectedDog.judges.join(", ")
-                          : selectedDog.judge || "Não informado"}
-                      </Typography>
-                    </Box>
                     <Box
                       sx={{
                         display: "flex",
@@ -1453,43 +1366,6 @@ export const PersonDetailsPage = () => {
             value={dogForm.breed}
             onChange={(e) => setDogForm({ ...dogForm, breed: e.target.value })}
           />
-          <Autocomplete
-            multiple
-            freeSolo
-            options={activeSeason?.judges || []}
-            value={
-              dogForm.judges && dogForm.judges.length > 0
-                ? dogForm.judges
-                : dogForm.judge
-                  ? dogForm.judge
-                      .split(",")
-                      .map((j) => j.trim())
-                      .filter(Boolean)
-                  : []
-            }
-            onChange={(_, val) => {
-              const cleaned = val.map((v) => v.trim()).filter(Boolean);
-              setDogForm({
-                ...dogForm,
-                judges: cleaned,
-                judge: cleaned.join(", "),
-              });
-            }}
-            renderInput={(params) => (
-              <TextField
-                {...params}
-                label="Juízes do Evento"
-                placeholder={
-                  dogForm.judges?.length ? "" : "Selecione ou digite juízes"
-                }
-                helperText={
-                  activeSeason?.judges && activeSeason.judges.length > 0
-                    ? "Selecione da lista de juízes do evento ou digite um novo nome e pressione Enter."
-                    : "Cadastre juízes no evento para selecioná-los aqui ou digite o nome e pressione Enter."
-                }
-              />
-            )}
-          />
           <TextField
             label="Competições Ganhas"
             type="number"
@@ -1695,23 +1571,30 @@ export const PersonDetailsPage = () => {
               </FormControl>
               <Autocomplete
                 multiple
-                freeSolo
                 size="small"
                 options={activeSeason?.judges || []}
                 value={batchPhotoForm.judges || []}
                 onChange={(_, val) => {
-                  const cleaned = val.map((v) => v.trim()).filter(Boolean);
                   setBatchPhotoForm({
                     ...batchPhotoForm,
-                    judges: cleaned,
+                    judges: val,
                   });
                 }}
                 renderInput={(params) => (
                   <TextField
                     {...params}
-                    label="Juízes da Foto (Opcional - padrão do cão)"
+                    label="Juízes da Foto"
                     placeholder={
-                      batchPhotoForm.judges?.length ? "" : "Selecione ou digite"
+                      batchPhotoForm.judges?.length
+                        ? ""
+                        : activeSeason?.judges?.length
+                          ? "Selecione os juízes"
+                          : "Nenhum juiz cadastrado no evento"
+                    }
+                    helperText={
+                      activeSeason?.judges?.length
+                        ? "Selecione os juízes do evento vinculados a estas fotos."
+                        : "Cadastre juízes no evento para poder selecioná-los aqui."
                     }
                   />
                 )}
@@ -1798,25 +1681,30 @@ export const PersonDetailsPage = () => {
               </FormControl>
               <Autocomplete
                 multiple
-                freeSolo
                 size="small"
                 options={activeSeason?.judges || []}
                 value={singlePhotoForm.judges || []}
                 onChange={(_, val) => {
-                  const cleaned = val.map((v) => v.trim()).filter(Boolean);
                   setSinglePhotoForm({
                     ...singlePhotoForm,
-                    judges: cleaned,
+                    judges: val,
                   });
                 }}
                 renderInput={(params) => (
                   <TextField
                     {...params}
-                    label="Juízes da Foto (Opcional - padrão do cão)"
+                    label="Juízes da Foto"
                     placeholder={
                       singlePhotoForm.judges?.length
                         ? ""
-                        : "Selecione ou digite"
+                        : activeSeason?.judges?.length
+                          ? "Selecione os juízes"
+                          : "Nenhum juiz cadastrado no evento"
+                    }
+                    helperText={
+                      activeSeason?.judges?.length
+                        ? "Selecione os juízes do evento vinculados a esta foto."
+                        : "Cadastre juízes no evento para poder selecioná-los aqui."
                     }
                   />
                 )}
@@ -1930,15 +1818,13 @@ export const PersonDetailsPage = () => {
           </FormControl>
           <Autocomplete
             multiple
-            freeSolo
             size="small"
             options={activeSeason?.judges || []}
             value={editPhotoForm.judges || []}
             onChange={(_, val) => {
-              const cleaned = val.map((v) => v.trim()).filter(Boolean);
               setEditPhotoForm({
                 ...editPhotoForm,
-                judges: cleaned,
+                judges: val,
               });
             }}
             renderInput={(params) => (
@@ -1946,7 +1832,16 @@ export const PersonDetailsPage = () => {
                 {...params}
                 label="Juízes da Foto"
                 placeholder={
-                  editPhotoForm.judges?.length ? "" : "Selecione ou digite"
+                  editPhotoForm.judges?.length
+                    ? ""
+                    : activeSeason?.judges?.length
+                      ? "Selecione os juízes"
+                      : "Nenhum juiz cadastrado no evento"
+                }
+                helperText={
+                  activeSeason?.judges?.length
+                    ? "Selecione os juízes do evento vinculados a esta foto."
+                    : "Cadastre juízes no evento para poder selecioná-los aqui."
                 }
               />
             )}

--- a/frontend/src/services/api/client.service.ts
+++ b/frontend/src/services/api/client.service.ts
@@ -11,7 +11,7 @@ export interface Photo {
 
 export interface Dog {
   breed: string;
-  judge: string;
+  judge?: string;
   judges?: string[];
   is_owner?: boolean;
   competitions_won: number;


### PR DESCRIPTION
## 📌 Descrição

Este Pull Request ajusta a modelagem e interface dos juízes no sistema:
1. **Juízes por Foto**: Os juízes passam a ser atribuídos e vinculados no nível da **foto** (e não mais no cão).
2. **Seleção a partir dos Juízes do Evento**: Ao cadastrar/editar fotos (em lote ou individualmente), os juízes são selecionáveis a partir da lista cadastrada no evento através de um seletor múltiplo (dropdown/autocomplete estrito, sem digitação livre).
3. **Exportações (CSV e PDF)**: A coluna de Juiz passa a refletir estritamente os juízes da foto. Caso a foto não possua juiz cadastrado, o campo é deixado em branco nos relatórios (.csv e PDF).

---

## 🚀 O que mudou

### 🏷️ 1. Cadastro de Juízes no Evento e Seleção por Foto
- Mantido o cadastro e listagem de juízes por evento na página de **Eventos** (`SeasonsPage`).
- Removido o campo de juiz dos formulários e cartões do cão (`PersonDetailsPage`, `ClientDetailsModal`, `LinkClientModal`, `ClientsPage`, `ClientDetailsPage`).
- Adicionado seletor múltiplo (`Autocomplete` vinculado a `activeSeason.judges`) nos diálogos de foto:
  - Adicionar Fotos em Lote (`batchPhotoForm`)
  - Adicionar Foto Individual (`singlePhotoForm`)
  - Editar Foto (`editPhotoForm`)
  - Linhas de fotos nos modais e páginas de clientes.
- Exibição de chips de juízes nos cartões de fotos.

### 📄 2. Relatórios CSV e PDF
- `GenerateClientsCSV`, `GenerateUnpaidClientsCSV` e motor de PDF direto (`buildClientsPDF`): o valor da coluna **Juiz** é extraído exclusivamente da foto daquela linha (`photo.Judges`). Se a foto não tiver juízes selecionados ou não houver foto, o campo permanece vazio (`""`).

---

## 🧪 Validação & Testes

- [x] `./scripts/swagger.sh` — Documentação OpenAPI regenerada.
- [x] `./scripts/fix.sh` — Formatação e linters executados.
- [x] `./scripts/check.sh all` — 100% de sucesso (Backend: 11 pacotes de teste passando; Frontend: typecheck, lint e 61 testes passando).