### PR TITLE
feat(reports): filtrar exportações por evento selecionado e enviar PDF por e-mail

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -1316,6 +1316,14 @@ const docTemplate = `{
                     "Reports"
                 ],
                 "summary": "Exportar relatório CSV de clientes",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID do evento para filtrar o relatório",
+                        "name": "season_id",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "202": {
                         "description": "Accepted",
@@ -1354,6 +1362,14 @@ const docTemplate = `{
                     "Reports"
                 ],
                 "summary": "Download direto do relatório PDF de clientes",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID do evento para filtrar o relatório",
+                        "name": "season_id",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "Arquivo PDF",
@@ -1390,6 +1406,14 @@ const docTemplate = `{
                     "Reports"
                 ],
                 "summary": "Exportar relatório PDF de clientes",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID do evento para filtrar o relatório",
+                        "name": "season_id",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "202": {
                         "description": "Accepted",
@@ -1488,6 +1512,14 @@ const docTemplate = `{
                     "Reports"
                 ],
                 "summary": "Exportar relatório CSV de clientes com pagamentos não pagos",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID do evento para filtrar o relatório",
+                        "name": "season_id",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "202": {
                         "description": "Accepted",

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -1310,6 +1310,14 @@
                     "Reports"
                 ],
                 "summary": "Exportar relatório CSV de clientes",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID do evento para filtrar o relatório",
+                        "name": "season_id",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "202": {
                         "description": "Accepted",
@@ -1348,6 +1356,14 @@
                     "Reports"
                 ],
                 "summary": "Download direto do relatório PDF de clientes",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID do evento para filtrar o relatório",
+                        "name": "season_id",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "Arquivo PDF",
@@ -1384,6 +1400,14 @@
                     "Reports"
                 ],
                 "summary": "Exportar relatório PDF de clientes",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID do evento para filtrar o relatório",
+                        "name": "season_id",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "202": {
                         "description": "Accepted",
@@ -1482,6 +1506,14 @@
                     "Reports"
                 ],
                 "summary": "Exportar relatório CSV de clientes com pagamentos não pagos",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID do evento para filtrar o relatório",
+                        "name": "season_id",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "202": {
                         "description": "Accepted",

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -1058,6 +1058,11 @@ paths:
       description: Inicia a extração assíncrona do relatório consolidado de clientes,
         cães, fotos e pagamentos do tenant autenticado e envia o link para o e-mail
         cadastrado
+      parameters:
+      - description: ID do evento para filtrar o relatório
+        in: query
+        name: season_id
+        type: string
       produces:
       - application/json
       responses:
@@ -1084,6 +1089,11 @@ paths:
     get:
       description: Gera e faz o download direto instantâneo do relatório consolidado
         em formato PDF
+      parameters:
+      - description: ID do evento para filtrar o relatório
+        in: query
+        name: season_id
+        type: string
       produces:
       - application/pdf
       responses:
@@ -1110,6 +1120,11 @@ paths:
       description: Inicia a extração assíncrona do relatório consolidado em PDF de
         clientes, cães e fotos para o tenant autenticado e envia o link para o e-mail
         cadastrado
+      parameters:
+      - description: ID do evento para filtrar o relatório
+        in: query
+        name: season_id
+        type: string
       produces:
       - application/json
       responses:
@@ -1178,6 +1193,11 @@ paths:
       description: Inicia a extração assíncrona do relatório de clientes e fotos com
         pagamentos não quitados ou pendentes do tenant autenticado e envia o link
         para o e-mail cadastrado
+      parameters:
+      - description: ID do evento para filtrar o relatório
+        in: query
+        name: season_id
+        type: string
       produces:
       - application/json
       responses:

--- a/backend/internal/application/ports/client/repository.go
+++ b/backend/internal/application/ports/client/repository.go
@@ -9,7 +9,7 @@ type Repository interface {
 	Create(ctx context.Context, client *client.SeasonClient) error
 	GetByID(ctx context.Context, id, tenantID string) (*client.SeasonClient, error)
 	List(ctx context.Context, tenantID string, filter client.ListFilter) (*client.PaginatedClients, error)
-	StreamByTenant(ctx context.Context, tenantID string, fn func(c *client.SeasonClient) error) error
+	StreamByTenant(ctx context.Context, tenantID, seasonID string, fn func(c *client.SeasonClient) error) error
 	Update(ctx context.Context, client *client.SeasonClient) error
 	Delete(ctx context.Context, id, tenantID string) error
 }

--- a/backend/internal/application/usecase/client/service_test.go
+++ b/backend/internal/application/usecase/client/service_test.go
@@ -64,9 +64,9 @@ func (m *mockRepo) List(ctx context.Context, tenantID string, filter domain.List
 	}, nil
 }
 
-func (m *mockRepo) StreamByTenant(ctx context.Context, tenantID string, fn func(c *domain.SeasonClient) error) error {
+func (m *mockRepo) StreamByTenant(ctx context.Context, tenantID, seasonID string, fn func(c *domain.SeasonClient) error) error {
 	for _, c := range m.items {
-		if c.TenantID == tenantID {
+		if c.TenantID == tenantID && (seasonID == "" || c.SeasonID == seasonID) {
 			if err := fn(c); err != nil {
 				return err
 			}

--- a/backend/internal/application/usecase/report/service.go
+++ b/backend/internal/application/usecase/report/service.go
@@ -156,7 +156,7 @@ func formatPhotoDate(photo *clientdomain.Photo, clientCreatedAt time.Time) strin
 	return ""
 }
 
-func (s *Service) GenerateClientsCSV(ctx context.Context, tenantID, userEmail, userName string) (string, error) {
+func (s *Service) GenerateClientsCSV(ctx context.Context, tenantID, seasonID, userEmail, userName string) (string, error) {
 	if tenantID == "" {
 		return "", errors.New("tenant ID cannot be empty")
 	}
@@ -199,7 +199,7 @@ func (s *Service) GenerateClientsCSV(ctx context.Context, tenantID, userEmail, u
 	}
 
 	// 4. Stream clients from MongoDB
-	streamErr := s.clientRepo.StreamByTenant(ctx, tenantID, func(c *clientdomain.SeasonClient) error {
+	streamErr := s.clientRepo.StreamByTenant(ctx, tenantID, seasonID, func(c *clientdomain.SeasonClient) error {
 		p, ok := personCache[c.PersonID]
 		if !ok {
 			personObj, err := s.personRepo.GetByID(ctx, c.PersonID, tenantID)
@@ -360,7 +360,7 @@ func (s *Service) GenerateClientsCSV(ctx context.Context, tenantID, userEmail, u
 	return relativePath, nil
 }
 
-func (s *Service) GenerateUnpaidClientsCSV(ctx context.Context, tenantID, userEmail, userName string) (string, error) {
+func (s *Service) GenerateUnpaidClientsCSV(ctx context.Context, tenantID, seasonID, userEmail, userName string) (string, error) {
 	if tenantID == "" {
 		return "", errors.New("tenant ID cannot be empty")
 	}
@@ -400,7 +400,7 @@ func (s *Service) GenerateUnpaidClientsCSV(ctx context.Context, tenantID, userEm
 	}
 
 	// 4. Stream clients from MongoDB and filter unpaid photos
-	streamErr := s.clientRepo.StreamByTenant(ctx, tenantID, func(c *clientdomain.SeasonClient) error {
+	streamErr := s.clientRepo.StreamByTenant(ctx, tenantID, seasonID, func(c *clientdomain.SeasonClient) error {
 		var personObj *persondomain.Person
 		var ok bool
 
@@ -514,7 +514,7 @@ func fitPdfText(pdf *fpdf.Fpdf, text string, maxWidth float64) string {
 	return string(runes) + "..."
 }
 
-func (s *Service) buildClientsPDF(ctx context.Context, tenantID string) ([]byte, error) {
+func (s *Service) buildClientsPDF(ctx context.Context, tenantID, seasonID string) ([]byte, error) {
 	if tenantID == "" {
 		return nil, errors.New("tenant ID cannot be empty")
 	}
@@ -532,7 +532,7 @@ func (s *Service) buildClientsPDF(ctx context.Context, tenantID string) ([]byte,
 	// Collect clients
 	personCache := make(map[string]*persondomain.Person)
 	var clients []*clientdomain.SeasonClient
-	err = s.clientRepo.StreamByTenant(ctx, tenantID, func(c *clientdomain.SeasonClient) error {
+	err = s.clientRepo.StreamByTenant(ctx, tenantID, seasonID, func(c *clientdomain.SeasonClient) error {
 		clients = append(clients, c)
 		if _, ok := personCache[c.PersonID]; !ok {
 			personObj, pErr := s.personRepo.GetByID(ctx, c.PersonID, tenantID)
@@ -730,8 +730,8 @@ func (s *Service) buildClientsPDF(ctx context.Context, tenantID string) ([]byte,
 	return buf.Bytes(), nil
 }
 
-func (s *Service) GenerateClientsPDF(ctx context.Context, tenantID, userEmail, userName string) (string, error) {
-	pdfBytes, err := s.buildClientsPDF(ctx, tenantID)
+func (s *Service) GenerateClientsPDF(ctx context.Context, tenantID, seasonID, userEmail, userName string) (string, error) {
+	pdfBytes, err := s.buildClientsPDF(ctx, tenantID, seasonID)
 	if err != nil {
 		return "", err
 	}
@@ -759,8 +759,8 @@ func (s *Service) GenerateClientsPDF(ctx context.Context, tenantID, userEmail, u
 	return relativePath, nil
 }
 
-func (s *Service) GenerateDirectClientsPDF(ctx context.Context, tenantID string) ([]byte, error) {
-	return s.buildClientsPDF(ctx, tenantID)
+func (s *Service) GenerateDirectClientsPDF(ctx context.Context, tenantID, seasonID string) ([]byte, error) {
+	return s.buildClientsPDF(ctx, tenantID, seasonID)
 }
 
 func (s *Service) GetReportFile(ctx context.Context, tenantID, relativePath string) ([]byte, error) {

--- a/backend/internal/application/usecase/report/service_test.go
+++ b/backend/internal/application/usecase/report/service_test.go
@@ -31,9 +31,9 @@ func (m *mockClientRepo) List(ctx context.Context, tenantID string, filter clien
 		Total: int64(len(m.clients)),
 	}, nil
 }
-func (m *mockClientRepo) StreamByTenant(ctx context.Context, tenantID string, fn func(c *clientdomain.SeasonClient) error) error {
+func (m *mockClientRepo) StreamByTenant(ctx context.Context, tenantID, seasonID string, fn func(c *clientdomain.SeasonClient) error) error {
 	for _, c := range m.clients {
-		if c.TenantID == tenantID {
+		if c.TenantID == tenantID && (seasonID == "" || c.SeasonID == seasonID) {
 			if err := fn(c); err != nil {
 				return err
 			}
@@ -253,7 +253,7 @@ func TestGenerateClientsCSV_FullExpansionAndRules(t *testing.T) {
 
 	svc := NewService(clientRepo, personRepo, photographerRepo, storage, emailSender, "http://localhost:8080")
 
-	filePath, err := svc.GenerateClientsCSV(context.Background(), tenantID, "admin@tenant.com", "Admin")
+	filePath, err := svc.GenerateClientsCSV(context.Background(), tenantID, "", "admin@tenant.com", "Admin")
 	if err != nil {
 		t.Fatalf("unexpected error generating CSV: %v", err)
 	}
@@ -386,7 +386,7 @@ func TestGenerateClientsPDF_Success(t *testing.T) {
 	svc := NewService(clientRepo, personRepo, photographerRepo, storage, emailSender, "http://localhost:8080")
 
 	// Direct PDF test
-	pdfBytes, err := svc.GenerateDirectClientsPDF(context.Background(), tenantID)
+	pdfBytes, err := svc.GenerateDirectClientsPDF(context.Background(), tenantID, "")
 	if err != nil {
 		t.Fatalf("unexpected error generating direct PDF: %v", err)
 	}
@@ -399,7 +399,7 @@ func TestGenerateClientsPDF_Success(t *testing.T) {
 	}
 
 	// Async PDF test with email
-	pdfPath, err := svc.GenerateClientsPDF(context.Background(), tenantID, "user@example.com", "User")
+	pdfPath, err := svc.GenerateClientsPDF(context.Background(), tenantID, "", "user@example.com", "User")
 	if err != nil {
 		t.Fatalf("unexpected error generating PDF with email: %v", err)
 	}
@@ -604,7 +604,7 @@ func TestGenerateUnpaidClientsCSV(t *testing.T) {
 
 	svc := NewService(clientRepo, personRepo, photographerRepo, storage, emailSender, "http://localhost:8080")
 
-	filePath, err := svc.GenerateUnpaidClientsCSV(context.Background(), tenantID, "user@test.com", "Tester")
+	filePath, err := svc.GenerateUnpaidClientsCSV(context.Background(), tenantID, "", "user@test.com", "Tester")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -664,5 +664,87 @@ func TestGenerateUnpaidClientsCSV(t *testing.T) {
 	}
 	if emailSender.sentReports[0].Email != "user@test.com" || emailSender.sentReports[0].ReportName != "Relatório de Clientes Não Pagos" {
 		t.Fatalf("unexpected email details: %v", emailSender.sentReports[0])
+	}
+}
+
+func TestGenerateReports_FilterBySeasonID(t *testing.T) {
+	tenantID := "tenant-xyz"
+	season1 := "season-1"
+	season2 := "season-2"
+
+	clientRepo := &mockClientRepo{
+		clients: []*clientdomain.SeasonClient{
+			{
+				ID:       "client-s1",
+				TenantID: tenantID,
+				SeasonID: season1,
+				PersonID: "person-1",
+				Dogs: []clientdomain.Dog{
+					{
+						Breed: "Golden",
+						Photos: []clientdomain.Photo{
+							{FileNumber: "S1_001", PaymentMethod: "Pix"},
+						},
+					},
+				},
+			},
+			{
+				ID:       "client-s2",
+				TenantID: tenantID,
+				SeasonID: season2,
+				PersonID: "person-2",
+				Dogs: []clientdomain.Dog{
+					{
+						Breed: "Poodle",
+						Photos: []clientdomain.Photo{
+							{FileNumber: "S2_001", PaymentMethod: "Pix"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	personRepo := &mockPersonRepo{
+		people: map[string]*persondomain.Person{
+			"person-1": {ID: "person-1", Name: "Cliente Evento 1"},
+			"person-2": {ID: "person-2", Name: "Cliente Evento 2"},
+		},
+	}
+
+	photographerRepo := &mockPhotographerRepo{}
+	storage := &mockStorageProvider{}
+	emailSender := &mockEmailSender{}
+
+	svc := NewService(clientRepo, personRepo, photographerRepo, storage, emailSender, "http://localhost:8080")
+
+	// Export CSV filtered by season 1
+	filePath, err := svc.GenerateClientsCSV(context.Background(), tenantID, season1, "admin@test.com", "Admin")
+	if err != nil {
+		t.Fatalf("unexpected error generating filtered CSV: %v", err)
+	}
+
+	csvData := storage.files[filePath]
+	reader := csv.NewReader(bytes.NewReader(csvData))
+	records, err := reader.ReadAll()
+	if err != nil {
+		t.Fatalf("failed to read CSV records: %v", err)
+	}
+
+	// Header (1) + Client Season 1 (1) = 2 rows
+	if len(records) != 2 {
+		t.Fatalf("expected 2 rows for season 1 filter, got %d", len(records))
+	}
+	if records[1][0] != "Cliente Evento 1" || records[1][5] != "Golden" {
+		t.Fatalf("unexpected record content: %v", records[1])
+	}
+
+	// Export PDF filtered by season 2
+	pdfBytes, err := svc.GenerateDirectClientsPDF(context.Background(), tenantID, season2)
+	if err != nil {
+		t.Fatalf("unexpected error generating filtered PDF: %v", err)
+	}
+	if len(pdfBytes) < 500 {
+		t.Fatalf("expected valid PDF bytes, got %d", len(pdfBytes))
 	}
 }

--- a/backend/internal/infrastructure/client/mongo/repository.go
+++ b/backend/internal/infrastructure/client/mongo/repository.go
@@ -212,13 +212,21 @@ func (r *repository) List(ctx context.Context, tenantID string, filter domain.Li
 	}, nil
 }
 
-func (r *repository) StreamByTenant(ctx context.Context, tenantID string, fn func(c *domain.SeasonClient) error) error {
+func (r *repository) StreamByTenant(ctx context.Context, tenantID, seasonID string, fn func(c *domain.SeasonClient) error) error {
 	cleanTenantID, err := mongoinfra.SanitizeID(tenantID)
 	if err != nil {
 		return err
 	}
 
 	filter := bson.D{{Key: "tenant_id", Value: cleanTenantID}}
+	if strings.TrimSpace(seasonID) != "" {
+		cleanSeasonID, err := mongoinfra.SanitizeID(seasonID)
+		if err != nil {
+			return err
+		}
+		filter = append(filter, bson.E{Key: "season_id", Value: cleanSeasonID})
+	}
+
 	cursor, err := r.collection.Find(ctx, filter)
 	if err != nil {
 		return err

--- a/backend/internal/interfaces/rest/handlers/report_handler.go
+++ b/backend/internal/interfaces/rest/handlers/report_handler.go
@@ -32,6 +32,7 @@ func NewReportHandler(service *reportusecase.Service, userRepo userport.Reposito
 // @Summary      Exportar relatório CSV de clientes
 // @Description  Inicia a extração assíncrona do relatório consolidado de clientes, cães, fotos e pagamentos do tenant autenticado e envia o link para o e-mail cadastrado
 // @Tags         Reports
+// @Param        season_id query string false "ID do evento para filtrar o relatório"
 // @Produce      json
 // @Success      202  {object}  httpx.SuccessEnvelope
 // @Failure      401  {object}  httpx.ErrorEnvelope "Não autenticado"
@@ -45,6 +46,8 @@ func (h *ReportHandler) ExportClientsCSV(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	seasonID := r.URL.Query().Get("season_id")
+
 	userID := middleware.GetUserID(r.Context())
 	var userEmail, userName string
 	if userID != "" && h.userRepo != nil {
@@ -56,14 +59,14 @@ func (h *ReportHandler) ExportClientsCSV(w http.ResponseWriter, r *http.Request)
 	}
 
 	// Launch async extraction job in background goroutine with detached context
-	go func(tID, uEmail, uName string) {
+	go func(tID, sID, uEmail, uName string) {
 		jobCtx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 		defer cancel()
 
-		if _, err := h.service.GenerateClientsCSV(jobCtx, tID, uEmail, uName); err != nil {
+		if _, err := h.service.GenerateClientsCSV(jobCtx, tID, sID, uEmail, uName); err != nil {
 			log.Printf("[REPORT-JOB-ERROR] Failed to generate clients CSV for tenant %s: %v", tID, err)
 		}
-	}(tenantID, userEmail, userName)
+	}(tenantID, seasonID, userEmail, userName)
 
 	httpx.Accepted(w, map[string]string{
 		"message": "Geração do relatório iniciada com sucesso. O arquivo CSV será enviado para o seu e-mail em instantes.",
@@ -74,6 +77,7 @@ func (h *ReportHandler) ExportClientsCSV(w http.ResponseWriter, r *http.Request)
 // @Summary      Exportar relatório CSV de clientes com pagamentos não pagos
 // @Description  Inicia a extração assíncrona do relatório de clientes e fotos com pagamentos não quitados ou pendentes do tenant autenticado e envia o link para o e-mail cadastrado
 // @Tags         Reports
+// @Param        season_id query string false "ID do evento para filtrar o relatório"
 // @Produce      json
 // @Success      202  {object}  httpx.SuccessEnvelope
 // @Failure      401  {object}  httpx.ErrorEnvelope "Não autenticado"
@@ -87,6 +91,8 @@ func (h *ReportHandler) ExportUnpaidClientsCSV(w http.ResponseWriter, r *http.Re
 		return
 	}
 
+	seasonID := r.URL.Query().Get("season_id")
+
 	userID := middleware.GetUserID(r.Context())
 	var userEmail, userName string
 	if userID != "" && h.userRepo != nil {
@@ -98,14 +104,14 @@ func (h *ReportHandler) ExportUnpaidClientsCSV(w http.ResponseWriter, r *http.Re
 	}
 
 	// Launch async extraction job in background goroutine with detached context
-	go func(tID, uEmail, uName string) {
+	go func(tID, sID, uEmail, uName string) {
 		jobCtx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 		defer cancel()
 
-		if _, err := h.service.GenerateUnpaidClientsCSV(jobCtx, tID, uEmail, uName); err != nil {
+		if _, err := h.service.GenerateUnpaidClientsCSV(jobCtx, tID, sID, uEmail, uName); err != nil {
 			log.Printf("[REPORT-JOB-ERROR] Failed to generate unpaid clients CSV for tenant %s: %v", tID, err)
 		}
-	}(tenantID, userEmail, userName)
+	}(tenantID, seasonID, userEmail, userName)
 
 	httpx.Accepted(w, map[string]string{
 		"message": "Geração do relatório iniciada com sucesso. O arquivo CSV será enviado para o seu e-mail em instantes.",
@@ -116,6 +122,7 @@ func (h *ReportHandler) ExportUnpaidClientsCSV(w http.ResponseWriter, r *http.Re
 // @Summary      Exportar relatório PDF de clientes
 // @Description  Inicia a extração assíncrona do relatório consolidado em PDF de clientes, cães e fotos para o tenant autenticado e envia o link para o e-mail cadastrado
 // @Tags         Reports
+// @Param        season_id query string false "ID do evento para filtrar o relatório"
 // @Produce      json
 // @Success      202  {object}  httpx.SuccessEnvelope
 // @Failure      401  {object}  httpx.ErrorEnvelope "Não autenticado"
@@ -129,6 +136,8 @@ func (h *ReportHandler) ExportClientsPDF(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	seasonID := r.URL.Query().Get("season_id")
+
 	userID := middleware.GetUserID(r.Context())
 	var userEmail, userName string
 	if userID != "" && h.userRepo != nil {
@@ -140,14 +149,14 @@ func (h *ReportHandler) ExportClientsPDF(w http.ResponseWriter, r *http.Request)
 	}
 
 	// Launch async extraction job in background goroutine with detached context
-	go func(tID, uEmail, uName string) {
+	go func(tID, sID, uEmail, uName string) {
 		jobCtx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 		defer cancel()
 
-		if _, err := h.service.GenerateClientsPDF(jobCtx, tID, uEmail, uName); err != nil {
+		if _, err := h.service.GenerateClientsPDF(jobCtx, tID, sID, uEmail, uName); err != nil {
 			log.Printf("[REPORT-JOB-ERROR] Failed to generate clients PDF for tenant %s: %v", tID, err)
 		}
-	}(tenantID, userEmail, userName)
+	}(tenantID, seasonID, userEmail, userName)
 
 	httpx.Accepted(w, map[string]string{
 		"message": "Geração do relatório em PDF iniciada com sucesso. O arquivo será enviado para o seu e-mail em instantes.",
@@ -158,6 +167,7 @@ func (h *ReportHandler) ExportClientsPDF(w http.ResponseWriter, r *http.Request)
 // @Summary      Download direto do relatório PDF de clientes
 // @Description  Gera e faz o download direto instantâneo do relatório consolidado em formato PDF
 // @Tags         Reports
+// @Param        season_id query string false "ID do evento para filtrar o relatório"
 // @Produce      application/pdf
 // @Success      200  {string}  string "Arquivo PDF"
 // @Failure      401  {object}  httpx.ErrorEnvelope "Não autenticado"
@@ -171,7 +181,9 @@ func (h *ReportHandler) DownloadDirectClientsPDF(w http.ResponseWriter, r *http.
 		return
 	}
 
-	pdfData, err := h.service.GenerateDirectClientsPDF(r.Context(), tenantID)
+	seasonID := r.URL.Query().Get("season_id")
+
+	pdfData, err := h.service.GenerateDirectClientsPDF(r.Context(), tenantID, seasonID)
 	if err != nil {
 		httpx.Error(w, http.StatusInternalServerError, "Falha ao gerar relatório PDF", nil)
 		return

--- a/frontend/src/features/clients/pages/ClientsPage.tsx
+++ b/frontend/src/features/clients/pages/ClientsPage.tsx
@@ -209,12 +209,12 @@ export const ClientsPage = () => {
     setReportMenuAnchor(null);
     setExportingReport(true);
     try {
-      const resp = await reportService.exportClientsCsv();
+      const resp = await reportService.exportClientsCsv(activeSeason?.id);
       setSnackbar({
         open: true,
         message:
           resp?.message ||
-          "Processamento do relatório iniciado! O link do arquivo será enviado para o seu e-mail cadastrado.",
+          "Processamento do relatório iniciado! O link do arquivo CSV será enviado para o seu e-mail cadastrado.",
         severity: "success",
       });
     } catch (err: any) {
@@ -234,26 +234,20 @@ export const ClientsPage = () => {
     setReportMenuAnchor(null);
     setExportingReport(true);
     try {
-      const blob = await reportService.downloadClientsPdfDirect();
-      const fileName = `clientes_${Math.floor(Date.now() / 1000)}.pdf`;
-      const blobUrl = window.URL.createObjectURL(blob);
-      const link = document.createElement("a");
-      link.href = blobUrl;
-      link.setAttribute("download", fileName);
-      document.body.appendChild(link);
-      link.click();
-      link.remove();
-      window.URL.revokeObjectURL(blobUrl);
-
+      const resp = await reportService.exportClientsPdf(activeSeason?.id);
       setSnackbar({
         open: true,
-        message: "Relatório PDF gerado e baixado com sucesso!",
+        message:
+          resp?.message ||
+          "Processamento do relatório em PDF iniciado! O link do arquivo será enviado para o seu e-mail cadastrado.",
         severity: "success",
       });
     } catch (err: any) {
       setSnackbar({
         open: true,
-        message: err?.response?.data?.message || "Erro ao gerar relatório PDF.",
+        message:
+          err?.response?.data?.message ||
+          "Erro ao solicitar exportação do relatório PDF.",
         severity: "error",
       });
     } finally {
@@ -265,7 +259,7 @@ export const ClientsPage = () => {
     setReportMenuAnchor(null);
     setExportingReport(true);
     try {
-      const resp = await reportService.exportUnpaidClientsCsv();
+      const resp = await reportService.exportUnpaidClientsCsv(activeSeason?.id);
       setSnackbar({
         open: true,
         message:

--- a/frontend/src/features/dashboard/pages/DashboardPage.tsx
+++ b/frontend/src/features/dashboard/pages/DashboardPage.tsx
@@ -103,12 +103,12 @@ export const DashboardPage = () => {
     setReportMenuAnchor(null);
     setExportingReport(true);
     try {
-      const resp = await reportService.exportClientsCsv();
+      const resp = await reportService.exportClientsCsv(activeSeason?.id);
       setSnackbar({
         open: true,
         message:
           resp?.message ||
-          "Processamento do relatório iniciado! O link do arquivo será enviado para o seu e-mail cadastrado.",
+          "Processamento do relatório iniciado! O link do arquivo CSV será enviado para o seu e-mail cadastrado.",
         severity: "success",
       });
     } catch (err: any) {
@@ -128,26 +128,20 @@ export const DashboardPage = () => {
     setReportMenuAnchor(null);
     setExportingReport(true);
     try {
-      const blob = await reportService.downloadClientsPdfDirect();
-      const fileName = `clientes_${Math.floor(Date.now() / 1000)}.pdf`;
-      const blobUrl = window.URL.createObjectURL(blob);
-      const link = document.createElement("a");
-      link.href = blobUrl;
-      link.setAttribute("download", fileName);
-      document.body.appendChild(link);
-      link.click();
-      link.remove();
-      window.URL.revokeObjectURL(blobUrl);
-
+      const resp = await reportService.exportClientsPdf(activeSeason?.id);
       setSnackbar({
         open: true,
-        message: "Relatório PDF gerado e baixado com sucesso!",
+        message:
+          resp?.message ||
+          "Processamento do relatório em PDF iniciado! O link do arquivo será enviado para o seu e-mail cadastrado.",
         severity: "success",
       });
     } catch (err: any) {
       setSnackbar({
         open: true,
-        message: err?.response?.data?.message || "Erro ao gerar relatório PDF.",
+        message:
+          err?.response?.data?.message ||
+          "Erro ao solicitar exportação do relatório PDF.",
         severity: "error",
       });
     } finally {
@@ -159,7 +153,7 @@ export const DashboardPage = () => {
     setReportMenuAnchor(null);
     setExportingReport(true);
     try {
-      const resp = await reportService.exportUnpaidClientsCsv();
+      const resp = await reportService.exportUnpaidClientsCsv(activeSeason?.id);
       setSnackbar({
         open: true,
         message:

--- a/frontend/src/services/api/report.service.ts
+++ b/frontend/src/services/api/report.service.ts
@@ -5,29 +5,42 @@ export interface ReportExportResponse {
 }
 
 export const reportService = {
-  exportClientsCsv: async (): Promise<ReportExportResponse> => {
+  exportClientsCsv: async (
+    seasonId?: string,
+  ): Promise<ReportExportResponse> => {
     const { data } = await apiClient.post<ReportExportResponse>(
       "/reports/clients-csv",
+      null,
+      { params: seasonId ? { season_id: seasonId } : undefined },
     );
     return data;
   },
 
-  exportUnpaidClientsCsv: async (): Promise<ReportExportResponse> => {
+  exportUnpaidClientsCsv: async (
+    seasonId?: string,
+  ): Promise<ReportExportResponse> => {
     const { data } = await apiClient.post<ReportExportResponse>(
       "/reports/unpaid-clients-csv",
+      null,
+      { params: seasonId ? { season_id: seasonId } : undefined },
     );
     return data;
   },
 
-  exportClientsPdf: async (): Promise<ReportExportResponse> => {
+  exportClientsPdf: async (
+    seasonId?: string,
+  ): Promise<ReportExportResponse> => {
     const { data } = await apiClient.post<ReportExportResponse>(
       "/reports/clients-pdf",
+      null,
+      { params: seasonId ? { season_id: seasonId } : undefined },
     );
     return data;
   },
 
-  downloadClientsPdfDirect: async (): Promise<Blob> => {
+  downloadClientsPdfDirect: async (seasonId?: string): Promise<Blob> => {
     const { data } = await apiClient.get<Blob>("/reports/clients-pdf", {
+      params: seasonId ? { season_id: seasonId } : undefined,
       responseType: "blob",
     });
     return data;


### PR DESCRIPTION
## 📌 Descrição

Este Pull Request adiciona o filtro por evento selecionado nas exportações e padroniza o envio do relatório em formato PDF por e-mail:

1. **Filtro de Evento nas Exportações**:
   - Todas as rotas de exportação (`/reports/clients-csv`, `/reports/unpaid-clients-csv`, `/reports/clients-pdf`) agora recebem o parâmetro `season_id` (`?season_id=...`).
   - O backend filtra a consulta de clientes no MongoDB trazendo **apenas os registros do evento ativo selecionado**. Caso nenhum evento seja especificado, exporta a listagem geral.
2. **Envio do Arquivo PDF por E-mail**:
   - A exportação em PDF agora é processada de forma assíncrona com notificação por e-mail, exatamente igual ao funcionamento dos relatórios `.csv`. O link seguro para download do PDF é enviado diretamente para o e-mail do usuário autenticado.

---

## 🚀 O que mudou

### 📄 1. Backend
- Atualizada a interface de repositório `StreamByTenant(ctx, tenantID, seasonID, fn)` e sua implementação em MongoDB para filtrar opcionalmente por `season_id`.
- Métodos do caso de uso `GenerateClientsCSV`, `GenerateUnpaidClientsCSV`, `GenerateClientsPDF` e `GenerateDirectClientsPDF` atualizados para receber `seasonID`.
- Handlers atualizados para ler o parâmetro `season_id` da query e documentados no Swagger.

### 💻 2. Frontend
- `reportService`: métodos `exportClientsCsv`, `exportUnpaidClientsCsv`, `exportClientsPdf` e `downloadClientsPdfDirect` atualizados para aceitar `seasonId` como parâmetro opcional.
- `DashboardPage` e `ClientsPage`: botões do menu de relatórios passam `activeSeason?.id` e exibem feedback de envio por e-mail para exportação em PDF.

---

## 🧪 Validação & Testes

- [x] `./scripts/swagger.sh` — Documentação OpenAPI regenerada com parâmetro `season_id`.
- [x] `./scripts/fix.sh` — Formatação e linters executados.
- [x] `./scripts/check.sh all` — 100% de sucesso (Backend: 11 pacotes de teste passando; Frontend: typecheck, lint e 61 testes passando).