### PR TITLE
feat(reports): exportação de clientes pagos em csv e ajuste no e-mail de relatório (#51)

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -1502,6 +1502,52 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/reports/paid-clients-csv": {
+            "post": {
+                "description": "Inicia a extração assíncrona do relatório de clientes e fotos com pagamentos confirmados (pagos) do tenant autenticado e envia o link para o e-mail cadastrado",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Reports"
+                ],
+                "summary": "Exportar relatório CSV de clientes com pagamentos confirmados",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID do evento para filtrar o relatório",
+                        "name": "season_id",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "Accepted",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.SuccessEnvelope"
+                        }
+                    },
+                    "401": {
+                        "description": "Não autenticado",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.ErrorEnvelope"
+                        }
+                    },
+                    "403": {
+                        "description": "Tenant não associado",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.ErrorEnvelope"
+                        }
+                    },
+                    "500": {
+                        "description": "Erro interno",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.ErrorEnvelope"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/reports/unpaid-clients-csv": {
             "post": {
                 "description": "Inicia a extração assíncrona do relatório de clientes e fotos com pagamentos não quitados ou pendentes do tenant autenticado e envia o link para o e-mail cadastrado",

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -1496,6 +1496,52 @@
                 }
             }
         },
+        "/api/v1/reports/paid-clients-csv": {
+            "post": {
+                "description": "Inicia a extração assíncrona do relatório de clientes e fotos com pagamentos confirmados (pagos) do tenant autenticado e envia o link para o e-mail cadastrado",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Reports"
+                ],
+                "summary": "Exportar relatório CSV de clientes com pagamentos confirmados",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "ID do evento para filtrar o relatório",
+                        "name": "season_id",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "Accepted",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.SuccessEnvelope"
+                        }
+                    },
+                    "401": {
+                        "description": "Não autenticado",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.ErrorEnvelope"
+                        }
+                    },
+                    "403": {
+                        "description": "Tenant não associado",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.ErrorEnvelope"
+                        }
+                    },
+                    "500": {
+                        "description": "Erro interno",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.ErrorEnvelope"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/reports/unpaid-clients-csv": {
             "post": {
                 "description": "Inicia a extração assíncrona do relatório de clientes e fotos com pagamentos não quitados ou pendentes do tenant autenticado e envia o link para o e-mail cadastrado",

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -1188,6 +1188,38 @@ paths:
       summary: Baixar arquivo de relatório gerado
       tags:
       - Reports
+  /api/v1/reports/paid-clients-csv:
+    post:
+      description: Inicia a extração assíncrona do relatório de clientes e fotos com
+        pagamentos confirmados (pagos) do tenant autenticado e envia o link para o
+        e-mail cadastrado
+      parameters:
+      - description: ID do evento para filtrar o relatório
+        in: query
+        name: season_id
+        type: string
+      produces:
+      - application/json
+      responses:
+        "202":
+          description: Accepted
+          schema:
+            $ref: '#/definitions/httpx.SuccessEnvelope'
+        "401":
+          description: Não autenticado
+          schema:
+            $ref: '#/definitions/httpx.ErrorEnvelope'
+        "403":
+          description: Tenant não associado
+          schema:
+            $ref: '#/definitions/httpx.ErrorEnvelope'
+        "500":
+          description: Erro interno
+          schema:
+            $ref: '#/definitions/httpx.ErrorEnvelope'
+      summary: Exportar relatório CSV de clientes com pagamentos confirmados
+      tags:
+      - Reports
   /api/v1/reports/unpaid-clients-csv:
     post:
       description: Inicia a extração assíncrona do relatório de clientes e fotos com

--- a/backend/internal/application/usecase/report/service.go
+++ b/backend/internal/application/usecase/report/service.go
@@ -509,6 +509,157 @@ func (s *Service) GenerateUnpaidClientsCSV(ctx context.Context, tenantID, season
 	return relativePath, nil
 }
 
+func (s *Service) GeneratePaidClientsCSV(ctx context.Context, tenantID, seasonID, userEmail, userName string) (string, error) {
+	if tenantID == "" {
+		return "", errors.New("tenant ID cannot be empty")
+	}
+
+	// 1. Fetch photographers to map IDs to names
+	photographersList, err := s.photographerRepo.List(ctx, tenantID)
+	if err != nil {
+		log.Printf("[REPORT] Failed to list photographers for tenant %s: %v", tenantID, err)
+		photographersList = nil
+	}
+	photogMap := make(map[string]string)
+	for _, p := range photographersList {
+		photogMap[p.ID] = p.Name
+	}
+
+	// 2. Cache persons dynamically during stream to avoid repeated identical queries
+	personCache := make(map[string]*persondomain.Person)
+
+	// 3. Prepare CSV buffer with UTF-8 BOM for Excel compatibility and headers
+	var buf bytes.Buffer
+	buf.WriteString("\xEF\xBB\xBF")
+	writer := csv.NewWriter(&buf)
+
+	headers := []string{
+		"Nome",
+		"E-mail",
+		"E-mail alternativo",
+		"Telefone",
+		"Dono",
+		"Raça",
+		"Juiz",
+		"Competições Vencidas",
+		"Número do Arquivo da Foto",
+		"Fotografo",
+		"Forma de Pagamento",
+		"Valor Pago",
+		"Data da Foto",
+	}
+	if err := writer.Write(sanitizeRow(headers)); err != nil {
+		return "", fmt.Errorf("failed to write csv headers: %w", err)
+	}
+
+	// 4. Stream clients from MongoDB and filter paid photos
+	streamErr := s.clientRepo.StreamByTenant(ctx, tenantID, seasonID, func(c *clientdomain.SeasonClient) error {
+		var personObj *persondomain.Person
+		var ok bool
+
+		for _, dog := range c.Dogs {
+			isOwnerStr := formatIsOwner(dog.IsOwner)
+			var wonCompStr string
+			if len(dog.WonCompetitions) > 0 {
+				wonCompStr = strings.Join(dog.WonCompetitions, ", ")
+			} else if dog.CompetitionsWon > 0 {
+				wonCompStr = "Sim"
+			}
+
+			for _, photo := range dog.Photos {
+				normPay := NormalizePaymentMethod(photo.PaymentMethod)
+				if normPay == "Não pago" || normPay == "" {
+					continue
+				}
+
+				if personObj == nil {
+					personObj, ok = personCache[c.PersonID]
+					if !ok {
+						p, err := s.personRepo.GetByID(ctx, c.PersonID, tenantID)
+						if err != nil || p == nil {
+							p = &persondomain.Person{
+								Name: "Desconhecido",
+							}
+						}
+						personCache[c.PersonID] = p
+						personObj = p
+					}
+				}
+
+				var photographerName string
+				if name, exists := photogMap[photo.PhotographerID]; exists && name != "" {
+					photographerName = name
+				} else {
+					photographerName = photo.PhotographerID
+				}
+
+				var amountPaid string
+				if photo.AmountPaid != nil {
+					amountPaid = fmt.Sprintf("%.2f", *photo.AmountPaid)
+				}
+
+				photoDate := formatPhotoDate(&photo, c.CreatedAt)
+				judgeStr := formatJudges(&photo)
+
+				row := []string{
+					personObj.Name,
+					personObj.Email,
+					personObj.AlternativeEmail,
+					FormatPhone(personObj.Phone),
+					isOwnerStr,
+					dog.Breed,
+					judgeStr,
+					wonCompStr,
+					photo.FileNumber,
+					photographerName,
+					normPay,
+					amountPaid,
+					photoDate,
+				}
+				if err := writer.Write(sanitizeRow(row)); err != nil {
+					return err
+				}
+			}
+		}
+
+		writer.Flush()
+		return writer.Error()
+	})
+
+	if streamErr != nil {
+		return "", fmt.Errorf("error during client streaming: %w", streamErr)
+	}
+
+	writer.Flush()
+	if err := writer.Error(); err != nil {
+		return "", fmt.Errorf("error finishing csv writer: %w", err)
+	}
+
+	// 5. Store generated CSV in Storage Provider with isolated tenant path
+	timestamp := time.Now().UTC().Unix()
+	fileName := fmt.Sprintf("clientes_pagos_%d.csv", timestamp)
+	relativePath := fmt.Sprintf("reports/tenant_%s/%s", tenantID, fileName)
+
+	_, err = s.storageProvider.Save(ctx, relativePath, storageport.File{
+		Name:        fileName,
+		Data:        buf.Bytes(),
+		ContentType: "text/csv; charset=utf-8",
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to save report to storage: %w", err)
+	}
+
+	// 6. Send notification email with download link if userEmail is provided
+	if userEmail != "" {
+		downloadURL := fmt.Sprintf("%s/reports/download?file=%s", s.appBaseURL, url.QueryEscape(relativePath))
+		if err := s.emailSender.SendReportReadyEmail(ctx, userEmail, userName, "Relatório de Clientes Pagos", downloadURL); err != nil {
+			log.Printf("[REPORT-EMAIL-ERROR] Failed to send report ready email to %s: %v", userEmail, err)
+		}
+	}
+
+	return relativePath, nil
+}
+
 func renderPdfRow(pdf *fpdf.Fpdf, tr func(string) string, colWidths []float64, rowVals []string, aligns []string, lineHeight float64, pageHeight float64, bottomMargin float64) {
 	if tr == nil {
 		tr = func(s string) string { return s }

--- a/backend/internal/application/usecase/report/service_test.go
+++ b/backend/internal/application/usecase/report/service_test.go
@@ -808,3 +808,187 @@ func TestGenerateClientsPDF_MultiLineJudgesAndAccents(t *testing.T) {
 		t.Fatalf("expected PDF magic header %%PDF-")
 	}
 }
+
+func TestGeneratePaidClientsCSV(t *testing.T) {
+	tenantID := "tenant-paid-123"
+	amount100 := 100.00
+	amount250 := 250.50
+	amount50 := 50.00
+	isOwnerTrue := true
+	isOwnerFalse := false
+
+	clientRepo := &mockClientRepo{
+		clients: []*clientdomain.SeasonClient{
+			{
+				ID:       "client-1",
+				TenantID: tenantID,
+				PersonID: "person-1",
+				Dogs: []clientdomain.Dog{
+					{
+						Breed:           "Golden Retriever",
+						IsOwner:         &isOwnerTrue,
+						WonCompetitions: []string{"Campeão Jovem", "Melhor da Raça"},
+						Photos: []clientdomain.Photo{
+							{
+								FileNumber:     "IMG_100",
+								PhotographerID: "photog-1",
+								PaymentMethod:  "Pix",
+								AmountPaid:     &amount100,
+								Judges:         []string{"Juiz Santos"},
+							},
+							{
+								FileNumber:     "IMG_101",
+								PhotographerID: "photog-2",
+								PaymentMethod:  "Cartão de Crédito",
+								AmountPaid:     &amount250,
+								Judges:         []string{"Juiz Santos", "Juiz Oliveira"},
+							},
+							{
+								FileNumber:     "IMG_102",
+								PhotographerID: "photog-1",
+								PaymentMethod:  "Não pago",
+								AmountPaid:     nil,
+							},
+						},
+					},
+					{
+						Breed:           "Border Collie",
+						IsOwner:         &isOwnerFalse,
+						CompetitionsWon: 2,
+						Photos: []clientdomain.Photo{
+							{
+								FileNumber:     "=MALICIOUS_CMD",
+								PhotographerID: "photog-1",
+								PaymentMethod:  "Dinheiro",
+								AmountPaid:     &amount50,
+							},
+						},
+					},
+				},
+			},
+			{
+				ID:       "client-2",
+				TenantID: tenantID,
+				PersonID: "person-2",
+				Dogs: []clientdomain.Dog{
+					{
+						Breed: "Poodle",
+						Photos: []clientdomain.Photo{
+							{
+								FileNumber:    "IMG_200",
+								PaymentMethod: "Não pago",
+							},
+							{
+								FileNumber:    "IMG_201",
+								PaymentMethod: "",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	personRepo := &mockPersonRepo{
+		people: map[string]*persondomain.Person{
+			"person-1": {
+				ID:               "person-1",
+				Name:             "Carlos Albuquerque",
+				Email:            "carlos@exemplo.com",
+				AlternativeEmail: "carlos.alt@exemplo.com",
+				Phone:            "11988889999",
+			},
+			"person-2": {
+				ID:    "person-2",
+				Name:  "João Inadimplente",
+				Email: "joao@exemplo.com",
+			},
+		},
+	}
+
+	photographerRepo := &mockPhotographerRepo{
+		photographers: []*photographerdomain.Photographer{
+			{ID: "photog-1", Name: "Fotógrafo Principal"},
+			{ID: "photog-2", Name: "Fotógrafo Secundário"},
+		},
+	}
+
+	storage := &mockStorageProvider{}
+	emailSender := &mockEmailSender{}
+
+	svc := NewService(clientRepo, personRepo, photographerRepo, storage, emailSender, "http://localhost:8080")
+
+	// 1. Error on empty tenant
+	_, err := svc.GeneratePaidClientsCSV(context.Background(), "", "", "admin@test.com", "Admin")
+	if err == nil {
+		t.Fatalf("expected error on empty tenant ID")
+	}
+
+	// 2. Generate paid clients report
+	filePath, err := svc.GeneratePaidClientsCSV(context.Background(), tenantID, "", "admin@test.com", "Admin")
+	if err != nil {
+		t.Fatalf("unexpected error generating paid clients CSV: %v", err)
+	}
+
+	if !strings.HasPrefix(filePath, "reports/tenant_tenant-paid-123/clientes_pagos_") {
+		t.Fatalf("unexpected file path: %s", filePath)
+	}
+
+	csvData, ok := storage.files[filePath]
+	if !ok || len(csvData) == 0 {
+		t.Fatalf("CSV data not found in storage")
+	}
+
+	if !bytes.HasPrefix(csvData, []byte("\xEF\xBB\xBF")) {
+		t.Fatalf("expected UTF-8 BOM at start of CSV")
+	}
+
+	reader := csv.NewReader(bytes.NewReader(bytes.TrimPrefix(csvData, []byte("\xEF\xBB\xBF"))))
+	records, err := reader.ReadAll()
+	if err != nil {
+		t.Fatalf("failed to parse CSV records: %v", err)
+	}
+
+	// Header + 2 paid photos (dog 1) + 1 paid photo (dog 2) = 4 rows
+	if len(records) != 4 {
+		t.Fatalf("expected 4 rows in paid clients CSV, got %d", len(records))
+	}
+
+	// Verify headers: Nome, E-mail, E-mail alternativo, Telefone, Dono, Raça, Juiz, Competições Vencidas, Número do Arquivo da Foto, Fotografo, Forma de Pagamento, Valor Pago, Data da Foto
+	headers := records[0]
+	expectedHeaders := []string{
+		"Nome", "E-mail", "E-mail alternativo", "Telefone", "Dono", "Raça", "Juiz",
+		"Competições Vencidas", "Número do Arquivo da Foto", "Fotografo", "Forma de Pagamento", "Valor Pago", "Data da Foto",
+	}
+	for i, h := range expectedHeaders {
+		if headers[i] != h {
+			t.Fatalf("header[%d] expected %q, got %q", i, h, headers[i])
+		}
+	}
+
+	// Row 1 (IMG_100): Pix
+	row1 := records[1]
+	if row1[0] != "Carlos Albuquerque" || row1[3] != "(11) 98888-9999" || row1[4] != "Sim" || row1[5] != "Golden Retriever" || row1[6] != "Juiz Santos" || row1[7] != "Campeão Jovem, Melhor da Raça" || row1[8] != "IMG_100" || row1[9] != "Fotógrafo Principal" || row1[10] != "Pix" || row1[11] != "100.00" {
+		t.Fatalf("unexpected row 1: %v", row1)
+	}
+
+	// Row 2 (IMG_101): Cartão de Crédito
+	row2 := records[2]
+	if row2[8] != "IMG_101" || row2[9] != "Fotógrafo Secundário" || row2[10] != "Cartão de Crédito" || row2[11] != "250.50" || row2[6] != "Juiz Santos, Juiz Oliveira" {
+		t.Fatalf("unexpected row 2: %v", row2)
+	}
+
+	// Row 3 (Malicious formula sanitized): Dinheiro
+	row3 := records[3]
+	if row3[4] != "Não" || row3[5] != "Border Collie" || row3[7] != "Sim" || row3[8] != "'=MALICIOUS_CMD" || row3[10] != "Dinheiro" || row3[11] != "50.00" {
+		t.Fatalf("unexpected row 3: %v", row3)
+	}
+
+	// Verify email sent with proper subject
+	if len(emailSender.sentReports) != 1 {
+		t.Fatalf("expected 1 report email sent, got %d", len(emailSender.sentReports))
+	}
+	if emailSender.sentReports[0].ReportName != "Relatório de Clientes Pagos" {
+		t.Fatalf("expected report name 'Relatório de Clientes Pagos', got %q", emailSender.sentReports[0].ReportName)
+	}
+}

--- a/backend/internal/infrastructure/email/sender_test.go
+++ b/backend/internal/infrastructure/email/sender_test.go
@@ -116,6 +116,12 @@ func TestEmailTemplatesRender(t *testing.T) {
 	if !strings.Contains(reportStr, "#0F52BA") {
 		t.Fatalf("report ready template missing brand color")
 	}
+	if !strings.Contains(reportStr, "Baixar Relatório") || !strings.Contains(reportStr, "fazer o download do arquivo:") {
+		t.Fatalf("report ready template should have format-neutral text and button")
+	}
+	if strings.Contains(reportStr, "Baixar Relatório (.csv)") {
+		t.Fatalf("report ready template should not have hardcoded (.csv) in button")
+	}
 }
 
 func TestEmailSenderRejectsInvalidAddress(t *testing.T) {

--- a/backend/internal/infrastructure/email/templates/report_ready.html
+++ b/backend/internal/infrastructure/email/templates/report_ready.html
@@ -24,7 +24,7 @@
                 Olá, <strong>{{ .Name }}</strong>!
               </p>
               <p style="margin: 0 0 28px 0; color: #475569; font-size: 15px; line-height: 1.6;">
-                A exportação do seu relatório <strong>{{ .ReportName }}</strong> foi concluída com sucesso. Clique no botão abaixo para fazer o download do arquivo CSV:
+                A exportação do seu relatório <strong>{{ .ReportName }}</strong> foi concluída com sucesso. Clique no botão abaixo para fazer o download do arquivo:
               </p>
               
               <!-- CTA Button -->
@@ -32,7 +32,7 @@
                 <tr>
                   <td align="center">
                     <a href="{{ .DownloadURL }}" target="_blank" style="display: inline-block; background-color: #0F52BA; color: #ffffff; font-size: 15px; font-weight: 600; text-decoration: none; padding: 14px 32px; border-radius: 8px; box-shadow: 0 2px 4px rgba(15, 82, 186, 0.25);">
-                      Baixar Relatório (.csv)
+                      Baixar Relatório
                     </a>
                   </td>
                 </tr>

--- a/backend/internal/interfaces/rest/handlers/report_handler.go
+++ b/backend/internal/interfaces/rest/handlers/report_handler.go
@@ -118,6 +118,51 @@ func (h *ReportHandler) ExportUnpaidClientsCSV(w http.ResponseWriter, r *http.Re
 	})
 }
 
+// ExportPaidClientsCSV godoc
+// @Summary      Exportar relatório CSV de clientes com pagamentos confirmados
+// @Description  Inicia a extração assíncrona do relatório de clientes e fotos com pagamentos confirmados (pagos) do tenant autenticado e envia o link para o e-mail cadastrado
+// @Tags         Reports
+// @Param        season_id query string false "ID do evento para filtrar o relatório"
+// @Produce      json
+// @Success      202  {object}  httpx.SuccessEnvelope
+// @Failure      401  {object}  httpx.ErrorEnvelope "Não autenticado"
+// @Failure      403  {object}  httpx.ErrorEnvelope "Tenant não associado"
+// @Failure      500  {object}  httpx.ErrorEnvelope "Erro interno"
+// @Router       /api/v1/reports/paid-clients-csv [post]
+func (h *ReportHandler) ExportPaidClientsCSV(w http.ResponseWriter, r *http.Request) {
+	tenantID := middleware.GetTenantID(r.Context())
+	if tenantID == "" {
+		httpx.Error(w, http.StatusForbidden, "Tenant is required", nil)
+		return
+	}
+
+	seasonID := r.URL.Query().Get("season_id")
+
+	userID := middleware.GetUserID(r.Context())
+	var userEmail, userName string
+	if userID != "" && h.userRepo != nil {
+		user, err := h.userRepo.FindByID(r.Context(), userID)
+		if err == nil && user.Email != "" {
+			userEmail = user.Email
+			userName = user.Name
+		}
+	}
+
+	// Launch async extraction job in background goroutine with detached context
+	go func(tID, sID, uEmail, uName string) {
+		jobCtx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+		defer cancel()
+
+		if _, err := h.service.GeneratePaidClientsCSV(jobCtx, tID, sID, uEmail, uName); err != nil {
+			log.Printf("[REPORT-JOB-ERROR] Failed to generate paid clients CSV for tenant %s: %v", tID, err)
+		}
+	}(tenantID, seasonID, userEmail, userName)
+
+	httpx.Accepted(w, map[string]string{
+		"message": "Geração do relatório iniciada com sucesso. O arquivo CSV será enviado para o seu e-mail em instantes.",
+	})
+}
+
 // ExportClientsPDF godoc
 // @Summary      Exportar relatório PDF de clientes
 // @Description  Inicia a extração assíncrona do relatório consolidado em PDF de clientes, cães e fotos para o tenant autenticado e envia o link para o e-mail cadastrado

--- a/backend/internal/interfaces/rest/handlers/report_handler_test.go
+++ b/backend/internal/interfaces/rest/handlers/report_handler_test.go
@@ -1,0 +1,283 @@
+package handlers_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	storageport "ps/internal/application/ports/storage"
+	reportusecase "ps/internal/application/usecase/report"
+	clientdomain "ps/internal/domain/client"
+	persondomain "ps/internal/domain/person"
+	photographerdomain "ps/internal/domain/photographer"
+	domainuser "ps/internal/domain/user"
+	usermemory "ps/internal/infrastructure/user/memory"
+	"ps/internal/interfaces/rest/handlers"
+	"ps/internal/shared/middleware"
+)
+
+type mockReportClientRepo struct {
+	clients []*clientdomain.SeasonClient
+}
+
+func (m *mockReportClientRepo) Create(ctx context.Context, client *clientdomain.SeasonClient) error {
+	return nil
+}
+func (m *mockReportClientRepo) GetByID(ctx context.Context, id, tenantID string) (*clientdomain.SeasonClient, error) {
+	return nil, nil
+}
+func (m *mockReportClientRepo) List(ctx context.Context, tenantID string, filter clientdomain.ListFilter) (*clientdomain.PaginatedClients, error) {
+	return &clientdomain.PaginatedClients{
+		Data:  m.clients,
+		Total: int64(len(m.clients)),
+	}, nil
+}
+func (m *mockReportClientRepo) StreamByTenant(ctx context.Context, tenantID, seasonID string, fn func(c *clientdomain.SeasonClient) error) error {
+	for _, c := range m.clients {
+		if c.TenantID == tenantID && (seasonID == "" || c.SeasonID == seasonID) {
+			if err := fn(c); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+func (m *mockReportClientRepo) Update(ctx context.Context, client *clientdomain.SeasonClient) error {
+	return nil
+}
+func (m *mockReportClientRepo) Delete(ctx context.Context, id, tenantID string) error {
+	return nil
+}
+func (m *mockReportClientRepo) DeleteBySeasonID(ctx context.Context, seasonID, tenantID string) error {
+	return nil
+}
+
+type mockReportPersonRepo struct {
+	people map[string]*persondomain.Person
+}
+
+func (m *mockReportPersonRepo) Create(ctx context.Context, person *persondomain.Person) error {
+	return nil
+}
+func (m *mockReportPersonRepo) GetByID(ctx context.Context, id, tenantID string) (*persondomain.Person, error) {
+	if p, ok := m.people[id]; ok {
+		return p, nil
+	}
+	return nil, nil
+}
+func (m *mockReportPersonRepo) List(ctx context.Context, tenantID string) ([]*persondomain.Person, error) {
+	return nil, nil
+}
+func (m *mockReportPersonRepo) Update(ctx context.Context, person *persondomain.Person) error {
+	return nil
+}
+func (m *mockReportPersonRepo) Delete(ctx context.Context, id, tenantID string) error {
+	return nil
+}
+
+type mockReportPhotographerRepo struct{}
+
+func (m *mockReportPhotographerRepo) Create(ctx context.Context, photographer *photographerdomain.Photographer) error {
+	return nil
+}
+func (m *mockReportPhotographerRepo) GetByID(ctx context.Context, id, tenantID string) (*photographerdomain.Photographer, error) {
+	return nil, nil
+}
+func (m *mockReportPhotographerRepo) List(ctx context.Context, tenantID string) ([]*photographerdomain.Photographer, error) {
+	return nil, nil
+}
+func (m *mockReportPhotographerRepo) Update(ctx context.Context, photographer *photographerdomain.Photographer) error {
+	return nil
+}
+func (m *mockReportPhotographerRepo) Delete(ctx context.Context, id, tenantID string) error {
+	return nil
+}
+
+type mockReportStorageProvider struct {
+	files map[string][]byte
+}
+
+func (m *mockReportStorageProvider) Save(ctx context.Context, path string, file storageport.File) (storageport.StoredObject, error) {
+	if m.files == nil {
+		m.files = make(map[string][]byte)
+	}
+	m.files[path] = file.Data
+	return storageport.StoredObject{FileName: path, Size: int64(len(file.Data))}, nil
+}
+func (m *mockReportStorageProvider) Get(ctx context.Context, path string) ([]byte, error) {
+	if data, ok := m.files[path]; ok {
+		return data, nil
+	}
+	return nil, nil
+}
+func (m *mockReportStorageProvider) Delete(ctx context.Context, path string) error {
+	delete(m.files, path)
+	return nil
+}
+
+type mockReportEmailSender struct{}
+
+func (m *mockReportEmailSender) SendVerificationEmail(ctx context.Context, toEmail, toName, token string) error {
+	return nil
+}
+func (m *mockReportEmailSender) SendPasswordResetEmail(ctx context.Context, toEmail, toName, token string) error {
+	return nil
+}
+func (m *mockReportEmailSender) SendReportReadyEmail(ctx context.Context, toEmail, toName, reportName, downloadURL string) error {
+	return nil
+}
+
+func setupReportHandler() (*handlers.ReportHandler, *mockReportStorageProvider, *usermemory.Repository) {
+	clientRepo := &mockReportClientRepo{}
+	personRepo := &mockReportPersonRepo{people: make(map[string]*persondomain.Person)}
+	photogRepo := &mockReportPhotographerRepo{}
+	storage := &mockReportStorageProvider{files: make(map[string][]byte)}
+	emailSender := &mockReportEmailSender{}
+	userRepo := usermemory.NewRepository()
+
+	svc := reportusecase.NewService(clientRepo, personRepo, photogRepo, storage, emailSender, "http://localhost:8080")
+	handler := handlers.NewReportHandler(svc, userRepo)
+	return handler, storage, userRepo
+}
+
+func TestReportHandler_ExportEndpoints(t *testing.T) {
+	handler, _, userRepo := setupReportHandler()
+
+	u, _ := userRepo.Create(context.Background(), domainuser.User{
+		Name:     "Test User",
+		Email:    "test@example.com",
+		TenantID: "tenant-1",
+	})
+
+	t.Run("ExportPaidClientsCSV requires tenant", func(t *testing.T) {
+		req := httptest.NewRequest("POST", "/api/v1/reports/paid-clients-csv", nil)
+		rec := httptest.NewRecorder()
+		handler.ExportPaidClientsCSV(rec, req)
+		if rec.Code != http.StatusForbidden {
+			t.Fatalf("expected 403 Forbidden without tenant, got %d", rec.Code)
+		}
+	})
+
+	t.Run("ExportPaidClientsCSV success", func(t *testing.T) {
+		req := httptest.NewRequest("POST", "/api/v1/reports/paid-clients-csv?season_id=season-1", nil)
+		ctx := context.WithValue(req.Context(), middleware.TenantIDKey, "tenant-1")
+		ctx = context.WithValue(ctx, middleware.UserIDKey, u.ID)
+		req = req.WithContext(ctx)
+
+		rec := httptest.NewRecorder()
+		handler.ExportPaidClientsCSV(rec, req)
+
+		if rec.Code != http.StatusAccepted {
+			t.Fatalf("expected 202 Accepted, got %d: %s", rec.Code, rec.Body.String())
+		}
+	})
+
+	t.Run("ExportClientsCSV success", func(t *testing.T) {
+		req := httptest.NewRequest("POST", "/api/v1/reports/clients-csv", nil)
+		ctx := context.WithValue(req.Context(), middleware.TenantIDKey, "tenant-1")
+		ctx = context.WithValue(ctx, middleware.UserIDKey, u.ID)
+		req = req.WithContext(ctx)
+
+		rec := httptest.NewRecorder()
+		handler.ExportClientsCSV(rec, req)
+
+		if rec.Code != http.StatusAccepted {
+			t.Fatalf("expected 202 Accepted, got %d: %s", rec.Code, rec.Body.String())
+		}
+	})
+
+	t.Run("ExportUnpaidClientsCSV success", func(t *testing.T) {
+		req := httptest.NewRequest("POST", "/api/v1/reports/unpaid-clients-csv", nil)
+		ctx := context.WithValue(req.Context(), middleware.TenantIDKey, "tenant-1")
+		ctx = context.WithValue(ctx, middleware.UserIDKey, u.ID)
+		req = req.WithContext(ctx)
+
+		rec := httptest.NewRecorder()
+		handler.ExportUnpaidClientsCSV(rec, req)
+
+		if rec.Code != http.StatusAccepted {
+			t.Fatalf("expected 202 Accepted, got %d: %s", rec.Code, rec.Body.String())
+		}
+	})
+
+	t.Run("ExportClientsPDF success", func(t *testing.T) {
+		req := httptest.NewRequest("POST", "/api/v1/reports/clients-pdf", nil)
+		ctx := context.WithValue(req.Context(), middleware.TenantIDKey, "tenant-1")
+		ctx = context.WithValue(ctx, middleware.UserIDKey, u.ID)
+		req = req.WithContext(ctx)
+
+		rec := httptest.NewRecorder()
+		handler.ExportClientsPDF(rec, req)
+
+		if rec.Code != http.StatusAccepted {
+			t.Fatalf("expected 202 Accepted, got %d: %s", rec.Code, rec.Body.String())
+		}
+	})
+
+	t.Run("DownloadDirectClientsPDF success", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/api/v1/reports/clients-pdf", nil)
+		ctx := context.WithValue(req.Context(), middleware.TenantIDKey, "tenant-1")
+		req = req.WithContext(ctx)
+
+		rec := httptest.NewRecorder()
+		handler.DownloadDirectClientsPDF(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200 OK, got %d: %s", rec.Code, rec.Body.String())
+		}
+		if rec.Header().Get("Content-Type") != "application/pdf" {
+			t.Fatalf("expected application/pdf header, got %s", rec.Header().Get("Content-Type"))
+		}
+	})
+}
+
+func TestReportHandler_DownloadReport(t *testing.T) {
+	handler, storage, _ := setupReportHandler()
+
+	// Store dummy file
+	validPath := "reports/tenant_tenant-1/clientes_123.csv"
+	storage.files[validPath] = []byte("header1,header2\nval1,val2")
+
+	t.Run("Missing file param", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/api/v1/reports/download", nil)
+		ctx := context.WithValue(req.Context(), middleware.TenantIDKey, "tenant-1")
+		req = req.WithContext(ctx)
+
+		rec := httptest.NewRecorder()
+		handler.DownloadReport(rec, req)
+
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400 Bad Request, got %d", rec.Code)
+		}
+	})
+
+	t.Run("Cross-tenant access forbidden", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/api/v1/reports/download?file=reports/tenant_other/secret.csv", nil)
+		ctx := context.WithValue(req.Context(), middleware.TenantIDKey, "tenant-1")
+		req = req.WithContext(ctx)
+
+		rec := httptest.NewRecorder()
+		handler.DownloadReport(rec, req)
+
+		if rec.Code != http.StatusForbidden {
+			t.Fatalf("expected 403 Forbidden, got %d", rec.Code)
+		}
+	})
+
+	t.Run("Valid file download", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/api/v1/reports/download?file="+validPath, nil)
+		ctx := context.WithValue(req.Context(), middleware.TenantIDKey, "tenant-1")
+		req = req.WithContext(ctx)
+
+		rec := httptest.NewRecorder()
+		handler.DownloadReport(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200 OK, got %d: %s", rec.Code, rec.Body.String())
+		}
+		if rec.Body.String() != "header1,header2\nval1,val2" {
+			t.Fatalf("expected file body, got %q", rec.Body.String())
+		}
+	})
+}

--- a/backend/internal/interfaces/rest/router.go
+++ b/backend/internal/interfaces/rest/router.go
@@ -150,6 +150,7 @@ func NewRouter(
 
 	mux.Handle("POST /api/v1/reports/clients-csv", businessChain(reportHandler.ExportClientsCSV))
 	mux.Handle("POST /api/v1/reports/unpaid-clients-csv", businessChain(reportHandler.ExportUnpaidClientsCSV))
+	mux.Handle("POST /api/v1/reports/paid-clients-csv", businessChain(reportHandler.ExportPaidClientsCSV))
 	mux.Handle("POST /api/v1/reports/clients-pdf", businessChain(reportHandler.ExportClientsPDF))
 	mux.Handle("GET /api/v1/reports/clients-pdf", businessChain(reportHandler.DownloadDirectClientsPDF))
 	mux.Handle("GET /api/v1/reports/download", businessChain(reportHandler.DownloadReport))

--- a/frontend/src/features/clients/pages/ClientsPage.tsx
+++ b/frontend/src/features/clients/pages/ClientsPage.tsx
@@ -287,6 +287,32 @@ export const ClientsPage = () => {
     }
   };
 
+  const handleExportPaidClientsCsv = async () => {
+    setReportMenuAnchor(null);
+    setExportingReport(true);
+    try {
+      const resp = await reportService.exportPaidClientsCsv(activeSeason?.id);
+      setSnackbar({
+        open: true,
+        message:
+          resp?.message ||
+          "Processamento do relatório iniciado! O link do arquivo será enviado para o seu e-mail cadastrado.",
+        severity: "success",
+      });
+    } catch (err: unknown) {
+      const errorObj = err as { response?: { data?: { message?: string } } };
+      setSnackbar({
+        open: true,
+        message:
+          errorObj?.response?.data?.message ||
+          "Erro ao solicitar exportação do relatório de clientes pagos.",
+        severity: "error",
+      });
+    } finally {
+      setExportingReport(false);
+    }
+  };
+
   if (!activeSeason) {
     return (
       <Box sx={{ p: { xs: 1.5, sm: 2.5, md: 3 } }}>
@@ -357,6 +383,12 @@ export const ClientsPage = () => {
                 <FileDownloadIcon fontSize="small" />
               </ListItemIcon>
               Exportar Clientes (.csv)
+            </MenuItem>
+            <MenuItem onClick={handleExportPaidClientsCsv}>
+              <ListItemIcon>
+                <FileDownloadIcon fontSize="small" />
+              </ListItemIcon>
+              Exportar Pagos (.csv)
             </MenuItem>
             <MenuItem onClick={handleExportUnpaidClientsCsv}>
               <ListItemIcon>

--- a/frontend/src/features/dashboard/pages/DashboardPage.test.tsx
+++ b/frontend/src/features/dashboard/pages/DashboardPage.test.tsx
@@ -269,6 +269,35 @@ describe("DashboardPage", () => {
     });
   });
 
+  it("triggers export of paid clients csv report from report menu", async () => {
+    useSeasonStore.setState({
+      activeSeason: { id: "season-1", name: "Temporada 2026" },
+    });
+
+    const exportSpy = vi
+      .spyOn(reportService, "exportPaidClientsCsv")
+      .mockResolvedValue({ message: "Exportação de pagos iniciada!" });
+
+    render(
+      <BrowserRouter>
+        <DashboardPage />
+      </BrowserRouter>,
+    );
+
+    const reportBtn = screen.getByRole("button", { name: /Relatórios/i });
+    fireEvent.click(reportBtn);
+
+    const exportOption = await screen.findByText("Exportar Pagos (.csv)");
+    fireEvent.click(exportOption);
+
+    await waitFor(() => {
+      expect(exportSpy).toHaveBeenCalled();
+      expect(
+        screen.getByText("Exportação de pagos iniciada!"),
+      ).toBeInTheDocument();
+    });
+  });
+
   it("opens quick create person modal when clicking Nova Pessoa", async () => {
     useSeasonStore.setState({
       activeSeason: { id: "season-1", name: "Temporada 2026" },

--- a/frontend/src/features/dashboard/pages/DashboardPage.tsx
+++ b/frontend/src/features/dashboard/pages/DashboardPage.tsx
@@ -177,6 +177,32 @@ export const DashboardPage = () => {
     }
   };
 
+  const handleExportPaidClientsCsv = async () => {
+    setReportMenuAnchor(null);
+    setExportingReport(true);
+    try {
+      const resp = await reportService.exportPaidClientsCsv(activeSeason?.id);
+      setSnackbar({
+        open: true,
+        message:
+          resp?.message ||
+          "Processamento do relatório iniciado! O link do arquivo será enviado para o seu e-mail cadastrado.",
+        severity: "success",
+      });
+    } catch (err: unknown) {
+      const errorObj = err as { response?: { data?: { message?: string } } };
+      setSnackbar({
+        open: true,
+        message:
+          errorObj?.response?.data?.message ||
+          "Erro ao solicitar exportação do relatório de clientes pagos.",
+        severity: "error",
+      });
+    } finally {
+      setExportingReport(false);
+    }
+  };
+
   // Debounce search input
   useEffect(() => {
     const timer = setTimeout(() => {
@@ -438,6 +464,12 @@ export const DashboardPage = () => {
                   <FileDownloadIcon fontSize="small" />
                 </ListItemIcon>
                 Exportar Clientes (.csv)
+              </MenuItem>
+              <MenuItem onClick={handleExportPaidClientsCsv}>
+                <ListItemIcon>
+                  <FileDownloadIcon fontSize="small" />
+                </ListItemIcon>
+                Exportar Pagos (.csv)
               </MenuItem>
               <MenuItem onClick={handleExportUnpaidClientsCsv}>
                 <ListItemIcon>

--- a/frontend/src/services/api/report.service.ts
+++ b/frontend/src/services/api/report.service.ts
@@ -27,6 +27,17 @@ export const reportService = {
     return data;
   },
 
+  exportPaidClientsCsv: async (
+    seasonId?: string,
+  ): Promise<ReportExportResponse> => {
+    const { data } = await apiClient.post<ReportExportResponse>(
+      "/reports/paid-clients-csv",
+      null,
+      { params: seasonId ? { season_id: seasonId } : undefined },
+    );
+    return data;
+  },
+
   exportClientsPdf: async (
     seasonId?: string,
   ): Promise<ReportExportResponse> => {


### PR DESCRIPTION
## 📌 Resumo das Alterações

Esta entrega implementa a exportação de clientes pagos em formato CSV e corrige o template de e-mail de notificação de relatório pronto, atendendo todos os requisitos da issue #51.

### 🛠️ Principais Modificações:
1. **Backend - Usecase de Relatórios (`backend/internal/application/usecase/report/`)**:
   - Adicionado método `GeneratePaidClientsCSV` que processa via streaming e filtra apenas fotos com pagamentos confirmados (excluindo `"Não pago"` e fotos sem pagamento informado).
   - Cabeçalhos CSV estruturados e sanitizados contra CSV Injection (CWE-1236): `Nome`, `E-mail`, `E-mail alternativo`, `Telefone`, `Dono`, `Raça`, `Juiz`, `Competições Vencidas`, `Número do Arquivo da Foto`, `Fotografo`, `Forma de Pagamento`, `Valor Pago`, `Data da Foto`.
   - Armazenamento em `reports/tenant_{tenantID}/clientes_pagos_{timestamp}.csv` e disparo de e-mail assíncrono com assunto `"Relatório de Clientes Pagos"`.

2. **Backend - Template de E-mail (`report_ready.html` & `sender.go`)**:
   - Ajustado texto e botão do template HTML para formato neutro (`"Clique no botão abaixo para fazer o download do arquivo:"` e botão `"Baixar Relatório"`), garantindo consistência para relatórios em PDF e CSV.

3. **Backend - REST Handlers, Router & Swagger (`backend/internal/interfaces/rest/`)**:
   - Criado handler `ExportPaidClientsCSV` no `report_handler.go` e mapeada rota `POST /api/v1/reports/paid-clients-csv` no `router.go`.
   - Gerada documentação OpenAPI/Swagger atualizada (`./scripts/swagger.sh`).
   - Adicionada suíte de testes unitários em `report_handler_test.go`.

4. **Frontend - Serviço e UI (`frontend/`)**:
   - Adicionado método `exportPaidClientsCsv` em `report.service.ts`.
   - Incluída opção `"Exportar Pagos (.csv)"` no menu suspenso de Relatórios em `ClientsPage.tsx` e `DashboardPage.tsx`.
   - Cobertura com testes unitários em `DashboardPage.test.tsx`.

---

## 🧪 Checklist de Validação
- [x] `./scripts/swagger.sh` (Swagger OpenAPI docs gerados e sincronizados)
- [x] `./scripts/check.sh backend` (100% dos testes unitários e `go vet` aprovados)
- [x] `./scripts/check.sh frontend` (typecheck, lint, format e testes Vitest aprovados)
- [x] `./scripts/check.sh all` (Validação geral da stack completa aprovada)

Closes #51