### PR TITLE
fix(reports,frontend): corrigir erros de encoding e quebra no pdf e remover warnings de lint no frontend

### DIFF
--- a/backend/internal/application/usecase/report/service.go
+++ b/backend/internal/application/usecase/report/service.go
@@ -136,6 +136,13 @@ func formatJudges(photo *clientdomain.Photo) string {
 	return strings.Join(photo.Judges, ", ")
 }
 
+func formatJudgesPDF(photo *clientdomain.Photo) string {
+	if photo == nil || len(photo.Judges) == 0 {
+		return ""
+	}
+	return strings.Join(photo.Judges, "\n")
+}
+
 func formatIsOwner(isOwner *bool) string {
 	if isOwner != nil {
 		if *isOwner {
@@ -175,8 +182,9 @@ func (s *Service) GenerateClientsCSV(ctx context.Context, tenantID, seasonID, us
 	// 2. Cache persons dynamically during stream to avoid repeated identical queries
 	personCache := make(map[string]*persondomain.Person)
 
-	// 3. Prepare CSV buffer with updated headers
+	// 3. Prepare CSV buffer with UTF-8 BOM for Excel compatibility and updated headers
 	var buf bytes.Buffer
+	buf.WriteString("\xEF\xBB\xBF")
 	writer := csv.NewWriter(&buf)
 
 	headers := []string{
@@ -379,8 +387,9 @@ func (s *Service) GenerateUnpaidClientsCSV(ctx context.Context, tenantID, season
 	// 2. Cache persons dynamically during stream to avoid repeated identical queries
 	personCache := make(map[string]*persondomain.Person)
 
-	// 3. Prepare CSV buffer with headers
+	// 3. Prepare CSV buffer with UTF-8 BOM for Excel compatibility and headers
 	var buf bytes.Buffer
+	buf.WriteString("\xEF\xBB\xBF")
 	writer := csv.NewWriter(&buf)
 
 	headers := []string{
@@ -500,18 +509,90 @@ func (s *Service) GenerateUnpaidClientsCSV(ctx context.Context, tenantID, season
 	return relativePath, nil
 }
 
-func fitPdfText(pdf *fpdf.Fpdf, text string, maxWidth float64) string {
-	if pdf.GetStringWidth(text) <= maxWidth {
-		return text
+func renderPdfRow(pdf *fpdf.Fpdf, tr func(string) string, colWidths []float64, rowVals []string, aligns []string, lineHeight float64, pageHeight float64, bottomMargin float64) {
+	if tr == nil {
+		tr = func(s string) string { return s }
 	}
-	runes := []rune(text)
-	for len(runes) > 0 && pdf.GetStringWidth(string(runes)+"...") > maxWidth {
-		runes = runes[:len(runes)-1]
+
+	numCols := len(colWidths)
+	colLines := make([][]string, numCols)
+	maxLines := 1
+
+	for i := 0; i < numCols; i++ {
+		val := ""
+		if i < len(rowVals) {
+			val = rowVals[i]
+		}
+		if strings.TrimSpace(val) == "" {
+			colLines[i] = []string{""}
+			continue
+		}
+
+		usableWidth := colWidths[i] - 2.0
+		if usableWidth < 1.0 {
+			usableWidth = colWidths[i]
+		}
+
+		var lines []string
+		rawParts := strings.Split(val, "\n")
+		for _, part := range rawParts {
+			trimmedPart := strings.TrimSpace(part)
+			if trimmedPart == "" {
+				lines = append(lines, "")
+				continue
+			}
+			translated := tr(trimmedPart)
+			splitLines := pdf.SplitLines([]byte(translated), usableWidth)
+			if len(splitLines) == 0 {
+				lines = append(lines, translated)
+			} else {
+				for _, sl := range splitLines {
+					lines = append(lines, string(sl))
+				}
+			}
+		}
+
+		if len(lines) == 0 {
+			lines = []string{""}
+		}
+		colLines[i] = lines
+		if len(lines) > maxLines {
+			maxLines = len(lines)
+		}
 	}
-	if len(runes) == 0 {
-		return ""
+
+	rowHeight := float64(maxLines) * lineHeight
+
+	// Check page break (210mm A4 landscape - bottomMargin)
+	if pdf.GetY()+rowHeight > (pageHeight - bottomMargin) {
+		pdf.AddPage()
 	}
-	return string(runes) + "..."
+
+	startX := pdf.GetX()
+	startY := pdf.GetY()
+
+	// Draw each cell
+	currentX := startX
+	for i := 0; i < numCols; i++ {
+		align := "L"
+		if i < len(aligns) && aligns[i] != "" {
+			align = aligns[i]
+		}
+
+		// Draw border box
+		pdf.Rect(currentX, startY, colWidths[i], rowHeight, "D")
+
+		// Render text lines inside the cell
+		for lIdx, lineText := range colLines[i] {
+			pdf.SetXY(currentX+1.0, startY+float64(lIdx)*lineHeight)
+			pdf.CellFormat(colWidths[i]-2.0, lineHeight, lineText, "", 0, align, false, 0, "")
+		}
+
+		currentX += colWidths[i]
+	}
+
+	// Move cursor to bottom of the row
+	pdf.SetXY(startX, startY+rowHeight)
 }
 
 func (s *Service) buildClientsPDF(ctx context.Context, tenantID, seasonID string) ([]byte, error) {
@@ -553,11 +634,13 @@ func (s *Service) buildClientsPDF(ctx context.Context, tenantID, seasonID string
 	pdf.SetAutoPageBreak(true, 12)
 	tr := pdf.UnicodeTranslatorFromDescriptor("")
 
-	colWidths := []float64{32, 40, 24, 24, 12, 32, 38, 16, 23, 18, 18}
+	// Columns without "Dono" (Total = 277mm)
+	colWidths := []float64{32, 42, 24, 30, 36, 42, 16, 22, 16, 17}
 	colHeaders := []string{
-		"Nome", "E-mail", "Telefone", "Raça", "Dono", "Juiz",
+		"Nome", "E-mail", "Telefone", "Raça", "Juiz",
 		"Competições Vencidas", "Arquivo", "Forma de Pagamento", "Valor Pago", "Data da Foto",
 	}
+	aligns := []string{"L", "L", "L", "L", "L", "L", "C", "C", "C", "C"}
 
 	pdf.SetHeaderFunc(func() {
 		pdf.SetFont("Arial", "B", 12)
@@ -577,7 +660,7 @@ func (s *Service) buildClientsPDF(ctx context.Context, tenantID, seasonID string
 
 		for i, h := range colHeaders {
 			align := "L"
-			if i == 4 || i == 7 || i == 9 || i == 10 {
+			if aligns[i] == "C" {
 				align = "C"
 			}
 			pdf.CellFormat(colWidths[i], 6.5, tr(h), "1", 0, align, true, 0, "")
@@ -610,6 +693,11 @@ func (s *Service) buildClientsPDF(ctx context.Context, tenantID, seasonID string
 	pdf.SetFont("Arial", "", 7)
 	pdf.SetDrawColor(226, 232, 240) // border color #e2e8f0
 	pdf.SetLineWidth(0.15)
+	pdf.SetTextColor(30, 41, 59)
+
+	lineHeight := 4.2
+	pageHeight := 210.0
+	bottomMargin := 12.0
 
 	for cIdx, client := range clients {
 		p := personCache[client.PersonID]
@@ -619,23 +707,13 @@ func (s *Service) buildClientsPDF(ctx context.Context, tenantID, seasonID string
 		formattedPhone := FormatPhone(p.Phone)
 
 		if len(client.Dogs) == 0 {
-			pdf.SetTextColor(15, 23, 42)
 			rowVals := []string{
 				p.Name, p.Email, formattedPhone,
-				"-", "-", "-", "-", "-", "-", "-", "-",
+				"-", "-", "-", "-", "-", "-", "-",
 			}
-			for i, val := range rowVals {
-				align := "L"
-				if i == 4 || i == 7 || i == 9 || i == 10 {
-					align = "C"
-				}
-				fitted := fitPdfText(pdf, tr(val), colWidths[i]-2)
-				pdf.CellFormat(colWidths[i], 5.5, fitted, "1", 0, align, false, 0, "")
-			}
-			pdf.Ln(-1)
+			renderPdfRow(pdf, tr, colWidths, rowVals, aligns, lineHeight, pageHeight, bottomMargin)
 		} else {
 			for dIdx, dog := range client.Dogs {
-				isOwnerStr := formatIsOwner(dog.IsOwner)
 				wonComps := dog.WonCompetitions
 				if len(wonComps) == 0 && dog.CompetitionsWon > 0 {
 					wonComps = []string{"Sim"}
@@ -647,7 +725,7 @@ func (s *Service) buildClientsPDF(ctx context.Context, tenantID, seasonID string
 				}
 
 				for rIdx := 0; rIdx < totalRows; rIdx++ {
-					var colName, colEmail, colPhone, colBreed, colOwner, colJudge, colComp, colFile, colPayment, colAmount, colDate string
+					var colName, colEmail, colPhone, colBreed, colJudge, colComp, colFile, colPayment, colAmount, colDate string
 
 					// Show person info only on the very first row of the very first dog for this client
 					if dIdx == 0 && rIdx == 0 {
@@ -656,10 +734,9 @@ func (s *Service) buildClientsPDF(ctx context.Context, tenantID, seasonID string
 						colPhone = formattedPhone
 					}
 
-					// Show dog info only on the first row of this dog
+					// Show dog breed only on the first row of this dog
 					if rIdx == 0 {
 						colBreed = dog.Breed
-						colOwner = isOwnerStr
 					}
 
 					// Won competition on current row index
@@ -676,47 +753,29 @@ func (s *Service) buildClientsPDF(ctx context.Context, tenantID, seasonID string
 							colAmount = fmt.Sprintf("R$ %.2f", *photo.AmountPaid)
 						}
 						colDate = formatPhotoDate(&photo, client.CreatedAt)
-						colJudge = formatJudges(&photo)
+						colJudge = formatJudgesPDF(&photo)
 					}
 
-					pdf.SetTextColor(30, 41, 59)
 					rowVals := []string{
 						colName, colEmail, colPhone,
-						colBreed, colOwner, colJudge,
+						colBreed, colJudge,
 						colComp, colFile, colPayment, colAmount, colDate,
 					}
 
-					for i, val := range rowVals {
-						align := "L"
-						if i == 4 || i == 7 || i == 9 || i == 10 {
-							align = "C"
-						}
-						fitted := fitPdfText(pdf, tr(val), colWidths[i]-2)
-						pdf.CellFormat(colWidths[i], 5.5, fitted, "1", 0, align, false, 0, "")
-					}
-					pdf.Ln(-1)
-				}
-
-				// Draw a subtle line between dogs of the same client
-				if dIdx < len(client.Dogs)-1 {
-					pdf.SetDrawColor(203, 213, 225)
-					pdf.SetLineWidth(0.1)
-					x := pdf.GetX()
-					y := pdf.GetY()
-					pdf.Line(x+colWidths[0]+colWidths[1]+colWidths[2], y, x+277, y)
-					pdf.SetDrawColor(226, 232, 240)
-					pdf.SetLineWidth(0.15)
+					renderPdfRow(pdf, tr, colWidths, rowVals, aligns, lineHeight, pageHeight, bottomMargin)
 				}
 			}
 		}
 
-		// Draw a solid divider line between distinct clients
+		// Draw a solid divider line between distinct clients if not at the end
 		if cIdx < len(clients)-1 {
 			pdf.SetDrawColor(100, 116, 139)
 			pdf.SetLineWidth(0.35)
 			x := pdf.GetX()
 			y := pdf.GetY()
-			pdf.Line(x, y, x+277, y)
+			if y < (pageHeight - bottomMargin) {
+				pdf.Line(x, y, x+277, y)
+			}
 			pdf.SetDrawColor(226, 232, 240)
 			pdf.SetLineWidth(0.15)
 		}

--- a/backend/internal/application/usecase/report/service_test.go
+++ b/backend/internal/application/usecase/report/service_test.go
@@ -267,7 +267,11 @@ func TestGenerateClientsCSV_FullExpansionAndRules(t *testing.T) {
 		t.Fatalf("CSV data not saved in storage")
 	}
 
-	reader := csv.NewReader(bytes.NewReader(csvData))
+	if !bytes.HasPrefix(csvData, []byte("\xEF\xBB\xBF")) {
+		t.Fatalf("expected UTF-8 BOM at start of CSV file")
+	}
+
+	reader := csv.NewReader(bytes.NewReader(bytes.TrimPrefix(csvData, []byte("\xEF\xBB\xBF"))))
 	records, err := reader.ReadAll()
 	if err != nil {
 		t.Fatalf("failed to read parsed CSV records: %v", err)
@@ -618,7 +622,7 @@ func TestGenerateUnpaidClientsCSV(t *testing.T) {
 		t.Fatalf("CSV not saved in storage")
 	}
 
-	reader := csv.NewReader(bytes.NewReader(csvData))
+	reader := csv.NewReader(bytes.NewReader(bytes.TrimPrefix(csvData, []byte("\xEF\xBB\xBF"))))
 	records, err := reader.ReadAll()
 	if err != nil {
 		t.Fatalf("failed to parse CSV: %v", err)
@@ -725,7 +729,7 @@ func TestGenerateReports_FilterBySeasonID(t *testing.T) {
 	}
 
 	csvData := storage.files[filePath]
-	reader := csv.NewReader(bytes.NewReader(csvData))
+	reader := csv.NewReader(bytes.NewReader(bytes.TrimPrefix(csvData, []byte("\xEF\xBB\xBF"))))
 	records, err := reader.ReadAll()
 	if err != nil {
 		t.Fatalf("failed to read CSV records: %v", err)
@@ -746,5 +750,58 @@ func TestGenerateReports_FilterBySeasonID(t *testing.T) {
 	}
 	if len(pdfBytes) < 500 {
 		t.Fatalf("expected valid PDF bytes, got %d", len(pdfBytes))
+	}
+}
+
+func TestGenerateClientsPDF_MultiLineJudgesAndAccents(t *testing.T) {
+	tenantID := "tenant-accents"
+	amount := 250.0
+
+	clientRepo := &mockClientRepo{
+		clients: []*clientdomain.SeasonClient{
+			{
+				ID:       "client-1",
+				TenantID: tenantID,
+				PersonID: "person-1",
+				Dogs: []clientdomain.Dog{
+					{
+						Breed: "Pastor Alemão Capa Preta com Pedigree",
+						WonCompetitions: []string{
+							"Melhor Filhote Américas e Caribe 2026 - Exposição Internacional",
+							"Campeão Adulto Nacional de Criação",
+						},
+						Photos: []clientdomain.Photo{
+							{
+								FileNumber:     "IMG_9999",
+								PaymentMethod:  "Cartão de Crédito",
+								AmountPaid:     &amount,
+								Judges:         []string{"Dr. Thiago Lopes Moreira", "Norberto da Silva Castro", "José Maurício Medeiros Júnior"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	personRepo := &mockPersonRepo{
+		people: map[string]*persondomain.Person{
+			"person-1": {
+				ID:    "person-1",
+				Name:  "João da Silva Conceição & Família",
+				Email: "joao.conceicao@exemplo.com.br",
+				Phone: "11988887777",
+			},
+		},
+	}
+
+	svc := NewService(clientRepo, personRepo, &mockPhotographerRepo{}, &mockStorageProvider{}, &mockEmailSender{}, "http://localhost:8080")
+
+	pdfBytes, err := svc.GenerateDirectClientsPDF(context.Background(), tenantID, "")
+	if err != nil {
+		t.Fatalf("unexpected error generating PDF with accents: %v", err)
+	}
+	if !bytes.HasPrefix(pdfBytes, []byte("%PDF-")) {
+		t.Fatalf("expected PDF magic header %%PDF-")
 	}
 }

--- a/frontend/src/features/auth/pages/PendingApprovalPage.tsx
+++ b/frontend/src/features/auth/pages/PendingApprovalPage.tsx
@@ -21,7 +21,7 @@ export function PendingApprovalPage() {
   const handleLogout = async () => {
     try {
       await authService.logout();
-    } catch (e) {
+    } catch {
       // ignore
     } finally {
       clearAuth();

--- a/frontend/src/features/auth/pages/VerifyEmailPage.tsx
+++ b/frontend/src/features/auth/pages/VerifyEmailPage.tsx
@@ -24,7 +24,7 @@ export function VerifyEmailPage() {
   const token = searchParams.get("token") || "";
   const hasToken = Boolean(token.trim());
 
-  const { user, setUser, isAuthenticated } = useAuthStore();
+  const { setUser, isAuthenticated } = useAuthStore();
 
   const [loading, setLoading] = useState(hasToken);
   const [success, setSuccess] = useState(false);

--- a/frontend/src/features/clients/pages/ClientDetailsPage.tsx
+++ b/frontend/src/features/clients/pages/ClientDetailsPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import {
   Box,
@@ -34,6 +34,7 @@ import {
   clientService,
   SeasonClient,
   Photo,
+  Dog,
 } from "../../../services/api/client.service";
 import { personService, Person } from "../../../services/api/person.service";
 import {
@@ -70,7 +71,7 @@ export const ClientDetailsPage = () => {
     severity: "success",
   });
 
-  const load = async () => {
+  const load = useCallback(async () => {
     if (!id) return;
     try {
       const c = await clientService.getById(id);
@@ -85,11 +86,11 @@ export const ClientDetailsPage = () => {
       console.error(e);
       navigate("/clients");
     }
-  };
+  }, [id, navigate]);
 
   useEffect(() => {
     load();
-  }, [id]);
+  }, [load]);
 
   const handleSave = async () => {
     if (!client || !id) return;
@@ -175,7 +176,11 @@ export const ClientDetailsPage = () => {
     setClient({ ...client, dogs: newDogs });
   };
 
-  const updateDog = (index: number, field: string, value: any) => {
+  const updateDog = <K extends keyof Dog>(
+    index: number,
+    field: K,
+    value: Dog[K],
+  ) => {
     if (!client) return;
     const newDogs = [...client.dogs];
     newDogs[index] = { ...newDogs[index], [field]: value };
@@ -205,11 +210,11 @@ export const ClientDetailsPage = () => {
     setClient({ ...client, dogs: newDogs });
   };
 
-  const updatePhoto = (
+  const updatePhoto = <K extends keyof Photo>(
     dogIndex: number,
     photoIndex: number,
-    field: string,
-    value: any,
+    field: K,
+    value: Photo[K],
   ) => {
     if (!client) return;
     const newDogs = [...client.dogs];

--- a/frontend/src/features/clients/pages/ClientsPage.tsx
+++ b/frontend/src/features/clients/pages/ClientsPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 import {
   Box,
@@ -85,7 +85,7 @@ export const ClientsPage = () => {
     severity: "success",
   });
 
-  const load = async () => {
+  const load = useCallback(async () => {
     if (!activeSeason) return;
     const [cRes, pData, photogData] = await Promise.all([
       clientService.list({ season_id: activeSeason.id, limit: 100 }),
@@ -95,11 +95,11 @@ export const ClientsPage = () => {
     setClients(cRes?.data || []);
     setPeople(pData || []);
     setPhotographers(photogData || []);
-  };
+  }, [activeSeason]);
 
   useEffect(() => {
     load();
-  }, [activeSeason]);
+  }, [load]);
 
   const handleSave = async () => {
     if (!activeSeason) return;
@@ -158,7 +158,11 @@ export const ClientsPage = () => {
     setDogs(newDogs);
   };
 
-  const updateDog = (index: number, field: string, value: any) => {
+  const updateDog = <K extends keyof Dog>(
+    index: number,
+    field: K,
+    value: Dog[K],
+  ) => {
     const newDogs = [...dogs];
     newDogs[index] = { ...newDogs[index], [field]: value };
     setDogs(newDogs);
@@ -185,11 +189,11 @@ export const ClientsPage = () => {
     setDogs(newDogs);
   };
 
-  const updatePhoto = (
+  const updatePhoto = <K extends keyof Photo>(
     dogIndex: number,
     photoIndex: number,
-    field: string,
-    value: any,
+    field: K,
+    value: Photo[K],
   ) => {
     const newDogs = [...dogs];
     newDogs[dogIndex].photos[photoIndex] = {
@@ -217,11 +221,12 @@ export const ClientsPage = () => {
           "Processamento do relatório iniciado! O link do arquivo CSV será enviado para o seu e-mail cadastrado.",
         severity: "success",
       });
-    } catch (err: any) {
+    } catch (err: unknown) {
+      const errorObj = err as { response?: { data?: { message?: string } } };
       setSnackbar({
         open: true,
         message:
-          err?.response?.data?.message ||
+          errorObj?.response?.data?.message ||
           "Erro ao solicitar exportação do relatório CSV.",
         severity: "error",
       });
@@ -242,11 +247,12 @@ export const ClientsPage = () => {
           "Processamento do relatório em PDF iniciado! O link do arquivo será enviado para o seu e-mail cadastrado.",
         severity: "success",
       });
-    } catch (err: any) {
+    } catch (err: unknown) {
+      const errorObj = err as { response?: { data?: { message?: string } } };
       setSnackbar({
         open: true,
         message:
-          err?.response?.data?.message ||
+          errorObj?.response?.data?.message ||
           "Erro ao solicitar exportação do relatório PDF.",
         severity: "error",
       });
@@ -267,11 +273,12 @@ export const ClientsPage = () => {
           "Processamento do relatório iniciado! O link do arquivo será enviado para o seu e-mail cadastrado.",
         severity: "success",
       });
-    } catch (err: any) {
+    } catch (err: unknown) {
+      const errorObj = err as { response?: { data?: { message?: string } } };
       setSnackbar({
         open: true,
         message:
-          err?.response?.data?.message ||
+          errorObj?.response?.data?.message ||
           "Erro ao solicitar exportação do relatório.",
         severity: "error",
       });

--- a/frontend/src/features/dashboard/pages/DashboardPage.tsx
+++ b/frontend/src/features/dashboard/pages/DashboardPage.tsx
@@ -111,11 +111,12 @@ export const DashboardPage = () => {
           "Processamento do relatório iniciado! O link do arquivo CSV será enviado para o seu e-mail cadastrado.",
         severity: "success",
       });
-    } catch (err: any) {
+    } catch (err: unknown) {
+      const errorObj = err as { response?: { data?: { message?: string } } };
       setSnackbar({
         open: true,
         message:
-          err?.response?.data?.message ||
+          errorObj?.response?.data?.message ||
           "Erro ao solicitar exportação do relatório CSV.",
         severity: "error",
       });
@@ -136,11 +137,12 @@ export const DashboardPage = () => {
           "Processamento do relatório em PDF iniciado! O link do arquivo será enviado para o seu e-mail cadastrado.",
         severity: "success",
       });
-    } catch (err: any) {
+    } catch (err: unknown) {
+      const errorObj = err as { response?: { data?: { message?: string } } };
       setSnackbar({
         open: true,
         message:
-          err?.response?.data?.message ||
+          errorObj?.response?.data?.message ||
           "Erro ao solicitar exportação do relatório PDF.",
         severity: "error",
       });
@@ -161,11 +163,12 @@ export const DashboardPage = () => {
           "Processamento do relatório iniciado! O link do arquivo será enviado para o seu e-mail cadastrado.",
         severity: "success",
       });
-    } catch (err: any) {
+    } catch (err: unknown) {
+      const errorObj = err as { response?: { data?: { message?: string } } };
       setSnackbar({
         open: true,
         message:
-          err?.response?.data?.message ||
+          errorObj?.response?.data?.message ||
           "Erro ao solicitar exportação do relatório.",
         severity: "error",
       });

--- a/frontend/src/features/people/pages/PersonDetailsPage.tsx
+++ b/frontend/src/features/people/pages/PersonDetailsPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo, useCallback } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import {
   Box,
@@ -188,7 +188,7 @@ export const PersonDetailsPage = () => {
     setSnackbar({ open: true, message, severity });
   };
 
-  const loadData = async () => {
+  const loadData = useCallback(async () => {
     if (!id) return;
     setLoading(true);
     try {
@@ -221,11 +221,11 @@ export const PersonDetailsPage = () => {
     } finally {
       setLoading(false);
     }
-  };
+  }, [id, activeSeason]);
 
   useEffect(() => {
     loadData();
-  }, [id, activeSeason?.id]);
+  }, [loadData]);
 
   // Ensure selected dog index is within bounds
   const dogsList = client?.dogs || [];

--- a/frontend/src/features/profile/pages/ProfilePage.tsx
+++ b/frontend/src/features/profile/pages/ProfilePage.tsx
@@ -10,7 +10,6 @@ import {
   Stack,
   Alert,
   Chip,
-  LinearProgress,
   Divider,
   InputAdornment,
   IconButton,

--- a/frontend/src/layouts/Topbar.tsx
+++ b/frontend/src/layouts/Topbar.tsx
@@ -41,11 +41,12 @@ export function Topbar({ onDrawerToggle }: TopbarProps) {
         const seasonList = data || [];
         setSeasons(seasonList);
         if (seasonList.length > 0) {
-          if (!activeSeason) {
+          const currentActive = useSeasonStore.getState().activeSeason;
+          if (!currentActive) {
             setActiveSeason(seasonList[0]);
           } else {
             // Keep active season updated with latest judges
-            const found = seasonList.find((x) => x.id === activeSeason.id);
+            const found = seasonList.find((x) => x.id === currentActive.id);
             if (found) {
               setActiveSeason(found);
             }


### PR DESCRIPTION
### Resumo das Alterações

1. **Relatórios Backend (PDF & CSV)**:
   - **Encoding & Quebra de Linha em PDF**:
     - Correção do bug de codificação de caracteres acentuados (`ç`, `é`, `ã`, `ê`, etc.) que causava o surgimento de `ï¿½` ao truncar textos.
     - Remoção da coluna de "Dono" conforme solicitado, otimizando o espaçamento das demais colunas na folha A4 em modo paisagem.
     - Implementação de renderização multi-linha dinâmica (`renderPdfRow` com `SplitLines`): caso o conteúdo de qualquer célula exceda a largura ou contenha quebras de linha (`\n`), a altura da linha é expandida automaticamente para que **nenhum dado seja cortado**.
     - Formatação de múltiplos juízes para que cada juiz seja exibido em sua própria linha.
   - **CSV com UTF-8 BOM**:
     - Inclusão de UTF-8 BOM (`\xef\xbb\xbf`) nos relatórios CSV (`GenerateClientsCSV` e `GenerateUnpaidClientsCSV`) para abertura direta e correta no Microsoft Excel.

2. **Frontend Lint & Tipagem Estrita**:
   - Correção de todos os 17 warnings apontados pelo ESLint:
     - Eliminação de tipos `any` em `ClientDetailsPage`, `ClientsPage` e `DashboardPage`.
     - Envolvimento de funções de carregamento em `useCallback` e correção de dependências de `useEffect`.
     - Remoção de variáveis e imports não utilizados (`PendingApprovalPage`, `VerifyEmailPage`, `ProfilePage`).
     - Resolução do warning de dependência em `Topbar.tsx` utilizando `useSeasonStore.getState().activeSeason`.

---

### Validações Executadas
- [x] `./scripts/check.sh all` (Backend Vet & 11 pacotes de testes OK, Frontend Typecheck, Lint, Format & Testes OK, Terraform Fmt OK).
- [x] Testes unitários de geração de PDF e CSV com suporte a acentos e multi-linhas validados.