### PR TITLE
fix(frontend): incluir rota photographers e demais rotas no spaPrerenderPlugin

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -24,7 +24,23 @@ function spaPrerenderPlugin(): Plugin {
         // Gera pastas com index.html para cada rota da aplicação
         // Garantindo que hosts estáticos como GitHub Pages retornem HTTP 200 OK
         // e possuam a tag rel=canonical correspondente para crawlers/Lighthouse
-        const routes = ["login", "register", "dashboard", "clients", "seasons"];
+        const routes = [
+          "login",
+          "register",
+          "verify-email",
+          "forgot-password",
+          "reset-password",
+          "dashboard",
+          "seasons",
+          "photographers",
+          "people",
+          "clients",
+          "profile",
+          "reports/download",
+          "admin",
+          "admin/tenants",
+          "admin/users",
+        ];
         for (const route of routes) {
           const routeDir = path.join(distDir, route);
           fs.mkdirSync(routeDir, { recursive: true });


### PR DESCRIPTION
### 📌 Descrição do Pull Request

Corrige o erro de status HTTP 404 exibido no console DevTools ao acessar ou recarregar rotas da aplicação (como `/photographers`, `/people`, `/profile`, `/admin/*`, etc.) hospedadas em servidores estáticos como GitHub Pages.

---

### 🚀 Modificações Realizadas

- **Vite Build Plugin (`frontend/vite.config.ts`)**:
  - Incluídas todas as rotas ativas da aplicação (`photographers`, `people`, `profile`, `verify-email`, `forgot-password`, `reset-password`, `reports/download`, `admin`, `admin/tenants`, `admin/users`) na lista de geração estática do `spaPrerenderPlugin`.
  - Garante que o build gere as pastas `/dist/<rota>/index.html` com a tag canônica correspondente, retornando status **200 OK** direto para o navegador e crawlers.

---

### ✅ Validações Executadas
- [x] `./scripts/check.sh frontend` (Build, Typecheck, ESLint, Prettier e Vitest 100% aprovados)
- [x] `./scripts/check.sh all` (Suíte completa de testes aprovada)
