### PR TITLE
feat(dashboard): mover botoes vincular cliente e nova pessoa para a tabela de clientes e competidores (#53)

### DIFF
--- a/backend/internal/application/usecase/report/service_test.go
+++ b/backend/internal/application/usecase/report/service_test.go
@@ -772,10 +772,10 @@ func TestGenerateClientsPDF_MultiLineJudgesAndAccents(t *testing.T) {
 						},
 						Photos: []clientdomain.Photo{
 							{
-								FileNumber:     "IMG_9999",
-								PaymentMethod:  "Cartão de Crédito",
-								AmountPaid:     &amount,
-								Judges:         []string{"Dr. Thiago Lopes Moreira", "Norberto da Silva Castro", "José Maurício Medeiros Júnior"},
+								FileNumber:    "IMG_9999",
+								PaymentMethod: "Cartão de Crédito",
+								AmountPaid:    &amount,
+								Judges:        []string{"Dr. Thiago Lopes Moreira", "Norberto da Silva Castro", "José Maurício Medeiros Júnior"},
 							},
 						},
 					},

--- a/frontend/src/features/dashboard/pages/DashboardPage.test.tsx
+++ b/frontend/src/features/dashboard/pages/DashboardPage.test.tsx
@@ -268,4 +268,34 @@ describe("DashboardPage", () => {
       ).toBeInTheDocument();
     });
   });
+
+  it("opens quick create person modal when clicking Nova Pessoa", async () => {
+    useSeasonStore.setState({
+      activeSeason: { id: "season-1", name: "Temporada 2026" },
+    });
+
+    vi.spyOn(clientService, "list").mockResolvedValue({
+      data: [],
+      total: 0,
+      page: 1,
+      limit: 10,
+    });
+    vi.spyOn(personService, "list").mockResolvedValue([]);
+    vi.spyOn(photographerService, "list").mockResolvedValue([]);
+
+    render(
+      <BrowserRouter>
+        <DashboardPage />
+      </BrowserRouter>,
+    );
+
+    const novaPessoaBtn = screen.getByRole("button", {
+      name: /Nova Pessoa/i,
+    });
+    fireEvent.click(novaPessoaBtn);
+
+    await waitFor(() => {
+      expect(screen.getByText("Cadastrar Nova Pessoa")).toBeInTheDocument();
+    });
+  });
 });

--- a/frontend/src/features/dashboard/pages/DashboardPage.tsx
+++ b/frontend/src/features/dashboard/pages/DashboardPage.tsx
@@ -372,37 +372,20 @@ export const DashboardPage = () => {
             }}
           >
             {activeSeason ? (
-              <>
-                <Chip
-                  icon={<EventNoteRoundedIcon style={{ color: "#38bdf8" }} />}
-                  label={`Evento: ${activeSeason.name}`}
-                  sx={{
-                    bgcolor: "rgba(56, 189, 248, 0.15)",
-                    color: "#38bdf8",
-                    fontWeight: 700,
-                    fontSize: "0.95rem",
-                    py: 2.2,
-                    px: 1,
-                    borderRadius: 2,
-                    border: "1px solid rgba(56, 189, 248, 0.3)",
-                  }}
-                />
-                <Button
-                  variant="contained"
-                  startIcon={<AddIcon />}
-                  onClick={() => setLinkModalOpen(true)}
-                  sx={{
-                    bgcolor: "primary.main",
-                    "&:hover": { bgcolor: "primary.dark" },
-                    borderRadius: 2,
-                    textTransform: "none",
-                    fontWeight: 700,
-                    px: 2.5,
-                  }}
-                >
-                  Vincular Cliente
-                </Button>
-              </>
+              <Chip
+                icon={<EventNoteRoundedIcon style={{ color: "#38bdf8" }} />}
+                label={`Evento: ${activeSeason.name}`}
+                sx={{
+                  bgcolor: "rgba(56, 189, 248, 0.15)",
+                  color: "#38bdf8",
+                  fontWeight: 700,
+                  fontSize: "0.95rem",
+                  py: 2.2,
+                  px: 1,
+                  borderRadius: 2,
+                  border: "1px solid rgba(56, 189, 248, 0.3)",
+                }}
+              />
             ) : (
               <Chip
                 label="Selecione um evento no menu superior"
@@ -463,25 +446,6 @@ export const DashboardPage = () => {
                 Exportar Não Pagos (.csv)
               </MenuItem>
             </Menu>
-
-            <Button
-              variant="outlined"
-              startIcon={<PersonAddAlt1Icon />}
-              onClick={() => setNewPersonOpen(true)}
-              sx={{
-                borderColor: "rgba(255,255,255,0.4)",
-                color: "white",
-                "&:hover": {
-                  borderColor: "white",
-                  bgcolor: "rgba(255,255,255,0.08)",
-                },
-                borderRadius: 2,
-                textTransform: "none",
-                fontWeight: 600,
-              }}
-            >
-              Nova Pessoa
-            </Button>
           </Box>
         </Box>
       </Paper>
@@ -747,22 +711,63 @@ export const DashboardPage = () => {
               </Typography>
             </Box>
 
-            <TextField
-              size="small"
-              placeholder="Buscar por pessoa, cão ou número da foto..."
-              value={searchTerm}
-              onChange={(e) => setSearchTerm(e.target.value)}
-              sx={{ width: { xs: "100%", sm: 380 } }}
-              slotProps={{
-                input: {
-                  startAdornment: (
-                    <InputAdornment position="start">
-                      <SearchIcon color="action" />
-                    </InputAdornment>
-                  ),
-                },
+            <Box
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                flexWrap: "wrap",
+                gap: 1.5,
+                width: { xs: "100%", md: "auto" },
               }}
-            />
+            >
+              <TextField
+                size="small"
+                placeholder="Buscar por pessoa, cão ou número da foto..."
+                value={searchTerm}
+                onChange={(e) => setSearchTerm(e.target.value)}
+                sx={{ width: { xs: "100%", sm: 280, md: 340 } }}
+                slotProps={{
+                  input: {
+                    startAdornment: (
+                      <InputAdornment position="start">
+                        <SearchIcon color="action" />
+                      </InputAdornment>
+                    ),
+                  },
+                }}
+              />
+              <Button
+                variant="contained"
+                startIcon={<AddIcon />}
+                onClick={() => setLinkModalOpen(true)}
+                disabled={!activeSeason}
+                sx={{
+                  bgcolor: "primary.main",
+                  "&:hover": { bgcolor: "primary.dark" },
+                  borderRadius: 2,
+                  textTransform: "none",
+                  fontWeight: 700,
+                  px: 2,
+                  whiteSpace: "nowrap",
+                }}
+              >
+                Vincular Cliente
+              </Button>
+              <Button
+                variant="outlined"
+                startIcon={<PersonAddAlt1Icon />}
+                onClick={() => setNewPersonOpen(true)}
+                sx={{
+                  borderRadius: 2,
+                  textTransform: "none",
+                  fontWeight: 600,
+                  px: 2,
+                  whiteSpace: "nowrap",
+                }}
+              >
+                Nova Pessoa
+              </Button>
+            </Box>
           </Box>
 
           {/* Table Content */}


### PR DESCRIPTION
## Resumo das Alterações
- Removeu os botões "Vincular Cliente" e "Nova Pessoa" do cabeçalho superior (`Visão Geral`) do Dashboard, mantendo-o limpo e focado no Chip do evento ativo e no menu de Relatórios.
- Adicionou os botões "Vincular Cliente" (destaque/`contained`) e "Nova Pessoa" (`outlined`) diretamente na barra de ferramentas da tabela de "Clientes e Competidores", ao lado do campo de busca.
- Configurou layout flexbox responsivo com `flexWrap: wrap` e larguras fluidas para adaptação em telas menores (mobile e tablet).
- Atualizou e adicionou testes unitários em `DashboardPage.test.tsx` para assegurar o funcionamento dos botões e abertura dos respectivos modais.

Closes #53

## Checklist de Validação
- [x] `./scripts/check.sh frontend` (TypeScript, ESLint, Prettier e Vitest aprovados com sucesso)
- [x] `./scripts/check.sh all` (Backend, Frontend e Terraform aprovados)