### PR TITLE
feat(dashboard): mudar nome do botao detalhes para editar dados na visao geral (#52)

### DIFF
--- a/frontend/src/features/dashboard/pages/DashboardPage.test.tsx
+++ b/frontend/src/features/dashboard/pages/DashboardPage.test.tsx
@@ -130,7 +130,7 @@ describe("DashboardPage", () => {
     ).toBeGreaterThanOrEqual(1);
     expect(screen.getByText("Fotos Registradas")).toBeInTheDocument();
     expect(screen.getByText("Cachorros & Fotos")).toBeInTheDocument();
-    expect(screen.getByText("Detalhes")).toBeInTheDocument();
+    expect(screen.getByText("Editar Dados")).toBeInTheDocument();
   });
 
   it("triggers search and shows empty search state when no results", async () => {
@@ -296,6 +296,7 @@ describe("DashboardPage", () => {
 
     await waitFor(() => {
       expect(screen.getByText("Cadastrar Nova Pessoa")).toBeInTheDocument();
+      expect(screen.getByText("Salvar e Editar Dados")).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/features/dashboard/pages/DashboardPage.tsx
+++ b/frontend/src/features/dashboard/pages/DashboardPage.tsx
@@ -40,7 +40,7 @@ import AddIcon from "@mui/icons-material/Add";
 import PersonAddAlt1Icon from "@mui/icons-material/PersonAddAlt1";
 import EventNoteRoundedIcon from "@mui/icons-material/EventNoteRounded";
 import PeopleOutlineRoundedIcon from "@mui/icons-material/PeopleOutlineRounded";
-import VisibilityRoundedIcon from "@mui/icons-material/VisibilityRounded";
+import EditRoundedIcon from "@mui/icons-material/EditRounded";
 import AssessmentIcon from "@mui/icons-material/Assessment";
 import FileDownloadIcon from "@mui/icons-material/FileDownload";
 import PictureAsPdfIcon from "@mui/icons-material/PictureAsPdf";
@@ -1016,7 +1016,7 @@ export const DashboardPage = () => {
                               <Button
                                 size="small"
                                 variant="outlined"
-                                startIcon={<VisibilityRoundedIcon />}
+                                startIcon={<EditRoundedIcon />}
                                 onClick={(e) => {
                                   e.stopPropagation();
                                   handleOpenDetails(client.id);
@@ -1026,7 +1026,7 @@ export const DashboardPage = () => {
                                   textTransform: "none",
                                 }}
                               >
-                                Detalhes
+                                Editar Dados
                               </Button>
                             </Box>
                           </TableCell>
@@ -1144,7 +1144,7 @@ export const DashboardPage = () => {
             disabled={!newPersonForm.name.trim()}
             sx={{ textTransform: "none", fontWeight: 600 }}
           >
-            Salvar e Abrir Detalhes
+            Salvar e Editar Dados
           </Button>
         </DialogActions>
       </Dialog>


### PR DESCRIPTION
### 📝 Resumo das Alterações
- Renomeado o botão de ação secundário na listagem de clientes da página de **Visão Geral** (`DashboardPage.tsx`) de `"Detalhes"` para `"Editar Dados"`.
- Substituído o ícone do botão para `EditRoundedIcon` (`@mui/icons-material/EditRounded`) para refletir a ação de edição.
- Atualizado o rótulo do botão no modal de cadastro rápido de pessoa (`DashboardPage.tsx`) de `"Salvar e Abrir Detalhes"` para `"Salvar e Editar Dados"`.
- Atualizados e expandidos os testes de componente em `DashboardPage.test.tsx` para cobrir a nova rotulagem.

### 🔗 Referência
Closes #52

### 🧪 Checklist de Validação
- [x] `./scripts/check.sh all` (Backend vet + unit tests, Frontend typecheck, lint, format & vitest, Terraform fmt)