### PR TITLE
feat(seasons): exclusao de eventos com remocao assincrona em cascata de entidades dependentes

### DIFF
--- a/backend/internal/application/ports/client/repository.go
+++ b/backend/internal/application/ports/client/repository.go
@@ -12,4 +12,5 @@ type Repository interface {
 	StreamByTenant(ctx context.Context, tenantID, seasonID string, fn func(c *client.SeasonClient) error) error
 	Update(ctx context.Context, client *client.SeasonClient) error
 	Delete(ctx context.Context, id, tenantID string) error
+	DeleteBySeasonID(ctx context.Context, seasonID, tenantID string) error
 }

--- a/backend/internal/application/usecase/client/service_test.go
+++ b/backend/internal/application/usecase/client/service_test.go
@@ -93,6 +93,15 @@ func (m *mockRepo) Delete(ctx context.Context, id, tenantID string) error {
 	return nil
 }
 
+func (m *mockRepo) DeleteBySeasonID(ctx context.Context, seasonID, tenantID string) error {
+	for id, c := range m.items {
+		if c.TenantID == tenantID && c.SeasonID == seasonID {
+			delete(m.items, id)
+		}
+	}
+	return nil
+}
+
 type mockPersonRepo struct {
 	items map[string]*persondomain.Person
 }

--- a/backend/internal/application/usecase/report/service_test.go
+++ b/backend/internal/application/usecase/report/service_test.go
@@ -47,6 +47,9 @@ func (m *mockClientRepo) Update(ctx context.Context, client *clientdomain.Season
 func (m *mockClientRepo) Delete(ctx context.Context, id, tenantID string) error {
 	return nil
 }
+func (m *mockClientRepo) DeleteBySeasonID(ctx context.Context, seasonID, tenantID string) error {
+	return nil
+}
 
 type mockPersonRepo struct {
 	people map[string]*persondomain.Person

--- a/backend/internal/application/usecase/season/service.go
+++ b/backend/internal/application/usecase/season/service.go
@@ -2,16 +2,24 @@ package season
 
 import (
 	"context"
+	"log"
+	"time"
+
+	clientport "ps/internal/application/ports/client"
 	"ps/internal/application/ports/season"
 	domain "ps/internal/domain/season"
 )
 
 type Service struct {
-	repo season.Repository
+	repo       season.Repository
+	clientRepo clientport.Repository
 }
 
-func NewService(repo season.Repository) *Service {
-	return &Service{repo: repo}
+func NewService(repo season.Repository, clientRepo clientport.Repository) *Service {
+	return &Service{
+		repo:       repo,
+		clientRepo: clientRepo,
+	}
 }
 
 func (s *Service) Create(ctx context.Context, season *domain.Season, tenantID string) error {
@@ -33,5 +41,20 @@ func (s *Service) Update(ctx context.Context, season *domain.Season, tenantID st
 }
 
 func (s *Service) Delete(ctx context.Context, id, tenantID string) error {
-	return s.repo.Delete(ctx, id, tenantID)
+	if err := s.repo.Delete(ctx, id, tenantID); err != nil {
+		return err
+	}
+
+	if s.clientRepo != nil {
+		go func(seasonID, tID string) {
+			bgCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+			defer cancel()
+
+			if err := s.clientRepo.DeleteBySeasonID(bgCtx, seasonID, tID); err != nil {
+				log.Printf("[SEASON-CASCADE-DELETE-ERROR] Failed to cascade delete clients for season %s (tenant %s): %v", seasonID, tID, err)
+			}
+		}(id, tenantID)
+	}
+
+	return nil
 }

--- a/backend/internal/application/usecase/season/service_test.go
+++ b/backend/internal/application/usecase/season/service_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"ps/internal/application/usecase/season"
+	clientdomain "ps/internal/domain/client"
 	domain "ps/internal/domain/season"
 )
 
@@ -61,9 +63,74 @@ func (m *mockRepo) Delete(ctx context.Context, id, tenantID string) error {
 	return nil
 }
 
+type mockClientRepo struct {
+	items map[string]*clientdomain.SeasonClient
+}
+
+func newMockClientRepo() *mockClientRepo {
+	return &mockClientRepo{items: make(map[string]*clientdomain.SeasonClient)}
+}
+
+func (m *mockClientRepo) Create(ctx context.Context, c *clientdomain.SeasonClient) error {
+	m.items[c.ID] = c
+	return nil
+}
+
+func (m *mockClientRepo) GetByID(ctx context.Context, id, tenantID string) (*clientdomain.SeasonClient, error) {
+	c, ok := m.items[id]
+	if !ok || c.TenantID != tenantID {
+		return nil, errors.New("not found")
+	}
+	return c, nil
+}
+
+func (m *mockClientRepo) List(ctx context.Context, tenantID string, filter clientdomain.ListFilter) (*clientdomain.PaginatedClients, error) {
+	var data []*clientdomain.SeasonClient
+	for _, c := range m.items {
+		if c.TenantID == tenantID && (filter.SeasonID == "" || c.SeasonID == filter.SeasonID) {
+			data = append(data, c)
+		}
+	}
+	return &clientdomain.PaginatedClients{
+		Data:  data,
+		Total: int64(len(data)),
+	}, nil
+}
+
+func (m *mockClientRepo) StreamByTenant(ctx context.Context, tenantID, seasonID string, fn func(c *clientdomain.SeasonClient) error) error {
+	for _, c := range m.items {
+		if c.TenantID == tenantID && (seasonID == "" || c.SeasonID == seasonID) {
+			if err := fn(c); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (m *mockClientRepo) Update(ctx context.Context, c *clientdomain.SeasonClient) error {
+	m.items[c.ID] = c
+	return nil
+}
+
+func (m *mockClientRepo) Delete(ctx context.Context, id, tenantID string) error {
+	delete(m.items, id)
+	return nil
+}
+
+func (m *mockClientRepo) DeleteBySeasonID(ctx context.Context, seasonID, tenantID string) error {
+	for id, c := range m.items {
+		if c.TenantID == tenantID && c.SeasonID == seasonID {
+			delete(m.items, id)
+		}
+	}
+	return nil
+}
+
 func TestSeasonService(t *testing.T) {
 	repo := newMockRepo()
-	svc := season.NewService(repo)
+	clientRepo := newMockClientRepo()
+	svc := season.NewService(repo, clientRepo)
 	ctx := context.Background()
 	tenantID := "tenant-xyz"
 
@@ -113,11 +180,34 @@ func TestSeasonService(t *testing.T) {
 		t.Fatalf("expected updated season, got %v", updated)
 	}
 
-	// 5. Delete
+	// Add dependent clients for this season, another season, and another tenant
+	clientRepo.Create(ctx, &clientdomain.SeasonClient{ID: "client-1", TenantID: tenantID, SeasonID: s.ID})
+	clientRepo.Create(ctx, &clientdomain.SeasonClient{ID: "client-2", TenantID: tenantID, SeasonID: s.ID})
+	clientRepo.Create(ctx, &clientdomain.SeasonClient{ID: "client-other-season", TenantID: tenantID, SeasonID: "other-season"})
+	clientRepo.Create(ctx, &clientdomain.SeasonClient{ID: "client-other-tenant", TenantID: "other-tenant", SeasonID: s.ID})
+
+	// 5. Delete (with cascade in background)
 	if err := svc.Delete(ctx, s.ID, tenantID); err != nil {
 		t.Fatalf("unexpected error on Delete: %v", err)
 	}
 	if _, err := svc.GetByID(ctx, s.ID, tenantID); err == nil {
 		t.Fatalf("expected error after delete, got nil")
+	}
+
+	// Give background goroutine a moment to complete
+	time.Sleep(50 * time.Millisecond)
+
+	// Check cascade deletion: client-1 and client-2 must be removed, other clients must remain
+	if _, err := clientRepo.GetByID(ctx, "client-1", tenantID); err == nil {
+		t.Fatalf("expected client-1 to be cascade deleted")
+	}
+	if _, err := clientRepo.GetByID(ctx, "client-2", tenantID); err == nil {
+		t.Fatalf("expected client-2 to be cascade deleted")
+	}
+	if _, err := clientRepo.GetByID(ctx, "client-other-season", tenantID); err != nil {
+		t.Fatalf("expected client-other-season to remain, got err: %v", err)
+	}
+	if _, err := clientRepo.GetByID(ctx, "client-other-tenant", "other-tenant"); err != nil {
+		t.Fatalf("expected client-other-tenant to remain, got err: %v", err)
 	}
 }

--- a/backend/internal/infrastructure/client/mongo/repository.go
+++ b/backend/internal/infrastructure/client/mongo/repository.go
@@ -296,3 +296,21 @@ func (r *repository) Delete(ctx context.Context, id, tenantID string) error {
 	_, err = r.collection.DeleteOne(ctx, filter)
 	return err
 }
+
+func (r *repository) DeleteBySeasonID(ctx context.Context, seasonID, tenantID string) error {
+	cleanSeasonID, err := mongoinfra.SanitizeID(seasonID)
+	if err != nil {
+		return err
+	}
+	cleanTenantID, err := mongoinfra.SanitizeID(tenantID)
+	if err != nil {
+		return err
+	}
+
+	filter := bson.D{
+		{Key: "season_id", Value: cleanSeasonID},
+		{Key: "tenant_id", Value: cleanTenantID},
+	}
+	_, err = r.collection.DeleteMany(ctx, filter)
+	return err
+}

--- a/backend/internal/interfaces/rest/router.go
+++ b/backend/internal/interfaces/rest/router.go
@@ -55,7 +55,7 @@ func NewRouter(
 	adminSvc := adminusecase.NewService(users, tenants)
 	adminHandler := handlers.NewAdminHandler(tenantSvc, adminSvc)
 
-	seasonSvc := seasonusecase.NewService(seasons)
+	seasonSvc := seasonusecase.NewService(seasons, clients)
 	photographerSvc := photographerusecase.NewService(photographers)
 	personSvc := personusecase.NewService(persons)
 	clientSvc := clientusecase.NewService(clients, persons, seasons, photographers)

--- a/frontend/src/features/seasons/pages/SeasonsPage.test.tsx
+++ b/frontend/src/features/seasons/pages/SeasonsPage.test.tsx
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { BrowserRouter } from "react-router-dom";
+import { SeasonsPage } from "./SeasonsPage";
+import { seasonService, Season } from "../../../services/api/season.service";
+import { photographerService } from "../../../services/api/photographer.service";
+import { useSeasonStore } from "../../../store/seasonStore";
+
+describe("SeasonsPage", () => {
+  const mockSeasons: Season[] = [
+    {
+      id: "season-1",
+      name: "Dog Show 2026",
+      photographer_ids: ["p1"],
+      judges: ["Juiz A", "Juiz B"],
+    },
+    {
+      id: "season-2",
+      name: "Agility Cup 2026",
+      photographer_ids: [],
+      judges: [],
+    },
+  ];
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    useSeasonStore.setState({ activeSeason: null });
+    vi.spyOn(seasonService, "list").mockResolvedValue(mockSeasons);
+    vi.spyOn(photographerService, "list").mockResolvedValue([]);
+    vi.spyOn(seasonService, "delete").mockResolvedValue();
+  });
+
+  it("renders seasons list correctly", async () => {
+    render(
+      <BrowserRouter>
+        <SeasonsPage />
+      </BrowserRouter>,
+    );
+
+    expect(screen.getByText("Eventos")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText("Dog Show 2026")).toBeInTheDocument();
+      expect(screen.getByText("Agility Cup 2026")).toBeInTheDocument();
+    });
+  });
+
+  it("opens delete confirmation modal with cascade entities warning", async () => {
+    render(
+      <BrowserRouter>
+        <SeasonsPage />
+      </BrowserRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Dog Show 2026")).toBeInTheDocument();
+    });
+
+    const deleteButtons = screen.getAllByRole("button", { name: /excluir/i });
+    fireEvent.click(deleteButtons[0]);
+
+    await waitFor(() => {
+      expect(screen.getByText("Confirmar Exclusão")).toBeInTheDocument();
+      expect(
+        screen.getByText(/removidos permanentemente em cascata/i),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("deletes season and updates activeSeason in store when deleted season was active", async () => {
+    useSeasonStore.setState({ activeSeason: mockSeasons[0] });
+
+    render(
+      <BrowserRouter>
+        <SeasonsPage />
+      </BrowserRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Dog Show 2026")).toBeInTheDocument();
+    });
+
+    const deleteButtons = screen.getAllByRole("button", { name: /excluir/i });
+    fireEvent.click(deleteButtons[0]);
+
+    await waitFor(() => {
+      expect(screen.getByText("Confirmar Exclusão")).toBeInTheDocument();
+    });
+
+    // Mock list after delete returning only season-2
+    vi.spyOn(seasonService, "list").mockResolvedValue([mockSeasons[1]]);
+
+    const confirmButton = screen.getByRole("button", { name: "Excluir" });
+    fireEvent.click(confirmButton);
+
+    await waitFor(() => {
+      expect(seasonService.delete).toHaveBeenCalledWith("season-1");
+      expect(useSeasonStore.getState().activeSeason?.id).toBe("season-2");
+    });
+  });
+});

--- a/frontend/src/features/seasons/pages/SeasonsPage.tsx
+++ b/frontend/src/features/seasons/pages/SeasonsPage.tsx
@@ -33,8 +33,10 @@ import {
   photographerService,
   Photographer,
 } from "../../../services/api/photographer.service";
+import { useSeasonStore } from "../../../store/seasonStore";
 
 export const SeasonsPage = () => {
+  const { activeSeason, setActiveSeason } = useSeasonStore();
   const [seasons, setSeasons] = useState<Season[]>([]);
   const [photographers, setPhotographers] = useState<Photographer[]>([]);
   const [open, setOpen] = useState(false);
@@ -132,6 +134,10 @@ export const SeasonsPage = () => {
     if (!deletingSeason) return;
     try {
       await seasonService.delete(deletingSeason.id);
+      if (activeSeason?.id === deletingSeason.id) {
+        const remaining = seasons.filter((s) => s.id !== deletingSeason.id);
+        setActiveSeason(remaining.length > 0 ? remaining[0] : null);
+      }
       setDeleteConfirmOpen(false);
       setDeletingSeason(null);
       await load();
@@ -417,6 +423,8 @@ export const SeasonsPage = () => {
       <Dialog
         open={deleteConfirmOpen}
         onClose={() => setDeleteConfirmOpen(false)}
+        maxWidth="xs"
+        fullWidth
       >
         <DialogTitle>Confirmar Exclusão</DialogTitle>
         <DialogContent>
@@ -424,8 +432,13 @@ export const SeasonsPage = () => {
             Tem certeza que deseja excluir o evento{" "}
             <strong>{deletingSeason?.name}</strong>?
           </Typography>
+          <Typography variant="body2" color="error.main" sx={{ mt: 1.5 }}>
+            Atenção: Ao excluir este evento, todas as entidades e registros
+            vinculados a ele (como vínculos de clientes, cães e fotos
+            participantes) serão removidos permanentemente em cascata.
+          </Typography>
         </DialogContent>
-        <DialogActions>
+        <DialogActions sx={{ px: 3, pb: 2 }}>
           <Button onClick={() => setDeleteConfirmOpen(false)}>Cancelar</Button>
           <Button
             onClick={handleConfirmDelete}


### PR DESCRIPTION
### 📌 Descrição do Pull Request

Implementa a exclusão de eventos (temporadas) com remoção completa e assíncrona em cascata de todas as entidades e registros dependentes (vínculos de clientes, cães e fotos registradas no evento) no banco de dados MongoDB, prevenindo timeouts HTTP na interface e garantindo consistência no estado global da aplicação.

---

### 🚀 Modificações Realizadas

#### 1. Backend (Go)
- **Contratos (`backend/internal/application/ports/client/repository.go`)**:
  - Adicionado o método `DeleteBySeasonID(ctx context.Context, seasonID, tenantID string) error` no contrato do repositório de clientes.
- **Repositório MongoDB (`backend/internal/infrastructure/client/mongo/repository.go`)**:
  - Implementado `DeleteBySeasonID` sanitizando parâmetros com `mongoinfra.SanitizeID` e executando `DeleteMany` isolado por `tenant_id` e `season_id`.
- **Caso de Uso de Temporada (`backend/internal/application/usecase/season/service.go`)**:
  - Atualizado construtor `NewService` para receber `clientport.Repository`.
  - No método `Delete`, remove imediatamente o registro do evento para sumir das listagens da UI e dispara goroutine desacoplada em background com timeout de 5 minutos para deleção em cascata dos clientes e registros dependentes, evitando bloqueio ou timeout no HTTP response.
- **Injeção de Dependências (`backend/internal/interfaces/rest/router.go`)**:
  - Injetado repositório `clients` em `seasonusecase.NewService(seasons, clients)`.
- **Testes Unitários Backend**:
  - Atualizados `service_test.go` de season, client e report com mock repositório e validação da exclusão em cascata.

#### 2. Frontend (React / TypeScript)
- **Interface de Temporadas (`frontend/src/features/seasons/pages/SeasonsPage.tsx`)**:
  - Diálogo de confirmação de exclusão atualizado com aviso explícito de que todas as entidades e vínculos associados ao evento serão removidos permanentemente em cascata.
  - Sincronização automática com `useSeasonStore`: ao excluir o evento ativo, o estado global seleciona o próximo evento disponível ou limpa a seleção (`null`).
- **Testes Unitários Frontend (`frontend/src/features/seasons/pages/SeasonsPage.test.tsx`)**:
  - Adicionados testes cobrindo a listagem, abertura do diálogo com texto de aviso de cascata e sincronização do store do evento ativo.

---

### ✅ Validações e Testes Executados
- [x] `./scripts/swagger.sh` (OpenAPI Swagger spec 100% atualizada)
- [x] `./scripts/check.sh backend` (11 pacotes de teste e `go vet` aprovados)
- [x] `./scripts/check.sh frontend` (TypeScript, ESLint, Prettier e Vitest aprovados)
- [x] `./scripts/check.sh all` (Validação completa de toda a stack)
