### PR TITLE
feat(plans): limites por plano no tenant, expiracao de trial e bloqueio por inadimplencia (#54)

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -65,7 +65,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Cria uma nova organização (tenant) imutável no sistema",
+                "description": "Cria uma nova organização (tenant) no sistema com plano e status inicial",
                 "consumes": [
                     "application/json"
                 ],
@@ -114,6 +114,146 @@ const docTemplate = `{
                     },
                     "409": {
                         "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.ErrorEnvelope"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/admin/tenants/{name}/payment-status": {
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Atualiza o status financeiro da organização (paid ou unpaid)",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Admin"
+                ],
+                "summary": "Atualizar status de pagamento da organização",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Nome do Tenant",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Novo status financeiro",
+                        "name": "payload",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.UpdateTenantPaymentStatusRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.SuccessEnvelope"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.ErrorEnvelope"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.ErrorEnvelope"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.ErrorEnvelope"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.ErrorEnvelope"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/admin/tenants/{name}/plan": {
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Atualiza o plano da organização (free ou standard) e renova 14 dias de teste se free",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Admin"
+                ],
+                "summary": "Atualizar plano da organização",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Nome do Tenant",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Novo plano",
+                        "name": "payload",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.UpdateTenantPlanRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.SuccessEnvelope"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.ErrorEnvelope"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.ErrorEnvelope"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.ErrorEnvelope"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
                         "schema": {
                             "$ref": "#/definitions/httpx.ErrorEnvelope"
                         }
@@ -665,6 +805,12 @@ const docTemplate = `{
                             "type": "string"
                         }
                     },
+                    "403": {
+                        "description": "Tenant bloqueado ou expirado",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
                     "500": {
                         "description": "Erro interno",
                         "schema": {
@@ -775,6 +921,12 @@ const docTemplate = `{
                             "type": "string"
                         }
                     },
+                    "403": {
+                        "description": "Tenant bloqueado ou expirado",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
                     "404": {
                         "description": "Cliente não encontrado",
                         "schema": {
@@ -819,6 +971,12 @@ const docTemplate = `{
                     },
                     "401": {
                         "description": "Não autenticado",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "Tenant bloqueado ou expirado",
                         "schema": {
                             "type": "string"
                         }
@@ -904,6 +1062,12 @@ const docTemplate = `{
                     },
                     "401": {
                         "description": "Não autenticado",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "Tenant bloqueado ou expirado",
                         "schema": {
                             "type": "string"
                         }
@@ -1018,6 +1182,12 @@ const docTemplate = `{
                             "type": "string"
                         }
                     },
+                    "403": {
+                        "description": "Tenant bloqueado ou expirado",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
                     "500": {
                         "description": "Erro interno",
                         "schema": {
@@ -1056,6 +1226,12 @@ const docTemplate = `{
                     },
                     "401": {
                         "description": "Não autenticado",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "Tenant bloqueado ou expirado",
                         "schema": {
                             "type": "string"
                         }
@@ -1141,6 +1317,12 @@ const docTemplate = `{
                     },
                     "401": {
                         "description": "Não autenticado",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "Tenant bloqueado ou expirado",
                         "schema": {
                             "type": "string"
                         }
@@ -1255,6 +1437,12 @@ const docTemplate = `{
                             "type": "string"
                         }
                     },
+                    "403": {
+                        "description": "Tenant bloqueado ou expirado",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
                     "500": {
                         "description": "Erro interno",
                         "schema": {
@@ -1293,6 +1481,12 @@ const docTemplate = `{
                     },
                     "401": {
                         "description": "Não autenticado",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "Tenant bloqueado ou expirado",
                         "schema": {
                             "type": "string"
                         }
@@ -1338,7 +1532,7 @@ const docTemplate = `{
                         }
                     },
                     "403": {
-                        "description": "Tenant não associado",
+                        "description": "Tenant não associado ou bloqueado",
                         "schema": {
                             "$ref": "#/definitions/httpx.ErrorEnvelope"
                         }
@@ -1384,7 +1578,7 @@ const docTemplate = `{
                         }
                     },
                     "403": {
-                        "description": "Tenant não associado",
+                        "description": "Tenant não associado ou bloqueado",
                         "schema": {
                             "$ref": "#/definitions/httpx.ErrorEnvelope"
                         }
@@ -1428,7 +1622,7 @@ const docTemplate = `{
                         }
                     },
                     "403": {
-                        "description": "Tenant não associado",
+                        "description": "Tenant não associado ou bloqueado",
                         "schema": {
                             "$ref": "#/definitions/httpx.ErrorEnvelope"
                         }
@@ -1534,7 +1728,7 @@ const docTemplate = `{
                         }
                     },
                     "403": {
-                        "description": "Tenant não associado",
+                        "description": "Tenant não associado ou bloqueado",
                         "schema": {
                             "$ref": "#/definitions/httpx.ErrorEnvelope"
                         }
@@ -1580,7 +1774,7 @@ const docTemplate = `{
                         }
                     },
                     "403": {
-                        "description": "Tenant não associado",
+                        "description": "Tenant não associado ou bloqueado",
                         "schema": {
                             "$ref": "#/definitions/httpx.ErrorEnvelope"
                         }
@@ -1666,6 +1860,12 @@ const docTemplate = `{
                     },
                     "401": {
                         "description": "Não autenticado",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "Tenant bloqueado ou limite excedido",
                         "schema": {
                             "type": "string"
                         }
@@ -1780,6 +1980,12 @@ const docTemplate = `{
                             "type": "string"
                         }
                     },
+                    "403": {
+                        "description": "Tenant bloqueado",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
                     "500": {
                         "description": "Erro interno",
                         "schema": {
@@ -1822,10 +2028,59 @@ const docTemplate = `{
                             "type": "string"
                         }
                     },
+                    "403": {
+                        "description": "Tenant bloqueado",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
                     "500": {
                         "description": "Erro interno",
                         "schema": {
                             "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/tenant": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retorna o status, plano, período de teste e limites da organização associada ao usuário autenticado",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Tenant"
+                ],
+                "summary": "Dados do tenant atual",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.SuccessEnvelope"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.ErrorEnvelope"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.ErrorEnvelope"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.ErrorEnvelope"
                         }
                     }
                 }
@@ -2019,6 +2274,14 @@ const docTemplate = `{
                 "name": {
                     "type": "string",
                     "example": "acme-corp"
+                },
+                "paymentStatus": {
+                    "type": "string",
+                    "example": "paid"
+                },
+                "plan": {
+                    "type": "string",
+                    "example": "free"
                 }
             }
         },
@@ -2071,6 +2334,24 @@ const docTemplate = `{
                 "token": {
                     "type": "string",
                     "example": "a1b2c3d4e5f6..."
+                }
+            }
+        },
+        "handlers.UpdateTenantPaymentStatusRequest": {
+            "type": "object",
+            "properties": {
+                "paymentStatus": {
+                    "type": "string",
+                    "example": "paid"
+                }
+            }
+        },
+        "handlers.UpdateTenantPlanRequest": {
+            "type": "object",
+            "properties": {
+                "plan": {
+                    "type": "string",
+                    "example": "standard"
                 }
             }
         },

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -59,7 +59,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Cria uma nova organização (tenant) imutável no sistema",
+                "description": "Cria uma nova organização (tenant) no sistema com plano e status inicial",
                 "consumes": [
                     "application/json"
                 ],
@@ -108,6 +108,146 @@
                     },
                     "409": {
                         "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.ErrorEnvelope"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/admin/tenants/{name}/payment-status": {
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Atualiza o status financeiro da organização (paid ou unpaid)",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Admin"
+                ],
+                "summary": "Atualizar status de pagamento da organização",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Nome do Tenant",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Novo status financeiro",
+                        "name": "payload",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.UpdateTenantPaymentStatusRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.SuccessEnvelope"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.ErrorEnvelope"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.ErrorEnvelope"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.ErrorEnvelope"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.ErrorEnvelope"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/admin/tenants/{name}/plan": {
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Atualiza o plano da organização (free ou standard) e renova 14 dias de teste se free",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Admin"
+                ],
+                "summary": "Atualizar plano da organização",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Nome do Tenant",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Novo plano",
+                        "name": "payload",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.UpdateTenantPlanRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.SuccessEnvelope"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.ErrorEnvelope"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.ErrorEnvelope"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.ErrorEnvelope"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
                         "schema": {
                             "$ref": "#/definitions/httpx.ErrorEnvelope"
                         }
@@ -659,6 +799,12 @@
                             "type": "string"
                         }
                     },
+                    "403": {
+                        "description": "Tenant bloqueado ou expirado",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
                     "500": {
                         "description": "Erro interno",
                         "schema": {
@@ -769,6 +915,12 @@
                             "type": "string"
                         }
                     },
+                    "403": {
+                        "description": "Tenant bloqueado ou expirado",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
                     "404": {
                         "description": "Cliente não encontrado",
                         "schema": {
@@ -813,6 +965,12 @@
                     },
                     "401": {
                         "description": "Não autenticado",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "Tenant bloqueado ou expirado",
                         "schema": {
                             "type": "string"
                         }
@@ -898,6 +1056,12 @@
                     },
                     "401": {
                         "description": "Não autenticado",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "Tenant bloqueado ou expirado",
                         "schema": {
                             "type": "string"
                         }
@@ -1012,6 +1176,12 @@
                             "type": "string"
                         }
                     },
+                    "403": {
+                        "description": "Tenant bloqueado ou expirado",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
                     "500": {
                         "description": "Erro interno",
                         "schema": {
@@ -1050,6 +1220,12 @@
                     },
                     "401": {
                         "description": "Não autenticado",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "Tenant bloqueado ou expirado",
                         "schema": {
                             "type": "string"
                         }
@@ -1135,6 +1311,12 @@
                     },
                     "401": {
                         "description": "Não autenticado",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "Tenant bloqueado ou expirado",
                         "schema": {
                             "type": "string"
                         }
@@ -1249,6 +1431,12 @@
                             "type": "string"
                         }
                     },
+                    "403": {
+                        "description": "Tenant bloqueado ou expirado",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
                     "500": {
                         "description": "Erro interno",
                         "schema": {
@@ -1287,6 +1475,12 @@
                     },
                     "401": {
                         "description": "Não autenticado",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "Tenant bloqueado ou expirado",
                         "schema": {
                             "type": "string"
                         }
@@ -1332,7 +1526,7 @@
                         }
                     },
                     "403": {
-                        "description": "Tenant não associado",
+                        "description": "Tenant não associado ou bloqueado",
                         "schema": {
                             "$ref": "#/definitions/httpx.ErrorEnvelope"
                         }
@@ -1378,7 +1572,7 @@
                         }
                     },
                     "403": {
-                        "description": "Tenant não associado",
+                        "description": "Tenant não associado ou bloqueado",
                         "schema": {
                             "$ref": "#/definitions/httpx.ErrorEnvelope"
                         }
@@ -1422,7 +1616,7 @@
                         }
                     },
                     "403": {
-                        "description": "Tenant não associado",
+                        "description": "Tenant não associado ou bloqueado",
                         "schema": {
                             "$ref": "#/definitions/httpx.ErrorEnvelope"
                         }
@@ -1528,7 +1722,7 @@
                         }
                     },
                     "403": {
-                        "description": "Tenant não associado",
+                        "description": "Tenant não associado ou bloqueado",
                         "schema": {
                             "$ref": "#/definitions/httpx.ErrorEnvelope"
                         }
@@ -1574,7 +1768,7 @@
                         }
                     },
                     "403": {
-                        "description": "Tenant não associado",
+                        "description": "Tenant não associado ou bloqueado",
                         "schema": {
                             "$ref": "#/definitions/httpx.ErrorEnvelope"
                         }
@@ -1660,6 +1854,12 @@
                     },
                     "401": {
                         "description": "Não autenticado",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "Tenant bloqueado ou limite excedido",
                         "schema": {
                             "type": "string"
                         }
@@ -1774,6 +1974,12 @@
                             "type": "string"
                         }
                     },
+                    "403": {
+                        "description": "Tenant bloqueado",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
                     "500": {
                         "description": "Erro interno",
                         "schema": {
@@ -1816,10 +2022,59 @@
                             "type": "string"
                         }
                     },
+                    "403": {
+                        "description": "Tenant bloqueado",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
                     "500": {
                         "description": "Erro interno",
                         "schema": {
                             "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/tenant": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retorna o status, plano, período de teste e limites da organização associada ao usuário autenticado",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Tenant"
+                ],
+                "summary": "Dados do tenant atual",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.SuccessEnvelope"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.ErrorEnvelope"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.ErrorEnvelope"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/httpx.ErrorEnvelope"
                         }
                     }
                 }
@@ -2013,6 +2268,14 @@
                 "name": {
                     "type": "string",
                     "example": "acme-corp"
+                },
+                "paymentStatus": {
+                    "type": "string",
+                    "example": "paid"
+                },
+                "plan": {
+                    "type": "string",
+                    "example": "free"
                 }
             }
         },
@@ -2065,6 +2328,24 @@
                 "token": {
                     "type": "string",
                     "example": "a1b2c3d4e5f6..."
+                }
+            }
+        },
+        "handlers.UpdateTenantPaymentStatusRequest": {
+            "type": "object",
+            "properties": {
+                "paymentStatus": {
+                    "type": "string",
+                    "example": "paid"
+                }
+            }
+        },
+        "handlers.UpdateTenantPlanRequest": {
+            "type": "object",
+            "properties": {
+                "plan": {
+                    "type": "string",
+                    "example": "standard"
                 }
             }
         },

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -84,6 +84,12 @@ definitions:
       name:
         example: acme-corp
         type: string
+      paymentStatus:
+        example: paid
+        type: string
+      plan:
+        example: free
+        type: string
     type: object
   handlers.ForgotPasswordRequest:
     properties:
@@ -119,6 +125,18 @@ definitions:
         type: string
       token:
         example: a1b2c3d4e5f6...
+        type: string
+    type: object
+  handlers.UpdateTenantPaymentStatusRequest:
+    properties:
+      paymentStatus:
+        example: paid
+        type: string
+    type: object
+  handlers.UpdateTenantPlanRequest:
+    properties:
+      plan:
+        example: standard
         type: string
     type: object
   handlers.VerifyEmailRequest:
@@ -235,7 +253,8 @@ paths:
     post:
       consumes:
       - application/json
-      description: Cria uma nova organização (tenant) imutável no sistema
+      description: Cria uma nova organização (tenant) no sistema com plano e status
+        inicial
       parameters:
       - description: Dados do tenant
         in: body
@@ -269,6 +288,97 @@ paths:
       security:
       - BearerAuth: []
       summary: Criar novo tenant
+      tags:
+      - Admin
+  /api/v1/admin/tenants/{name}/payment-status:
+    put:
+      consumes:
+      - application/json
+      description: Atualiza o status financeiro da organização (paid ou unpaid)
+      parameters:
+      - description: Nome do Tenant
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: Novo status financeiro
+        in: body
+        name: payload
+        required: true
+        schema:
+          $ref: '#/definitions/handlers.UpdateTenantPaymentStatusRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/httpx.SuccessEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/httpx.ErrorEnvelope'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/httpx.ErrorEnvelope'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/httpx.ErrorEnvelope'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/httpx.ErrorEnvelope'
+      security:
+      - BearerAuth: []
+      summary: Atualizar status de pagamento da organização
+      tags:
+      - Admin
+  /api/v1/admin/tenants/{name}/plan:
+    put:
+      consumes:
+      - application/json
+      description: Atualiza o plano da organização (free ou standard) e renova 14
+        dias de teste se free
+      parameters:
+      - description: Nome do Tenant
+        in: path
+        name: name
+        required: true
+        type: string
+      - description: Novo plano
+        in: body
+        name: payload
+        required: true
+        schema:
+          $ref: '#/definitions/handlers.UpdateTenantPlanRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/httpx.SuccessEnvelope'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/httpx.ErrorEnvelope'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/httpx.ErrorEnvelope'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/httpx.ErrorEnvelope'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/httpx.ErrorEnvelope'
+      security:
+      - BearerAuth: []
+      summary: Atualizar plano da organização
       tags:
       - Admin
   /api/v1/admin/users:
@@ -627,6 +737,10 @@ paths:
           description: Não autenticado
           schema:
             type: string
+        "403":
+          description: Tenant bloqueado ou expirado
+          schema:
+            type: string
         "500":
           description: Erro interno
           schema:
@@ -654,6 +768,10 @@ paths:
             type: string
         "401":
           description: Não autenticado
+          schema:
+            type: string
+        "403":
+          description: Tenant bloqueado ou expirado
           schema:
             type: string
         "500":
@@ -728,6 +846,10 @@ paths:
           description: Não autenticado
           schema:
             type: string
+        "403":
+          description: Tenant bloqueado ou expirado
+          schema:
+            type: string
         "404":
           description: Cliente não encontrado
           schema:
@@ -788,6 +910,10 @@ paths:
           description: Não autenticado
           schema:
             type: string
+        "403":
+          description: Tenant bloqueado ou expirado
+          schema:
+            type: string
         "500":
           description: Erro interno
           schema:
@@ -815,6 +941,10 @@ paths:
             type: string
         "401":
           description: Não autenticado
+          schema:
+            type: string
+        "403":
+          description: Tenant bloqueado ou expirado
           schema:
             type: string
         "500":
@@ -889,6 +1019,10 @@ paths:
           description: Não autenticado
           schema:
             type: string
+        "403":
+          description: Tenant bloqueado ou expirado
+          schema:
+            type: string
         "500":
           description: Erro interno
           schema:
@@ -945,6 +1079,10 @@ paths:
           description: Não autenticado
           schema:
             type: string
+        "403":
+          description: Tenant bloqueado ou expirado
+          schema:
+            type: string
         "500":
           description: Erro interno
           schema:
@@ -972,6 +1110,10 @@ paths:
             type: string
         "401":
           description: Não autenticado
+          schema:
+            type: string
+        "403":
+          description: Tenant bloqueado ou expirado
           schema:
             type: string
         "500":
@@ -1046,6 +1188,10 @@ paths:
           description: Não autenticado
           schema:
             type: string
+        "403":
+          description: Tenant bloqueado ou expirado
+          schema:
+            type: string
         "500":
           description: Erro interno
           schema:
@@ -1075,7 +1221,7 @@ paths:
           schema:
             $ref: '#/definitions/httpx.ErrorEnvelope'
         "403":
-          description: Tenant não associado
+          description: Tenant não associado ou bloqueado
           schema:
             $ref: '#/definitions/httpx.ErrorEnvelope'
         "500":
@@ -1106,7 +1252,7 @@ paths:
           schema:
             $ref: '#/definitions/httpx.ErrorEnvelope'
         "403":
-          description: Tenant não associado
+          description: Tenant não associado ou bloqueado
           schema:
             $ref: '#/definitions/httpx.ErrorEnvelope'
         "500":
@@ -1137,7 +1283,7 @@ paths:
           schema:
             $ref: '#/definitions/httpx.ErrorEnvelope'
         "403":
-          description: Tenant não associado
+          description: Tenant não associado ou bloqueado
           schema:
             $ref: '#/definitions/httpx.ErrorEnvelope'
         "500":
@@ -1210,7 +1356,7 @@ paths:
           schema:
             $ref: '#/definitions/httpx.ErrorEnvelope'
         "403":
-          description: Tenant não associado
+          description: Tenant não associado ou bloqueado
           schema:
             $ref: '#/definitions/httpx.ErrorEnvelope'
         "500":
@@ -1242,7 +1388,7 @@ paths:
           schema:
             $ref: '#/definitions/httpx.ErrorEnvelope'
         "403":
-          description: Tenant não associado
+          description: Tenant não associado ou bloqueado
           schema:
             $ref: '#/definitions/httpx.ErrorEnvelope'
         "500":
@@ -1301,6 +1447,10 @@ paths:
           description: Não autenticado
           schema:
             type: string
+        "403":
+          description: Tenant bloqueado ou limite excedido
+          schema:
+            type: string
         "500":
           description: Erro interno
           schema:
@@ -1328,6 +1478,10 @@ paths:
             type: string
         "401":
           description: Não autenticado
+          schema:
+            type: string
+        "403":
+          description: Tenant bloqueado
           schema:
             type: string
         "500":
@@ -1402,6 +1556,10 @@ paths:
           description: Não autenticado
           schema:
             type: string
+        "403":
+          description: Tenant bloqueado
+          schema:
+            type: string
         "500":
           description: Erro interno
           schema:
@@ -1409,6 +1567,34 @@ paths:
       summary: Atualizar temporada
       tags:
       - Seasons
+  /api/v1/tenant:
+    get:
+      description: Retorna o status, plano, período de teste e limites da organização
+        associada ao usuário autenticado
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/httpx.SuccessEnvelope'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/httpx.ErrorEnvelope'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/httpx.ErrorEnvelope'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/httpx.ErrorEnvelope'
+      security:
+      - BearerAuth: []
+      summary: Dados do tenant atual
+      tags:
+      - Tenant
   /health:
     get:
       description: Retorna o status geral de saúde da aplicação

--- a/backend/internal/application/ports/client/repository.go
+++ b/backend/internal/application/ports/client/repository.go
@@ -10,6 +10,8 @@ type Repository interface {
 	GetByID(ctx context.Context, id, tenantID string) (*client.SeasonClient, error)
 	List(ctx context.Context, tenantID string, filter client.ListFilter) (*client.PaginatedClients, error)
 	StreamByTenant(ctx context.Context, tenantID, seasonID string, fn func(c *client.SeasonClient) error) error
+	CountBySeason(ctx context.Context, tenantID, seasonID string) (int64, error)
+	MaxClientsPerSeason(ctx context.Context, tenantID string) (int64, error)
 	Update(ctx context.Context, client *client.SeasonClient) error
 	Delete(ctx context.Context, id, tenantID string) error
 	DeleteBySeasonID(ctx context.Context, seasonID, tenantID string) error

--- a/backend/internal/application/ports/tenant/repository.go
+++ b/backend/internal/application/ports/tenant/repository.go
@@ -16,4 +16,12 @@ type Repository interface {
 	Create(ctx context.Context, tenant domaintenant.Tenant) (domaintenant.Tenant, error)
 	FindByName(ctx context.Context, name string) (domaintenant.Tenant, error)
 	List(ctx context.Context) ([]domaintenant.Tenant, error)
+	Update(ctx context.Context, tenant domaintenant.Tenant) (domaintenant.Tenant, error)
+}
+
+type Validator interface {
+	ValidateCanCreateSeason(ctx context.Context, tenantID string) error
+	ValidateCanExportReport(ctx context.Context, tenantID, seasonID string) error
+	ValidateCanWriteClients(ctx context.Context, tenantID string) error
+	ValidateCanWriteEntities(ctx context.Context, tenantID string) error
 }

--- a/backend/internal/application/usecase/admin/service_test.go
+++ b/backend/internal/application/usecase/admin/service_test.go
@@ -40,6 +40,14 @@ func (m *mockTenantRepo) List(ctx context.Context) ([]domaintenant.Tenant, error
 	return res, nil
 }
 
+func (m *mockTenantRepo) Update(ctx context.Context, t domaintenant.Tenant) (domaintenant.Tenant, error) {
+	if _, ok := m.items[t.Name]; !ok {
+		return domaintenant.Tenant{}, adminusecase.ErrTenantNotFound
+	}
+	m.items[t.Name] = t
+	return t, nil
+}
+
 func TestAdminService(t *testing.T) {
 	userRepo := usermemory.NewRepository()
 	tenantRepo := newMockTenantRepo()

--- a/backend/internal/application/usecase/client/service.go
+++ b/backend/internal/application/usecase/client/service.go
@@ -8,6 +8,7 @@ import (
 	personport "ps/internal/application/ports/person"
 	photographerport "ps/internal/application/ports/photographer"
 	seasonport "ps/internal/application/ports/season"
+	tenantport "ps/internal/application/ports/tenant"
 	domain "ps/internal/domain/client"
 )
 
@@ -23,6 +24,7 @@ type Service struct {
 	personRepo       personport.Repository
 	seasonRepo       seasonport.Repository
 	photographerRepo photographerport.Repository
+	tenantValidator  tenantport.Validator
 }
 
 func NewService(
@@ -30,12 +32,18 @@ func NewService(
 	personRepo personport.Repository,
 	seasonRepo seasonport.Repository,
 	photographerRepo photographerport.Repository,
+	validator ...tenantport.Validator,
 ) *Service {
+	var tv tenantport.Validator
+	if len(validator) > 0 {
+		tv = validator[0]
+	}
 	return &Service{
 		repo:             repo,
 		personRepo:       personRepo,
 		seasonRepo:       seasonRepo,
 		photographerRepo: photographerRepo,
+		tenantValidator:  tv,
 	}
 }
 
@@ -82,6 +90,11 @@ func (s *Service) validateReferences(ctx context.Context, c *domain.SeasonClient
 }
 
 func (s *Service) Create(ctx context.Context, client *domain.SeasonClient, tenantID string) error {
+	if s.tenantValidator != nil {
+		if err := s.tenantValidator.ValidateCanWriteClients(ctx, tenantID); err != nil {
+			return err
+		}
+	}
 	client.TenantID = tenantID
 	if err := s.validateReferences(ctx, client, tenantID); err != nil {
 		return err
@@ -107,6 +120,11 @@ func (s *Service) List(ctx context.Context, tenantID string, filter domain.ListF
 }
 
 func (s *Service) Update(ctx context.Context, client *domain.SeasonClient, tenantID string) error {
+	if s.tenantValidator != nil {
+		if err := s.tenantValidator.ValidateCanWriteClients(ctx, tenantID); err != nil {
+			return err
+		}
+	}
 	client.TenantID = tenantID
 	if _, err := s.repo.GetByID(ctx, client.ID, tenantID); err != nil {
 		return ErrClientNotFound
@@ -118,5 +136,10 @@ func (s *Service) Update(ctx context.Context, client *domain.SeasonClient, tenan
 }
 
 func (s *Service) Delete(ctx context.Context, id, tenantID string) error {
+	if s.tenantValidator != nil {
+		if err := s.tenantValidator.ValidateCanWriteClients(ctx, tenantID); err != nil {
+			return err
+		}
+	}
 	return s.repo.Delete(ctx, id, tenantID)
 }

--- a/backend/internal/application/usecase/client/service_test.go
+++ b/backend/internal/application/usecase/client/service_test.go
@@ -93,6 +93,32 @@ func (m *mockRepo) Delete(ctx context.Context, id, tenantID string) error {
 	return nil
 }
 
+func (m *mockRepo) CountBySeason(ctx context.Context, tenantID, seasonID string) (int64, error) {
+	var count int64
+	for _, c := range m.items {
+		if c.TenantID == tenantID && (seasonID == "" || c.SeasonID == seasonID) {
+			count++
+		}
+	}
+	return count, nil
+}
+
+func (m *mockRepo) MaxClientsPerSeason(ctx context.Context, tenantID string) (int64, error) {
+	counts := make(map[string]int64)
+	for _, c := range m.items {
+		if c.TenantID == tenantID {
+			counts[c.SeasonID]++
+		}
+	}
+	var maxCount int64
+	for _, cnt := range counts {
+		if cnt > maxCount {
+			maxCount = cnt
+		}
+	}
+	return maxCount, nil
+}
+
 func (m *mockRepo) DeleteBySeasonID(ctx context.Context, seasonID, tenantID string) error {
 	for id, c := range m.items {
 		if c.TenantID == tenantID && c.SeasonID == seasonID {

--- a/backend/internal/application/usecase/person/service.go
+++ b/backend/internal/application/usecase/person/service.go
@@ -2,19 +2,34 @@ package person
 
 import (
 	"context"
+
 	"ps/internal/application/ports/person"
+	tenantport "ps/internal/application/ports/tenant"
 	domain "ps/internal/domain/person"
 )
 
 type Service struct {
-	repo person.Repository
+	repo            person.Repository
+	tenantValidator tenantport.Validator
 }
 
-func NewService(repo person.Repository) *Service {
-	return &Service{repo: repo}
+func NewService(repo person.Repository, validator ...tenantport.Validator) *Service {
+	var tv tenantport.Validator
+	if len(validator) > 0 {
+		tv = validator[0]
+	}
+	return &Service{
+		repo:            repo,
+		tenantValidator: tv,
+	}
 }
 
 func (s *Service) Create(ctx context.Context, person *domain.Person, tenantID string) error {
+	if s.tenantValidator != nil {
+		if err := s.tenantValidator.ValidateCanWriteEntities(ctx, tenantID); err != nil {
+			return err
+		}
+	}
 	person.TenantID = tenantID
 	return s.repo.Create(ctx, person)
 }
@@ -28,10 +43,20 @@ func (s *Service) List(ctx context.Context, tenantID string) ([]*domain.Person, 
 }
 
 func (s *Service) Update(ctx context.Context, person *domain.Person, tenantID string) error {
+	if s.tenantValidator != nil {
+		if err := s.tenantValidator.ValidateCanWriteEntities(ctx, tenantID); err != nil {
+			return err
+		}
+	}
 	person.TenantID = tenantID
 	return s.repo.Update(ctx, person)
 }
 
 func (s *Service) Delete(ctx context.Context, id, tenantID string) error {
+	if s.tenantValidator != nil {
+		if err := s.tenantValidator.ValidateCanWriteEntities(ctx, tenantID); err != nil {
+			return err
+		}
+	}
 	return s.repo.Delete(ctx, id, tenantID)
 }

--- a/backend/internal/application/usecase/photographer/service.go
+++ b/backend/internal/application/usecase/photographer/service.go
@@ -2,19 +2,34 @@ package photographer
 
 import (
 	"context"
+
 	"ps/internal/application/ports/photographer"
+	tenantport "ps/internal/application/ports/tenant"
 	domain "ps/internal/domain/photographer"
 )
 
 type Service struct {
-	repo photographer.Repository
+	repo            photographer.Repository
+	tenantValidator tenantport.Validator
 }
 
-func NewService(repo photographer.Repository) *Service {
-	return &Service{repo: repo}
+func NewService(repo photographer.Repository, validator ...tenantport.Validator) *Service {
+	var tv tenantport.Validator
+	if len(validator) > 0 {
+		tv = validator[0]
+	}
+	return &Service{
+		repo:            repo,
+		tenantValidator: tv,
+	}
 }
 
 func (s *Service) Create(ctx context.Context, photographer *domain.Photographer, tenantID string) error {
+	if s.tenantValidator != nil {
+		if err := s.tenantValidator.ValidateCanWriteEntities(ctx, tenantID); err != nil {
+			return err
+		}
+	}
 	photographer.TenantID = tenantID
 	return s.repo.Create(ctx, photographer)
 }
@@ -28,10 +43,20 @@ func (s *Service) List(ctx context.Context, tenantID string) ([]*domain.Photogra
 }
 
 func (s *Service) Update(ctx context.Context, photographer *domain.Photographer, tenantID string) error {
+	if s.tenantValidator != nil {
+		if err := s.tenantValidator.ValidateCanWriteEntities(ctx, tenantID); err != nil {
+			return err
+		}
+	}
 	photographer.TenantID = tenantID
 	return s.repo.Update(ctx, photographer)
 }
 
 func (s *Service) Delete(ctx context.Context, id, tenantID string) error {
+	if s.tenantValidator != nil {
+		if err := s.tenantValidator.ValidateCanWriteEntities(ctx, tenantID); err != nil {
+			return err
+		}
+	}
 	return s.repo.Delete(ctx, id, tenantID)
 }

--- a/backend/internal/application/usecase/report/service.go
+++ b/backend/internal/application/usecase/report/service.go
@@ -20,6 +20,7 @@ import (
 	personport "ps/internal/application/ports/person"
 	photographerport "ps/internal/application/ports/photographer"
 	storageport "ps/internal/application/ports/storage"
+	tenantport "ps/internal/application/ports/tenant"
 	clientdomain "ps/internal/domain/client"
 	persondomain "ps/internal/domain/person"
 )
@@ -35,6 +36,7 @@ type Service struct {
 	photographerRepo photographerport.Repository
 	storageProvider  storageport.Provider
 	emailSender      emailport.Sender
+	tenantValidator  tenantport.Validator
 	appBaseURL       string
 }
 
@@ -45,9 +47,14 @@ func NewService(
 	storageProvider storageport.Provider,
 	emailSender emailport.Sender,
 	appBaseURL string,
+	validator ...tenantport.Validator,
 ) *Service {
 	if appBaseURL == "" {
 		appBaseURL = "http://localhost:8080"
+	}
+	var tv tenantport.Validator
+	if len(validator) > 0 {
+		tv = validator[0]
 	}
 	return &Service{
 		clientRepo:       clientRepo,
@@ -55,6 +62,7 @@ func NewService(
 		photographerRepo: photographerRepo,
 		storageProvider:  storageProvider,
 		emailSender:      emailSender,
+		tenantValidator:  tv,
 		appBaseURL:       strings.TrimRight(appBaseURL, "/"),
 	}
 }
@@ -166,6 +174,12 @@ func formatPhotoDate(photo *clientdomain.Photo, clientCreatedAt time.Time) strin
 func (s *Service) GenerateClientsCSV(ctx context.Context, tenantID, seasonID, userEmail, userName string) (string, error) {
 	if tenantID == "" {
 		return "", errors.New("tenant ID cannot be empty")
+	}
+
+	if s.tenantValidator != nil {
+		if err := s.tenantValidator.ValidateCanExportReport(ctx, tenantID, seasonID); err != nil {
+			return "", err
+		}
 	}
 
 	// 1. Fetch photographers to map IDs to names
@@ -373,6 +387,12 @@ func (s *Service) GenerateUnpaidClientsCSV(ctx context.Context, tenantID, season
 		return "", errors.New("tenant ID cannot be empty")
 	}
 
+	if s.tenantValidator != nil {
+		if err := s.tenantValidator.ValidateCanExportReport(ctx, tenantID, seasonID); err != nil {
+			return "", err
+		}
+	}
+
 	// 1. Fetch photographers to map IDs to names
 	photographersList, err := s.photographerRepo.List(ctx, tenantID)
 	if err != nil {
@@ -512,6 +532,12 @@ func (s *Service) GenerateUnpaidClientsCSV(ctx context.Context, tenantID, season
 func (s *Service) GeneratePaidClientsCSV(ctx context.Context, tenantID, seasonID, userEmail, userName string) (string, error) {
 	if tenantID == "" {
 		return "", errors.New("tenant ID cannot be empty")
+	}
+
+	if s.tenantValidator != nil {
+		if err := s.tenantValidator.ValidateCanExportReport(ctx, tenantID, seasonID); err != nil {
+			return "", err
+		}
 	}
 
 	// 1. Fetch photographers to map IDs to names
@@ -751,6 +777,12 @@ func (s *Service) buildClientsPDF(ctx context.Context, tenantID, seasonID string
 		return nil, errors.New("tenant ID cannot be empty")
 	}
 
+	if s.tenantValidator != nil {
+		if err := s.tenantValidator.ValidateCanExportReport(ctx, tenantID, seasonID); err != nil {
+			return nil, err
+		}
+	}
+
 	// Fetch photographers
 	photographersList, err := s.photographerRepo.List(ctx, tenantID)
 	if err != nil {
@@ -969,11 +1001,24 @@ func (s *Service) GenerateClientsPDF(ctx context.Context, tenantID, seasonID, us
 	return relativePath, nil
 }
 
+func (s *Service) ValidateAccess(ctx context.Context, tenantID, seasonID string) error {
+	if s.tenantValidator != nil {
+		return s.tenantValidator.ValidateCanExportReport(ctx, tenantID, seasonID)
+	}
+	return nil
+}
+
 func (s *Service) GenerateDirectClientsPDF(ctx context.Context, tenantID, seasonID string) ([]byte, error) {
 	return s.buildClientsPDF(ctx, tenantID, seasonID)
 }
 
 func (s *Service) GetReportFile(ctx context.Context, tenantID, relativePath string) ([]byte, error) {
+	if s.tenantValidator != nil {
+		if err := s.tenantValidator.ValidateCanExportReport(ctx, tenantID, ""); err != nil {
+			return nil, err
+		}
+	}
+
 	cleanPath := filepath.Clean(strings.TrimPrefix(relativePath, "/"))
 	if strings.Contains(cleanPath, "..") {
 		return nil, ErrInvalidReportPath

--- a/backend/internal/application/usecase/report/service_test.go
+++ b/backend/internal/application/usecase/report/service_test.go
@@ -47,6 +47,30 @@ func (m *mockClientRepo) Update(ctx context.Context, client *clientdomain.Season
 func (m *mockClientRepo) Delete(ctx context.Context, id, tenantID string) error {
 	return nil
 }
+func (m *mockClientRepo) CountBySeason(ctx context.Context, tenantID, seasonID string) (int64, error) {
+	var count int64
+	for _, c := range m.clients {
+		if c.TenantID == tenantID && (seasonID == "" || c.SeasonID == seasonID) {
+			count++
+		}
+	}
+	return count, nil
+}
+func (m *mockClientRepo) MaxClientsPerSeason(ctx context.Context, tenantID string) (int64, error) {
+	counts := make(map[string]int64)
+	for _, c := range m.clients {
+		if c.TenantID == tenantID {
+			counts[c.SeasonID]++
+		}
+	}
+	var maxCount int64
+	for _, cnt := range counts {
+		if cnt > maxCount {
+			maxCount = cnt
+		}
+	}
+	return maxCount, nil
+}
 func (m *mockClientRepo) DeleteBySeasonID(ctx context.Context, seasonID, tenantID string) error {
 	return nil
 }

--- a/backend/internal/application/usecase/season/service.go
+++ b/backend/internal/application/usecase/season/service.go
@@ -7,22 +7,34 @@ import (
 
 	clientport "ps/internal/application/ports/client"
 	"ps/internal/application/ports/season"
+	tenantport "ps/internal/application/ports/tenant"
 	domain "ps/internal/domain/season"
 )
 
 type Service struct {
-	repo       season.Repository
-	clientRepo clientport.Repository
+	repo            season.Repository
+	clientRepo      clientport.Repository
+	tenantValidator tenantport.Validator
 }
 
-func NewService(repo season.Repository, clientRepo clientport.Repository) *Service {
+func NewService(repo season.Repository, clientRepo clientport.Repository, validator ...tenantport.Validator) *Service {
+	var tv tenantport.Validator
+	if len(validator) > 0 {
+		tv = validator[0]
+	}
 	return &Service{
-		repo:       repo,
-		clientRepo: clientRepo,
+		repo:            repo,
+		clientRepo:      clientRepo,
+		tenantValidator: tv,
 	}
 }
 
 func (s *Service) Create(ctx context.Context, season *domain.Season, tenantID string) error {
+	if s.tenantValidator != nil {
+		if err := s.tenantValidator.ValidateCanCreateSeason(ctx, tenantID); err != nil {
+			return err
+		}
+	}
 	season.TenantID = tenantID
 	return s.repo.Create(ctx, season)
 }
@@ -36,11 +48,21 @@ func (s *Service) List(ctx context.Context, tenantID string) ([]*domain.Season, 
 }
 
 func (s *Service) Update(ctx context.Context, season *domain.Season, tenantID string) error {
+	if s.tenantValidator != nil {
+		if err := s.tenantValidator.ValidateCanWriteEntities(ctx, tenantID); err != nil {
+			return err
+		}
+	}
 	season.TenantID = tenantID
 	return s.repo.Update(ctx, season)
 }
 
 func (s *Service) Delete(ctx context.Context, id, tenantID string) error {
+	if s.tenantValidator != nil {
+		if err := s.tenantValidator.ValidateCanWriteEntities(ctx, tenantID); err != nil {
+			return err
+		}
+	}
 	if err := s.repo.Delete(ctx, id, tenantID); err != nil {
 		return err
 	}

--- a/backend/internal/application/usecase/season/service_test.go
+++ b/backend/internal/application/usecase/season/service_test.go
@@ -118,6 +118,32 @@ func (m *mockClientRepo) Delete(ctx context.Context, id, tenantID string) error 
 	return nil
 }
 
+func (m *mockClientRepo) CountBySeason(ctx context.Context, tenantID, seasonID string) (int64, error) {
+	var count int64
+	for _, c := range m.items {
+		if c.TenantID == tenantID && (seasonID == "" || c.SeasonID == seasonID) {
+			count++
+		}
+	}
+	return count, nil
+}
+
+func (m *mockClientRepo) MaxClientsPerSeason(ctx context.Context, tenantID string) (int64, error) {
+	counts := make(map[string]int64)
+	for _, c := range m.items {
+		if c.TenantID == tenantID {
+			counts[c.SeasonID]++
+		}
+	}
+	var maxCount int64
+	for _, cnt := range counts {
+		if cnt > maxCount {
+			maxCount = cnt
+		}
+	}
+	return maxCount, nil
+}
+
 func (m *mockClientRepo) DeleteBySeasonID(ctx context.Context, seasonID, tenantID string) error {
 	for id, c := range m.items {
 		if c.TenantID == tenantID && c.SeasonID == seasonID {

--- a/backend/internal/application/usecase/tenant/service.go
+++ b/backend/internal/application/usecase/tenant/service.go
@@ -7,30 +7,81 @@ import (
 	"strings"
 	"time"
 
+	clientport "ps/internal/application/ports/client"
 	tenantport "ps/internal/application/ports/tenant"
 	domaintenant "ps/internal/domain/tenant"
 )
 
 var (
-	ErrInvalidName   = errors.New("invalid tenant name")
-	ErrAlreadyExists = tenantport.ErrAlreadyExists
-	ErrNotFound      = tenantport.ErrNotFound
+	ErrInvalidName          = errors.New("invalid tenant name")
+	ErrInvalidPlan          = errors.New("invalid plan: must be 'free' or 'standard'")
+	ErrInvalidPaymentStatus = errors.New("invalid payment status: must be 'paid' or 'unpaid'")
+	ErrAlreadyExists        = tenantport.ErrAlreadyExists
+	ErrNotFound             = tenantport.ErrNotFound
+	ErrLimitExceeded        = domaintenant.ErrLimitExceeded
+	ErrPaymentUnpaid        = domaintenant.ErrPaymentUnpaid
+	ErrTrialExpired         = domaintenant.ErrTrialExpired
 
 	validNameRegex = regexp.MustCompile(`^[a-zA-Z0-9_\-]+$`)
 )
 
+type CreateTenantInput struct {
+	Name          string
+	Plan          string
+	PaymentStatus string
+}
+
+type TenantStatusDTO struct {
+	Name                string     `json:"name"`
+	Plan                string     `json:"plan"`
+	PaymentStatus       string     `json:"paymentStatus"`
+	PlanStartedAt       *time.Time `json:"planStartedAt,omitempty"`
+	PlanExpiresAt       *time.Time `json:"planExpiresAt,omitempty"`
+	IsTrialExpired      bool       `json:"isTrialExpired"`
+	TrialDaysRemaining  int        `json:"trialDaysRemaining"`
+	IsUnpaid            bool       `json:"isUnpaid"`
+	ClientLimitExceeded bool       `json:"clientLimitExceeded"`
+	MaxClientsInSeason  int64      `json:"maxClientsInSeason"`
+	CreatedAt           time.Time  `json:"createdAt"`
+	UpdatedAt           time.Time  `json:"updatedAt,omitempty"`
+}
+
 type Service struct {
-	repo tenantport.Repository
+	repo       tenantport.Repository
+	clientRepo clientport.Repository
 }
 
-func NewService(repo tenantport.Repository) *Service {
-	return &Service{repo: repo}
+func NewService(repo tenantport.Repository, clientRepo ...clientport.Repository) *Service {
+	var cr clientport.Repository
+	if len(clientRepo) > 0 {
+		cr = clientRepo[0]
+	}
+	return &Service{
+		repo:       repo,
+		clientRepo: cr,
+	}
 }
 
-func (s *Service) Create(ctx context.Context, name string) (domaintenant.Tenant, error) {
-	cleanName := strings.TrimSpace(name)
+func (s *Service) Create(ctx context.Context, input CreateTenantInput) (domaintenant.Tenant, error) {
+	cleanName := strings.TrimSpace(input.Name)
 	if cleanName == "" || len(cleanName) > 128 || !validNameRegex.MatchString(cleanName) {
 		return domaintenant.Tenant{}, ErrInvalidName
+	}
+
+	plan := strings.ToLower(strings.TrimSpace(input.Plan))
+	if plan == "" {
+		plan = domaintenant.PlanFree
+	}
+	if plan != domaintenant.PlanFree && plan != domaintenant.PlanStandard {
+		return domaintenant.Tenant{}, ErrInvalidPlan
+	}
+
+	paymentStatus := strings.ToLower(strings.TrimSpace(input.PaymentStatus))
+	if paymentStatus == "" {
+		paymentStatus = domaintenant.PaymentStatusPaid
+	}
+	if paymentStatus != domaintenant.PaymentStatusPaid && paymentStatus != domaintenant.PaymentStatusUnpaid {
+		return domaintenant.Tenant{}, ErrInvalidPaymentStatus
 	}
 
 	// Check if already exists
@@ -38,12 +89,80 @@ func (s *Service) Create(ctx context.Context, name string) (domaintenant.Tenant,
 		return domaintenant.Tenant{}, ErrAlreadyExists
 	}
 
+	now := time.Now().UTC()
+	var planStartedAt *time.Time = &now
+	var planExpiresAt *time.Time
+	if plan == domaintenant.PlanFree {
+		exp := now.Add(domaintenant.TrialDurationDays * 24 * time.Hour)
+		planExpiresAt = &exp
+	}
+
 	t := domaintenant.Tenant{
-		Name:      cleanName,
-		CreatedAt: time.Now().UTC(),
+		Name:          cleanName,
+		Plan:          plan,
+		PaymentStatus: paymentStatus,
+		PlanStartedAt: planStartedAt,
+		PlanExpiresAt: planExpiresAt,
+		CreatedAt:     now,
+		UpdatedAt:     now,
 	}
 
 	return s.repo.Create(ctx, t)
+}
+
+func (s *Service) UpdatePlan(ctx context.Context, name string, plan string) (domaintenant.Tenant, error) {
+	cleanName := strings.TrimSpace(name)
+	if cleanName == "" {
+		return domaintenant.Tenant{}, ErrInvalidName
+	}
+
+	cleanPlan := strings.ToLower(strings.TrimSpace(plan))
+	if cleanPlan != domaintenant.PlanFree && cleanPlan != domaintenant.PlanStandard {
+		return domaintenant.Tenant{}, ErrInvalidPlan
+	}
+
+	t, err := s.repo.FindByName(ctx, cleanName)
+	if err != nil {
+		return domaintenant.Tenant{}, err
+	}
+
+	now := time.Now().UTC()
+	t.Plan = cleanPlan
+	t.UpdatedAt = now
+
+	if cleanPlan == domaintenant.PlanFree {
+		// Renovar 14 dias de trial se mudar para free
+		t.PlanStartedAt = &now
+		exp := now.Add(domaintenant.TrialDurationDays * 24 * time.Hour)
+		t.PlanExpiresAt = &exp
+	} else if cleanPlan == domaintenant.PlanStandard {
+		t.PlanExpiresAt = nil
+	}
+
+	return s.repo.Update(ctx, t)
+}
+
+func (s *Service) UpdatePaymentStatus(ctx context.Context, name string, status string) (domaintenant.Tenant, error) {
+	cleanName := strings.TrimSpace(name)
+	if cleanName == "" {
+		return domaintenant.Tenant{}, ErrInvalidName
+	}
+
+	cleanStatus := strings.ToLower(strings.TrimSpace(status))
+	if cleanStatus != domaintenant.PaymentStatusPaid && cleanStatus != domaintenant.PaymentStatusUnpaid {
+		return domaintenant.Tenant{}, ErrInvalidPaymentStatus
+	}
+
+	t, err := s.repo.FindByName(ctx, cleanName)
+	if err != nil {
+		return domaintenant.Tenant{}, err
+	}
+
+	now := time.Now().UTC()
+	t.PaymentStatus = cleanStatus
+	t.UpdatedAt = now
+
+	return s.repo.Update(ctx, t)
 }
 
 func (s *Service) List(ctx context.Context) ([]domaintenant.Tenant, error) {
@@ -56,4 +175,129 @@ func (s *Service) GetByName(ctx context.Context, name string) (domaintenant.Tena
 		return domaintenant.Tenant{}, ErrInvalidName
 	}
 	return s.repo.FindByName(ctx, cleanName)
+}
+
+func (s *Service) GetTenantStatus(ctx context.Context, tenantID string) (*TenantStatusDTO, error) {
+	t, err := s.repo.FindByName(ctx, tenantID)
+	if err != nil {
+		return nil, err
+	}
+
+	now := time.Now().UTC()
+	isTrialExpired := t.IsTrialExpired(now)
+	trialDaysRemaining := 0
+	if t.Plan == domaintenant.PlanFree && t.PlanExpiresAt != nil {
+		diff := t.PlanExpiresAt.Sub(now)
+		if diff > 0 {
+			trialDaysRemaining = int((diff + 24*time.Hour - 1) / (24 * time.Hour))
+		}
+	}
+
+	var maxClients int64
+	clientLimitExceeded := false
+	if s.clientRepo != nil {
+		maxClients, _ = s.clientRepo.MaxClientsPerSeason(ctx, tenantID)
+		if maxClients >= domaintenant.StandardMaxClients {
+			clientLimitExceeded = true
+		}
+	}
+
+	return &TenantStatusDTO{
+		Name:                t.Name,
+		Plan:                t.Plan,
+		PaymentStatus:       t.PaymentStatus,
+		PlanStartedAt:       t.PlanStartedAt,
+		PlanExpiresAt:       t.PlanExpiresAt,
+		IsTrialExpired:      isTrialExpired,
+		TrialDaysRemaining:  trialDaysRemaining,
+		IsUnpaid:            t.IsUnpaid(),
+		ClientLimitExceeded: clientLimitExceeded,
+		MaxClientsInSeason:  maxClients,
+		CreatedAt:           t.CreatedAt,
+		UpdatedAt:           t.UpdatedAt,
+	}, nil
+}
+
+func (s *Service) ValidateCanCreateSeason(ctx context.Context, tenantID string) error {
+	t, err := s.repo.FindByName(ctx, tenantID)
+	if err != nil {
+		return err
+	}
+
+	if t.IsUnpaid() {
+		return domaintenant.ErrPaymentUnpaid
+	}
+	if t.IsTrialExpired(time.Now().UTC()) {
+		return domaintenant.ErrTrialExpired
+	}
+
+	if s.clientRepo != nil {
+		maxClients, err := s.clientRepo.MaxClientsPerSeason(ctx, tenantID)
+		if err == nil && maxClients >= domaintenant.StandardMaxClients {
+			return domaintenant.ErrLimitExceeded
+		}
+	}
+
+	return nil
+}
+
+func (s *Service) ValidateCanExportReport(ctx context.Context, tenantID, seasonID string) error {
+	t, err := s.repo.FindByName(ctx, tenantID)
+	if err != nil {
+		return err
+	}
+
+	if t.IsUnpaid() {
+		return domaintenant.ErrPaymentUnpaid
+	}
+	if t.IsTrialExpired(time.Now().UTC()) {
+		return domaintenant.ErrTrialExpired
+	}
+
+	if s.clientRepo != nil {
+		var count int64
+		var err error
+		if seasonID != "" {
+			count, err = s.clientRepo.CountBySeason(ctx, tenantID, seasonID)
+		} else {
+			count, err = s.clientRepo.MaxClientsPerSeason(ctx, tenantID)
+		}
+		if err == nil && count >= domaintenant.StandardMaxClients {
+			return domaintenant.ErrLimitExceeded
+		}
+	}
+
+	return nil
+}
+
+func (s *Service) ValidateCanWriteClients(ctx context.Context, tenantID string) error {
+	t, err := s.repo.FindByName(ctx, tenantID)
+	if err != nil {
+		return err
+	}
+
+	if t.IsUnpaid() {
+		return domaintenant.ErrPaymentUnpaid
+	}
+	if t.IsTrialExpired(time.Now().UTC()) {
+		return domaintenant.ErrTrialExpired
+	}
+
+	return nil
+}
+
+func (s *Service) ValidateCanWriteEntities(ctx context.Context, tenantID string) error {
+	t, err := s.repo.FindByName(ctx, tenantID)
+	if err != nil {
+		return err
+	}
+
+	if t.IsUnpaid() {
+		return domaintenant.ErrPaymentUnpaid
+	}
+	if t.IsTrialExpired(time.Now().UTC()) {
+		return domaintenant.ErrTrialExpired
+	}
+
+	return nil
 }

--- a/backend/internal/application/usecase/tenant/service_test.go
+++ b/backend/internal/application/usecase/tenant/service_test.go
@@ -2,10 +2,14 @@ package tenant_test
 
 import (
 	"context"
+	"errors"
 	"testing"
+	"time"
 
+	clientport "ps/internal/application/ports/client"
 	tenantport "ps/internal/application/ports/tenant"
 	tenantusecase "ps/internal/application/usecase/tenant"
+	domainclient "ps/internal/domain/client"
 	domaintenant "ps/internal/domain/tenant"
 )
 
@@ -41,30 +45,81 @@ func (m *mockTenantRepo) List(ctx context.Context) ([]domaintenant.Tenant, error
 	return res, nil
 }
 
+func (m *mockTenantRepo) Update(ctx context.Context, t domaintenant.Tenant) (domaintenant.Tenant, error) {
+	if _, ok := m.items[t.Name]; !ok {
+		return domaintenant.Tenant{}, tenantport.ErrNotFound
+	}
+	m.items[t.Name] = t
+	return t, nil
+}
+
+type mockClientRepo struct {
+	countsBySeason map[string]int64
+	maxPerSeason   int64
+}
+
+func newMockClientRepo() *mockClientRepo {
+	return &mockClientRepo{countsBySeason: make(map[string]int64)}
+}
+
+func (m *mockClientRepo) Create(ctx context.Context, c *domainclient.SeasonClient) error { return nil }
+func (m *mockClientRepo) GetByID(ctx context.Context, id, tenantID string) (*domainclient.SeasonClient, error) {
+	return nil, nil
+}
+func (m *mockClientRepo) List(ctx context.Context, tenantID string, filter domainclient.ListFilter) (*domainclient.PaginatedClients, error) {
+	return nil, nil
+}
+func (m *mockClientRepo) StreamByTenant(ctx context.Context, tenantID, seasonID string, fn func(c *domainclient.SeasonClient) error) error {
+	return nil
+}
+func (m *mockClientRepo) Update(ctx context.Context, c *domainclient.SeasonClient) error { return nil }
+func (m *mockClientRepo) Delete(ctx context.Context, id, tenantID string) error          { return nil }
+func (m *mockClientRepo) DeleteBySeasonID(ctx context.Context, seasonID, tenantID string) error {
+	return nil
+}
+func (m *mockClientRepo) CountBySeason(ctx context.Context, tenantID, seasonID string) (int64, error) {
+	return m.countsBySeason[tenantID+":"+seasonID], nil
+}
+func (m *mockClientRepo) MaxClientsPerSeason(ctx context.Context, tenantID string) (int64, error) {
+	return m.maxPerSeason, nil
+}
+
+var _ clientport.Repository = (*mockClientRepo)(nil)
+
 func TestTenantService(t *testing.T) {
 	repo := newMockTenantRepo()
-	svc := tenantusecase.NewService(repo)
+	clientRepo := newMockClientRepo()
+	svc := tenantusecase.NewService(repo, clientRepo)
 	ctx := context.Background()
 
 	// 1. Invalid names
 	invalidNames := []string{"", "   ", "invalid name with space", "invalid@name", "org/name"}
 	for _, inv := range invalidNames {
-		if _, err := svc.Create(ctx, inv); err != tenantusecase.ErrInvalidName {
+		if _, err := svc.Create(ctx, tenantusecase.CreateTenantInput{Name: inv}); err != tenantusecase.ErrInvalidName {
 			t.Fatalf("expected ErrInvalidName for %q, got %v", inv, err)
 		}
 	}
 
-	// 2. Valid creation
-	created, err := svc.Create(ctx, "acme-corp")
+	// 2. Valid creation with default trial
+	created, err := svc.Create(ctx, tenantusecase.CreateTenantInput{Name: "acme-corp"})
 	if err != nil {
 		t.Fatalf("unexpected error creating tenant: %v", err)
 	}
 	if created.Name != "acme-corp" {
 		t.Fatalf("expected acme-corp, got %s", created.Name)
 	}
+	if created.Plan != domaintenant.PlanFree {
+		t.Fatalf("expected free plan, got %s", created.Plan)
+	}
+	if created.PaymentStatus != domaintenant.PaymentStatusPaid {
+		t.Fatalf("expected paid status, got %s", created.PaymentStatus)
+	}
+	if created.PlanExpiresAt == nil {
+		t.Fatal("expected planExpiresAt to be set for free plan")
+	}
 
 	// 3. Duplicate creation error
-	if _, err := svc.Create(ctx, "acme-corp"); err != tenantusecase.ErrAlreadyExists {
+	if _, err := svc.Create(ctx, tenantusecase.CreateTenantInput{Name: "acme-corp"}); err != tenantusecase.ErrAlreadyExists {
 		t.Fatalf("expected ErrAlreadyExists on duplicate, got %v", err)
 	}
 
@@ -89,5 +144,133 @@ func TestTenantService(t *testing.T) {
 	// 6. GetByName not found
 	if _, err := svc.GetByName(ctx, "non-existent"); err != tenantusecase.ErrNotFound {
 		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestTenantService_PlanLimitsAndRules(t *testing.T) {
+	repo := newMockTenantRepo()
+	clientRepo := newMockClientRepo()
+	svc := tenantusecase.NewService(repo, clientRepo)
+	ctx := context.Background()
+
+	// 1. Create a free tenant
+	_, err := svc.Create(ctx, tenantusecase.CreateTenantInput{Name: "active-free"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should be allowed to do standard actions
+	if err := svc.ValidateCanCreateSeason(ctx, "active-free"); err != nil {
+		t.Fatalf("active free tenant should be allowed to create season: %v", err)
+	}
+	if err := svc.ValidateCanExportReport(ctx, "active-free", "season-1"); err != nil {
+		t.Fatalf("active free tenant should be allowed to export report: %v", err)
+	}
+	if err := svc.ValidateCanWriteClients(ctx, "active-free"); err != nil {
+		t.Fatalf("active free tenant should be allowed to write clients: %v", err)
+	}
+
+	// 2. Expired Trial Tenant
+	past := time.Now().UTC().Add(-24 * time.Hour)
+	_, _ = repo.Create(ctx, domaintenant.Tenant{
+		Name:          "expired-trial",
+		Plan:          domaintenant.PlanFree,
+		PaymentStatus: domaintenant.PaymentStatusPaid,
+		PlanExpiresAt: &past,
+		CreatedAt:     time.Now().UTC().Add(-15 * 24 * time.Hour),
+	})
+
+	if err := svc.ValidateCanCreateSeason(ctx, "expired-trial"); !errors.Is(err, domaintenant.ErrTrialExpired) {
+		t.Fatalf("expected ErrTrialExpired, got %v", err)
+	}
+	if err := svc.ValidateCanExportReport(ctx, "expired-trial", "season-1"); !errors.Is(err, domaintenant.ErrTrialExpired) {
+		t.Fatalf("expected ErrTrialExpired, got %v", err)
+	}
+	if err := svc.ValidateCanWriteClients(ctx, "expired-trial"); !errors.Is(err, domaintenant.ErrTrialExpired) {
+		t.Fatalf("expected ErrTrialExpired, got %v", err)
+	}
+	if err := svc.ValidateCanWriteEntities(ctx, "expired-trial"); !errors.Is(err, domaintenant.ErrTrialExpired) {
+		t.Fatalf("expected ErrTrialExpired, got %v", err)
+	}
+
+	// Check status DTO
+	statusExpired, err := svc.GetTenantStatus(ctx, "expired-trial")
+	if err != nil {
+		t.Fatalf("failed to get tenant status: %v", err)
+	}
+	if !statusExpired.IsTrialExpired {
+		t.Fatal("expected IsTrialExpired to be true")
+	}
+
+	// 3. Unpaid Tenant
+	_, _ = repo.Create(ctx, domaintenant.Tenant{
+		Name:          "unpaid-org",
+		Plan:          domaintenant.PlanStandard,
+		PaymentStatus: domaintenant.PaymentStatusUnpaid,
+		CreatedAt:     time.Now().UTC(),
+	})
+
+	if err := svc.ValidateCanCreateSeason(ctx, "unpaid-org"); !errors.Is(err, domaintenant.ErrPaymentUnpaid) {
+		t.Fatalf("expected ErrPaymentUnpaid, got %v", err)
+	}
+	if err := svc.ValidateCanExportReport(ctx, "unpaid-org", "season-1"); !errors.Is(err, domaintenant.ErrPaymentUnpaid) {
+		t.Fatalf("expected ErrPaymentUnpaid, got %v", err)
+	}
+	if err := svc.ValidateCanWriteClients(ctx, "unpaid-org"); !errors.Is(err, domaintenant.ErrPaymentUnpaid) {
+		t.Fatalf("expected ErrPaymentUnpaid, got %v", err)
+	}
+	if err := svc.ValidateCanWriteEntities(ctx, "unpaid-org"); !errors.Is(err, domaintenant.ErrPaymentUnpaid) {
+		t.Fatalf("expected ErrPaymentUnpaid, got %v", err)
+	}
+
+	// 4. Standard Plan with >= 300 clients
+	_, _ = repo.Create(ctx, domaintenant.Tenant{
+		Name:          "limit-exceeded-org",
+		Plan:          domaintenant.PlanStandard,
+		PaymentStatus: domaintenant.PaymentStatusPaid,
+		CreatedAt:     time.Now().UTC(),
+	})
+	clientRepo.maxPerSeason = 300
+	clientRepo.countsBySeason["limit-exceeded-org:season-1"] = 300
+
+	// Should block season creation and report exports
+	if err := svc.ValidateCanCreateSeason(ctx, "limit-exceeded-org"); !errors.Is(err, domaintenant.ErrLimitExceeded) {
+		t.Fatalf("expected ErrLimitExceeded on create season, got %v", err)
+	}
+	if err := svc.ValidateCanExportReport(ctx, "limit-exceeded-org", "season-1"); !errors.Is(err, domaintenant.ErrLimitExceeded) {
+		t.Fatalf("expected ErrLimitExceeded on export report, got %v", err)
+	}
+	// Should NOT block writing entities or writing clients
+	if err := svc.ValidateCanWriteEntities(ctx, "limit-exceeded-org"); err != nil {
+		t.Fatalf("ValidateCanWriteEntities should not be blocked by 300 client limit: %v", err)
+	}
+	if err := svc.ValidateCanWriteClients(ctx, "limit-exceeded-org"); err != nil {
+		t.Fatalf("ValidateCanWriteClients should not be blocked by 300 client limit: %v", err)
+	}
+
+	// 5. Update plan to standard, then free
+	updatedStandard, err := svc.UpdatePlan(ctx, "active-free", domaintenant.PlanStandard)
+	if err != nil {
+		t.Fatalf("failed to update plan to standard: %v", err)
+	}
+	if updatedStandard.Plan != domaintenant.PlanStandard || updatedStandard.PlanExpiresAt != nil {
+		t.Fatal("expected standard plan with nil PlanExpiresAt")
+	}
+
+	updatedFree, err := svc.UpdatePlan(ctx, "active-free", domaintenant.PlanFree)
+	if err != nil {
+		t.Fatalf("failed to update plan to free: %v", err)
+	}
+	if updatedFree.Plan != domaintenant.PlanFree || updatedFree.PlanExpiresAt == nil {
+		t.Fatal("expected free plan with new 14-day trial")
+	}
+
+	// 6. Update payment status
+	updatedPaid, err := svc.UpdatePaymentStatus(ctx, "unpaid-org", domaintenant.PaymentStatusPaid)
+	if err != nil {
+		t.Fatalf("failed to update payment status: %v", err)
+	}
+	if updatedPaid.PaymentStatus != domaintenant.PaymentStatusPaid {
+		t.Fatalf("expected paid status, got %s", updatedPaid.PaymentStatus)
 	}
 }

--- a/backend/internal/domain/tenant/tenant.go
+++ b/backend/internal/domain/tenant/tenant.go
@@ -1,8 +1,44 @@
 package tenant
 
-import "time"
+import (
+	"errors"
+	"time"
+)
+
+const (
+	PlanFree     = "free"
+	PlanStandard = "standard"
+
+	PaymentStatusPaid   = "paid"
+	PaymentStatusUnpaid = "unpaid"
+
+	TrialDurationDays  = 14
+	StandardMaxClients = 300
+)
+
+var (
+	ErrLimitExceeded = errors.New("A sua organização excedeu o limite de clientes cadastrados no plano atual. A criação de novos eventos e a exportação de relatórios estão suspensas. Entre em contato com o suporte para regularizar.")
+	ErrPaymentUnpaid = errors.New("Acesso suspenso por pendência de pagamento da assinatura. Entre em contato com o suporte para regularizar.")
+	ErrTrialExpired  = errors.New("O período de teste gratuito de 14 dias da sua organização encerrou. A edição de clientes e exportação de relatórios estão bloqueadas. Entre em contato com o suporte para assinar um plano.")
+)
 
 type Tenant struct {
-	Name      string    `json:"name" bson:"_id"`
-	CreatedAt time.Time `json:"createdAt" bson:"createdAt"`
+	Name          string     `json:"name" bson:"_id"`
+	Plan          string     `json:"plan" bson:"plan"`
+	PaymentStatus string     `json:"paymentStatus" bson:"paymentStatus"`
+	PlanStartedAt *time.Time `json:"planStartedAt,omitempty" bson:"planStartedAt,omitempty"`
+	PlanExpiresAt *time.Time `json:"planExpiresAt,omitempty" bson:"planExpiresAt,omitempty"`
+	CreatedAt     time.Time  `json:"createdAt" bson:"createdAt"`
+	UpdatedAt     time.Time  `json:"updatedAt,omitempty" bson:"updatedAt,omitempty"`
+}
+
+func (t Tenant) IsTrialExpired(now time.Time) bool {
+	if t.Plan == PlanFree && t.PlanExpiresAt != nil && now.After(*t.PlanExpiresAt) {
+		return true
+	}
+	return false
+}
+
+func (t Tenant) IsUnpaid() bool {
+	return t.PaymentStatus == PaymentStatusUnpaid
 }

--- a/backend/internal/infrastructure/client/mongo/repository.go
+++ b/backend/internal/infrastructure/client/mongo/repository.go
@@ -256,6 +256,60 @@ func (r *repository) StreamByTenant(ctx context.Context, tenantID, seasonID stri
 	return cursor.Err()
 }
 
+func (r *repository) CountBySeason(ctx context.Context, tenantID, seasonID string) (int64, error) {
+	cleanTenantID, err := mongoinfra.SanitizeID(tenantID)
+	if err != nil {
+		return 0, err
+	}
+
+	filter := bson.D{{Key: "tenant_id", Value: cleanTenantID}}
+	if strings.TrimSpace(seasonID) != "" {
+		cleanSeasonID, err := mongoinfra.SanitizeID(seasonID)
+		if err != nil {
+			return 0, err
+		}
+		filter = append(filter, bson.E{Key: "season_id", Value: cleanSeasonID})
+	}
+
+	return r.collection.CountDocuments(ctx, filter)
+}
+
+func (r *repository) MaxClientsPerSeason(ctx context.Context, tenantID string) (int64, error) {
+	cleanTenantID, err := mongoinfra.SanitizeID(tenantID)
+	if err != nil {
+		return 0, err
+	}
+
+	pipeline := mongo.Pipeline{
+		bson.D{{Key: "$match", Value: bson.D{{Key: "tenant_id", Value: cleanTenantID}}}},
+		bson.D{{Key: "$group", Value: bson.D{
+			{Key: "_id", Value: "$season_id"},
+			{Key: "count", Value: bson.D{{Key: "$sum", Value: 1}}},
+		}}},
+		bson.D{{Key: "$sort", Value: bson.D{{Key: "count", Value: -1}}}},
+		bson.D{{Key: "$limit", Value: 1}},
+	}
+
+	cursor, err := r.collection.Aggregate(ctx, pipeline)
+	if err != nil {
+		return 0, err
+	}
+	defer cursor.Close(ctx)
+
+	var results []struct {
+		Count int64 `bson:"count"`
+	}
+	if err := cursor.All(ctx, &results); err != nil {
+		return 0, err
+	}
+
+	if len(results) == 0 {
+		return 0, nil
+	}
+
+	return results[0].Count, nil
+}
+
 func (r *repository) Update(ctx context.Context, client *domain.SeasonClient) error {
 	cleanID, err := mongoinfra.SanitizeID(client.ID)
 	if err != nil {

--- a/backend/internal/infrastructure/tenant/mongo/repository.go
+++ b/backend/internal/infrastructure/tenant/mongo/repository.go
@@ -13,14 +13,42 @@ import (
 )
 
 type tenantDoc struct {
-	Name      string    `bson:"_id"`
-	CreatedAt time.Time `bson:"createdAt"`
+	Name          string     `bson:"_id"`
+	Plan          string     `bson:"plan"`
+	PaymentStatus string     `bson:"paymentStatus"`
+	PlanStartedAt *time.Time `bson:"planStartedAt,omitempty"`
+	PlanExpiresAt *time.Time `bson:"planExpiresAt,omitempty"`
+	CreatedAt     time.Time  `bson:"createdAt"`
+	UpdatedAt     time.Time  `bson:"updatedAt,omitempty"`
 }
 
 func (d tenantDoc) toDomain() domaintenant.Tenant {
+	plan := d.Plan
+	if plan == "" {
+		plan = domaintenant.PlanFree
+	}
+	paymentStatus := d.PaymentStatus
+	if paymentStatus == "" {
+		paymentStatus = domaintenant.PaymentStatusPaid
+	}
+	startedAt := d.PlanStartedAt
+	if startedAt == nil && !d.CreatedAt.IsZero() {
+		startedAt = &d.CreatedAt
+	}
+	expiresAt := d.PlanExpiresAt
+	if expiresAt == nil && plan == domaintenant.PlanFree && startedAt != nil {
+		exp := startedAt.Add(domaintenant.TrialDurationDays * 24 * time.Hour)
+		expiresAt = &exp
+	}
+
 	return domaintenant.Tenant{
-		Name:      d.Name,
-		CreatedAt: d.CreatedAt,
+		Name:          d.Name,
+		Plan:          plan,
+		PaymentStatus: paymentStatus,
+		PlanStartedAt: startedAt,
+		PlanExpiresAt: expiresAt,
+		CreatedAt:     d.CreatedAt,
+		UpdatedAt:     d.UpdatedAt,
 	}
 }
 
@@ -41,13 +69,35 @@ func (r *Repository) Create(ctx context.Context, tenant domaintenant.Tenant) (do
 	}
 	tenant.Name = cleanName
 
+	now := time.Now().UTC()
 	if tenant.CreatedAt.IsZero() {
-		tenant.CreatedAt = time.Now().UTC()
+		tenant.CreatedAt = now
+	}
+	if tenant.UpdatedAt.IsZero() {
+		tenant.UpdatedAt = now
+	}
+	if tenant.Plan == "" {
+		tenant.Plan = domaintenant.PlanFree
+	}
+	if tenant.PaymentStatus == "" {
+		tenant.PaymentStatus = domaintenant.PaymentStatusPaid
+	}
+	if tenant.PlanStartedAt == nil {
+		tenant.PlanStartedAt = &now
+	}
+	if tenant.Plan == domaintenant.PlanFree && tenant.PlanExpiresAt == nil {
+		exp := tenant.PlanStartedAt.Add(domaintenant.TrialDurationDays * 24 * time.Hour)
+		tenant.PlanExpiresAt = &exp
 	}
 
 	doc := tenantDoc{
-		Name:      tenant.Name,
-		CreatedAt: tenant.CreatedAt,
+		Name:          tenant.Name,
+		Plan:          tenant.Plan,
+		PaymentStatus: tenant.PaymentStatus,
+		PlanStartedAt: tenant.PlanStartedAt,
+		PlanExpiresAt: tenant.PlanExpiresAt,
+		CreatedAt:     tenant.CreatedAt,
+		UpdatedAt:     tenant.UpdatedAt,
 	}
 
 	_, err = r.coll.InsertOne(ctx, doc)
@@ -56,6 +106,36 @@ func (r *Repository) Create(ctx context.Context, tenant domaintenant.Tenant) (do
 			return domaintenant.Tenant{}, tenantport.ErrAlreadyExists
 		}
 		return domaintenant.Tenant{}, err
+	}
+
+	return tenant, nil
+}
+
+func (r *Repository) Update(ctx context.Context, tenant domaintenant.Tenant) (domaintenant.Tenant, error) {
+	cleanName, err := mongoinfra.SanitizeID(tenant.Name)
+	if err != nil {
+		return domaintenant.Tenant{}, err
+	}
+	tenant.Name = cleanName
+	tenant.UpdatedAt = time.Now().UTC()
+
+	filter := bson.D{{Key: "_id", Value: cleanName}}
+	updateDoc := bson.D{
+		{Key: "$set", Value: bson.D{
+			{Key: "plan", Value: tenant.Plan},
+			{Key: "paymentStatus", Value: tenant.PaymentStatus},
+			{Key: "planStartedAt", Value: tenant.PlanStartedAt},
+			{Key: "planExpiresAt", Value: tenant.PlanExpiresAt},
+			{Key: "updatedAt", Value: tenant.UpdatedAt},
+		}},
+	}
+
+	res, err := r.coll.UpdateOne(ctx, filter, updateDoc)
+	if err != nil {
+		return domaintenant.Tenant{}, err
+	}
+	if res.MatchedCount == 0 {
+		return domaintenant.Tenant{}, tenantport.ErrNotFound
 	}
 
 	return tenant, nil

--- a/backend/internal/interfaces/rest/handlers/admin_handler.go
+++ b/backend/internal/interfaces/rest/handlers/admin_handler.go
@@ -23,7 +23,17 @@ func NewAdminHandler(tenantService *tenantusecase.Service, adminService *adminus
 }
 
 type CreateTenantRequest struct {
-	Name string `json:"name" example:"acme-corp"`
+	Name          string `json:"name" example:"acme-corp"`
+	Plan          string `json:"plan,omitempty" example:"free"`
+	PaymentStatus string `json:"paymentStatus,omitempty" example:"paid"`
+}
+
+type UpdateTenantPlanRequest struct {
+	Plan string `json:"plan" example:"standard"`
+}
+
+type UpdateTenantPaymentStatusRequest struct {
+	PaymentStatus string `json:"paymentStatus" example:"paid"`
 }
 
 type AssignTenantRequest struct {
@@ -53,7 +63,7 @@ func (h *AdminHandler) ListTenants(w http.ResponseWriter, r *http.Request) {
 
 // CreateTenant godoc
 // @Summary      Criar novo tenant
-// @Description  Cria uma nova organização (tenant) imutável no sistema
+// @Description  Cria uma nova organização (tenant) no sistema com plano e status inicial
 // @Tags         Admin
 // @Accept       json
 // @Produce      json
@@ -72,11 +82,19 @@ func (h *AdminHandler) CreateTenant(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	created, err := h.tenantService.Create(r.Context(), input.Name)
+	created, err := h.tenantService.Create(r.Context(), tenantusecase.CreateTenantInput{
+		Name:          input.Name,
+		Plan:          input.Plan,
+		PaymentStatus: input.PaymentStatus,
+	})
 	if err != nil {
 		switch {
 		case errors.Is(err, tenantusecase.ErrInvalidName):
 			httpx.Error(w, http.StatusBadRequest, "Invalid tenant name. Only alphanumeric characters, dashes and underscores are allowed (max 128 chars).", nil)
+		case errors.Is(err, tenantusecase.ErrInvalidPlan):
+			httpx.Error(w, http.StatusBadRequest, "Invalid plan. Must be 'free' or 'standard'.", nil)
+		case errors.Is(err, tenantusecase.ErrInvalidPaymentStatus):
+			httpx.Error(w, http.StatusBadRequest, "Invalid payment status. Must be 'paid' or 'unpaid'.", nil)
 		case errors.Is(err, tenantusecase.ErrAlreadyExists):
 			httpx.Error(w, http.StatusConflict, "Tenant already exists", nil)
 		default:
@@ -87,6 +105,98 @@ func (h *AdminHandler) CreateTenant(w http.ResponseWriter, r *http.Request) {
 
 	httpx.Created(w, map[string]any{
 		"tenant": created,
+	})
+}
+
+// UpdateTenantPlan godoc
+// @Summary      Atualizar plano da organização
+// @Description  Atualiza o plano da organização (free ou standard) e renova 14 dias de teste se free
+// @Tags         Admin
+// @Accept       json
+// @Produce      json
+// @Param        name path string true "Nome do Tenant"
+// @Param        payload body UpdateTenantPlanRequest true "Novo plano"
+// @Security     BearerAuth
+// @Success      200 {object} httpx.SuccessEnvelope
+// @Failure      400 {object} httpx.ErrorEnvelope
+// @Failure      401 {object} httpx.ErrorEnvelope
+// @Failure      403 {object} httpx.ErrorEnvelope
+// @Failure      404 {object} httpx.ErrorEnvelope
+// @Router       /api/v1/admin/tenants/{name}/plan [put]
+func (h *AdminHandler) UpdateTenantPlan(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+	if name == "" {
+		httpx.Error(w, http.StatusBadRequest, "Tenant name is required", nil)
+		return
+	}
+
+	var input UpdateTenantPlanRequest
+	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+		httpx.Error(w, http.StatusBadRequest, "Invalid request payload", nil)
+		return
+	}
+
+	updated, err := h.tenantService.UpdatePlan(r.Context(), name, input.Plan)
+	if err != nil {
+		switch {
+		case errors.Is(err, tenantusecase.ErrNotFound):
+			httpx.Error(w, http.StatusNotFound, "Tenant not found", nil)
+		case errors.Is(err, tenantusecase.ErrInvalidPlan), errors.Is(err, tenantusecase.ErrInvalidName):
+			httpx.Error(w, http.StatusBadRequest, "Invalid plan. Must be 'free' or 'standard'.", nil)
+		default:
+			httpx.Error(w, http.StatusInternalServerError, "Failed to update tenant plan", nil)
+		}
+		return
+	}
+
+	httpx.Success(w, map[string]any{
+		"tenant": updated,
+	})
+}
+
+// UpdateTenantPaymentStatus godoc
+// @Summary      Atualizar status de pagamento da organização
+// @Description  Atualiza o status financeiro da organização (paid ou unpaid)
+// @Tags         Admin
+// @Accept       json
+// @Produce      json
+// @Param        name path string true "Nome do Tenant"
+// @Param        payload body UpdateTenantPaymentStatusRequest true "Novo status financeiro"
+// @Security     BearerAuth
+// @Success      200 {object} httpx.SuccessEnvelope
+// @Failure      400 {object} httpx.ErrorEnvelope
+// @Failure      401 {object} httpx.ErrorEnvelope
+// @Failure      403 {object} httpx.ErrorEnvelope
+// @Failure      404 {object} httpx.ErrorEnvelope
+// @Router       /api/v1/admin/tenants/{name}/payment-status [put]
+func (h *AdminHandler) UpdateTenantPaymentStatus(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+	if name == "" {
+		httpx.Error(w, http.StatusBadRequest, "Tenant name is required", nil)
+		return
+	}
+
+	var input UpdateTenantPaymentStatusRequest
+	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+		httpx.Error(w, http.StatusBadRequest, "Invalid request payload", nil)
+		return
+	}
+
+	updated, err := h.tenantService.UpdatePaymentStatus(r.Context(), name, input.PaymentStatus)
+	if err != nil {
+		switch {
+		case errors.Is(err, tenantusecase.ErrNotFound):
+			httpx.Error(w, http.StatusNotFound, "Tenant not found", nil)
+		case errors.Is(err, tenantusecase.ErrInvalidPaymentStatus), errors.Is(err, tenantusecase.ErrInvalidName):
+			httpx.Error(w, http.StatusBadRequest, "Invalid payment status. Must be 'paid' or 'unpaid'.", nil)
+		default:
+			httpx.Error(w, http.StatusInternalServerError, "Failed to update tenant payment status", nil)
+		}
+		return
+	}
+
+	httpx.Success(w, map[string]any{
+		"tenant": updated,
 	})
 }
 

--- a/backend/internal/interfaces/rest/handlers/admin_handler_test.go
+++ b/backend/internal/interfaces/rest/handlers/admin_handler_test.go
@@ -46,6 +46,14 @@ func (m *mockTenantRepo) List(ctx context.Context) ([]domaintenant.Tenant, error
 	return res, nil
 }
 
+func (m *mockTenantRepo) Update(ctx context.Context, t domaintenant.Tenant) (domaintenant.Tenant, error) {
+	if _, ok := m.items[t.Name]; !ok {
+		return domaintenant.Tenant{}, tenantusecase.ErrNotFound
+	}
+	m.items[t.Name] = t
+	return t, nil
+}
+
 func TestAdminHandler_Tenants(t *testing.T) {
 	tenantRepo := newMockTenantRepo()
 	userRepo := usermemory.NewRepository()
@@ -54,7 +62,7 @@ func TestAdminHandler_Tenants(t *testing.T) {
 	handler := handlers.NewAdminHandler(tenantSvc, adminSvc)
 
 	// 1. Create Tenant
-	body, _ := json.Marshal(map[string]string{"name": "alpha-tenant"})
+	body, _ := json.Marshal(map[string]string{"name": "alpha-tenant", "plan": "free", "paymentStatus": "paid"})
 	req := httptest.NewRequest("POST", "/api/v1/admin/tenants", bytes.NewReader(body))
 	rec := httptest.NewRecorder()
 	handler.CreateTenant(rec, req)
@@ -70,6 +78,28 @@ func TestAdminHandler_Tenants(t *testing.T) {
 
 	if recList.Code != http.StatusOK {
 		t.Fatalf("expected 200 OK, got %d", recList.Code)
+	}
+
+	// 3. Update Plan to Standard
+	planBody, _ := json.Marshal(map[string]string{"plan": "standard"})
+	reqPlan := httptest.NewRequest("PUT", "/api/v1/admin/tenants/alpha-tenant/plan", bytes.NewReader(planBody))
+	reqPlan.SetPathValue("name", "alpha-tenant")
+	recPlan := httptest.NewRecorder()
+	handler.UpdateTenantPlan(recPlan, reqPlan)
+
+	if recPlan.Code != http.StatusOK {
+		t.Fatalf("expected 200 OK, got %d: %s", recPlan.Code, recPlan.Body.String())
+	}
+
+	// 4. Update Payment Status to Unpaid
+	payBody, _ := json.Marshal(map[string]string{"paymentStatus": "unpaid"})
+	reqPay := httptest.NewRequest("PUT", "/api/v1/admin/tenants/alpha-tenant/payment-status", bytes.NewReader(payBody))
+	reqPay.SetPathValue("name", "alpha-tenant")
+	recPay := httptest.NewRecorder()
+	handler.UpdateTenantPaymentStatus(recPay, reqPay)
+
+	if recPay.Code != http.StatusOK {
+		t.Fatalf("expected 200 OK, got %d: %s", recPay.Code, recPay.Body.String())
 	}
 }
 

--- a/backend/internal/interfaces/rest/handlers/client_handler.go
+++ b/backend/internal/interfaces/rest/handlers/client_handler.go
@@ -8,6 +8,7 @@ import (
 
 	"ps/internal/application/usecase/client"
 	domain "ps/internal/domain/client"
+	domaintenant "ps/internal/domain/tenant"
 	"ps/internal/shared/middleware"
 )
 
@@ -29,6 +30,7 @@ func NewSeasonClientHandler(service *client.Service) *SeasonClientHandler {
 // @Success      201    {object}  client.SeasonClient
 // @Failure      400    {string}  string "Requisição inválida ou referência não pertencente ao tenant"
 // @Failure      401    {string}  string "Não autenticado"
+// @Failure      403    {string}  string "Tenant bloqueado ou expirado"
 // @Failure      500    {string}  string "Erro interno"
 // @Router       /api/v1/clients [post]
 func (h *SeasonClientHandler) Create(w http.ResponseWriter, r *http.Request) {
@@ -41,6 +43,10 @@ func (h *SeasonClientHandler) Create(w http.ResponseWriter, r *http.Request) {
 
 	if err := h.service.Create(r.Context(), &req, tenantID); err != nil {
 		switch {
+		case errors.Is(err, domaintenant.ErrLimitExceeded),
+			errors.Is(err, domaintenant.ErrPaymentUnpaid),
+			errors.Is(err, domaintenant.ErrTrialExpired):
+			http.Error(w, err.Error(), http.StatusForbidden)
 		case errors.Is(err, client.ErrPersonNotFound),
 			errors.Is(err, client.ErrSeasonNotFound),
 			errors.Is(err, client.ErrPhotographerNotFound):
@@ -144,6 +150,7 @@ func (h *SeasonClientHandler) GetByID(w http.ResponseWriter, r *http.Request) {
 // @Success      200     {object}  client.SeasonClient
 // @Failure      400     {string}  string "Requisição inválida ou referência não pertencente ao tenant"
 // @Failure      401     {string}  string "Não autenticado"
+// @Failure      403     {string}  string "Tenant bloqueado ou expirado"
 // @Failure      404     {string}  string "Cliente não encontrado"
 // @Failure      500     {string}  string "Erro interno"
 // @Router       /api/v1/clients/{id} [put]
@@ -164,6 +171,10 @@ func (h *SeasonClientHandler) Update(w http.ResponseWriter, r *http.Request) {
 
 	if err := h.service.Update(r.Context(), &req, tenantID); err != nil {
 		switch {
+		case errors.Is(err, domaintenant.ErrLimitExceeded),
+			errors.Is(err, domaintenant.ErrPaymentUnpaid),
+			errors.Is(err, domaintenant.ErrTrialExpired):
+			http.Error(w, err.Error(), http.StatusForbidden)
 		case errors.Is(err, client.ErrClientNotFound):
 			http.Error(w, err.Error(), http.StatusNotFound)
 		case errors.Is(err, client.ErrPersonNotFound),
@@ -189,6 +200,7 @@ func (h *SeasonClientHandler) Update(w http.ResponseWriter, r *http.Request) {
 // @Success      204  {string}  string "Excluído com sucesso"
 // @Failure      400  {string}  string "ID obrigatório"
 // @Failure      401  {string}  string "Não autenticado"
+// @Failure      403  {string}  string "Tenant bloqueado ou expirado"
 // @Failure      500  {string}  string "Erro interno"
 // @Router       /api/v1/clients/{id} [delete]
 func (h *SeasonClientHandler) Delete(w http.ResponseWriter, r *http.Request) {
@@ -200,6 +212,10 @@ func (h *SeasonClientHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.service.Delete(r.Context(), id, tenantID); err != nil {
+		if errors.Is(err, domaintenant.ErrLimitExceeded) || errors.Is(err, domaintenant.ErrPaymentUnpaid) || errors.Is(err, domaintenant.ErrTrialExpired) {
+			http.Error(w, err.Error(), http.StatusForbidden)
+			return
+		}
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/backend/internal/interfaces/rest/handlers/person_handler.go
+++ b/backend/internal/interfaces/rest/handlers/person_handler.go
@@ -2,9 +2,11 @@ package handlers
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"ps/internal/application/usecase/person"
 	domain "ps/internal/domain/person"
+	domaintenant "ps/internal/domain/tenant"
 	"ps/internal/shared/middleware"
 )
 
@@ -26,6 +28,7 @@ func NewPersonHandler(service *person.Service) *PersonHandler {
 // @Success      201    {object}  person.Person
 // @Failure      400    {string}  string "Requisição inválida"
 // @Failure      401    {string}  string "Não autenticado"
+// @Failure      403    {string}  string "Tenant bloqueado ou expirado"
 // @Failure      500    {string}  string "Erro interno"
 // @Router       /api/v1/people [post]
 func (h *PersonHandler) Create(w http.ResponseWriter, r *http.Request) {
@@ -37,6 +40,10 @@ func (h *PersonHandler) Create(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.service.Create(r.Context(), &req, tenantID); err != nil {
+		if errors.Is(err, domaintenant.ErrLimitExceeded) || errors.Is(err, domaintenant.ErrPaymentUnpaid) || errors.Is(err, domaintenant.ErrTrialExpired) {
+			http.Error(w, err.Error(), http.StatusForbidden)
+			return
+		}
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -112,6 +119,7 @@ func (h *PersonHandler) GetByID(w http.ResponseWriter, r *http.Request) {
 // @Success      200     {object}  person.Person
 // @Failure      400     {string}  string "Requisição inválida"
 // @Failure      401     {string}  string "Não autenticado"
+// @Failure      403     {string}  string "Tenant bloqueado ou expirado"
 // @Failure      500     {string}  string "Erro interno"
 // @Router       /api/v1/people/{id} [put]
 func (h *PersonHandler) Update(w http.ResponseWriter, r *http.Request) {
@@ -130,6 +138,10 @@ func (h *PersonHandler) Update(w http.ResponseWriter, r *http.Request) {
 	req.ID = id
 
 	if err := h.service.Update(r.Context(), &req, tenantID); err != nil {
+		if errors.Is(err, domaintenant.ErrLimitExceeded) || errors.Is(err, domaintenant.ErrPaymentUnpaid) || errors.Is(err, domaintenant.ErrTrialExpired) {
+			http.Error(w, err.Error(), http.StatusForbidden)
+			return
+		}
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -147,6 +159,7 @@ func (h *PersonHandler) Update(w http.ResponseWriter, r *http.Request) {
 // @Success      204  {string}  string "Excluído com sucesso"
 // @Failure      400  {string}  string "ID obrigatório"
 // @Failure      401  {string}  string "Não autenticado"
+// @Failure      403  {string}  string "Tenant bloqueado ou expirado"
 // @Failure      500  {string}  string "Erro interno"
 // @Router       /api/v1/people/{id} [delete]
 func (h *PersonHandler) Delete(w http.ResponseWriter, r *http.Request) {
@@ -158,6 +171,10 @@ func (h *PersonHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.service.Delete(r.Context(), id, tenantID); err != nil {
+		if errors.Is(err, domaintenant.ErrLimitExceeded) || errors.Is(err, domaintenant.ErrPaymentUnpaid) || errors.Is(err, domaintenant.ErrTrialExpired) {
+			http.Error(w, err.Error(), http.StatusForbidden)
+			return
+		}
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/backend/internal/interfaces/rest/handlers/photographer_handler.go
+++ b/backend/internal/interfaces/rest/handlers/photographer_handler.go
@@ -2,9 +2,11 @@ package handlers
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"ps/internal/application/usecase/photographer"
 	domain "ps/internal/domain/photographer"
+	domaintenant "ps/internal/domain/tenant"
 	"ps/internal/shared/middleware"
 )
 
@@ -26,6 +28,7 @@ func NewPhotographerHandler(service *photographer.Service) *PhotographerHandler 
 // @Success      201  {object}  photographer.Photographer
 // @Failure      400  {string}  string "Requisição inválida"
 // @Failure      401  {string}  string "Não autenticado"
+// @Failure      403  {string}  string "Tenant bloqueado ou expirado"
 // @Failure      500  {string}  string "Erro interno"
 // @Router       /api/v1/photographers [post]
 func (h *PhotographerHandler) Create(w http.ResponseWriter, r *http.Request) {
@@ -37,6 +40,10 @@ func (h *PhotographerHandler) Create(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.service.Create(r.Context(), &req, tenantID); err != nil {
+		if errors.Is(err, domaintenant.ErrLimitExceeded) || errors.Is(err, domaintenant.ErrPaymentUnpaid) || errors.Is(err, domaintenant.ErrTrialExpired) {
+			http.Error(w, err.Error(), http.StatusForbidden)
+			return
+		}
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -112,6 +119,7 @@ func (h *PhotographerHandler) GetByID(w http.ResponseWriter, r *http.Request) {
 // @Success      200          {object}  photographer.Photographer
 // @Failure      400          {string}  string "Requisição inválida"
 // @Failure      401          {string}  string "Não autenticado"
+// @Failure      403          {string}  string "Tenant bloqueado ou expirado"
 // @Failure      500          {string}  string "Erro interno"
 // @Router       /api/v1/photographers/{id} [put]
 func (h *PhotographerHandler) Update(w http.ResponseWriter, r *http.Request) {
@@ -130,6 +138,10 @@ func (h *PhotographerHandler) Update(w http.ResponseWriter, r *http.Request) {
 	req.ID = id
 
 	if err := h.service.Update(r.Context(), &req, tenantID); err != nil {
+		if errors.Is(err, domaintenant.ErrLimitExceeded) || errors.Is(err, domaintenant.ErrPaymentUnpaid) || errors.Is(err, domaintenant.ErrTrialExpired) {
+			http.Error(w, err.Error(), http.StatusForbidden)
+			return
+		}
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -147,6 +159,7 @@ func (h *PhotographerHandler) Update(w http.ResponseWriter, r *http.Request) {
 // @Success      204  {string}  string "Excluído com sucesso"
 // @Failure      400  {string}  string "ID obrigatório"
 // @Failure      401  {string}  string "Não autenticado"
+// @Failure      403  {string}  string "Tenant bloqueado ou expirado"
 // @Failure      500  {string}  string "Erro interno"
 // @Router       /api/v1/photographers/{id} [delete]
 func (h *PhotographerHandler) Delete(w http.ResponseWriter, r *http.Request) {
@@ -158,6 +171,10 @@ func (h *PhotographerHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.service.Delete(r.Context(), id, tenantID); err != nil {
+		if errors.Is(err, domaintenant.ErrLimitExceeded) || errors.Is(err, domaintenant.ErrPaymentUnpaid) || errors.Is(err, domaintenant.ErrTrialExpired) {
+			http.Error(w, err.Error(), http.StatusForbidden)
+			return
+		}
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/backend/internal/interfaces/rest/handlers/report_handler.go
+++ b/backend/internal/interfaces/rest/handlers/report_handler.go
@@ -12,6 +12,7 @@ import (
 
 	userport "ps/internal/application/ports/user"
 	reportusecase "ps/internal/application/usecase/report"
+	domaintenant "ps/internal/domain/tenant"
 	"ps/internal/shared/httpx"
 	"ps/internal/shared/middleware"
 )
@@ -28,6 +29,16 @@ func NewReportHandler(service *reportusecase.Service, userRepo userport.Reposito
 	}
 }
 
+func handleReportTenantError(w http.ResponseWriter, err error) bool {
+	if errors.Is(err, domaintenant.ErrLimitExceeded) ||
+		errors.Is(err, domaintenant.ErrPaymentUnpaid) ||
+		errors.Is(err, domaintenant.ErrTrialExpired) {
+		httpx.Error(w, http.StatusForbidden, err.Error(), nil)
+		return true
+	}
+	return false
+}
+
 // ExportClientsCSV godoc
 // @Summary      Exportar relatório CSV de clientes
 // @Description  Inicia a extração assíncrona do relatório consolidado de clientes, cães, fotos e pagamentos do tenant autenticado e envia o link para o e-mail cadastrado
@@ -36,7 +47,7 @@ func NewReportHandler(service *reportusecase.Service, userRepo userport.Reposito
 // @Produce      json
 // @Success      202  {object}  httpx.SuccessEnvelope
 // @Failure      401  {object}  httpx.ErrorEnvelope "Não autenticado"
-// @Failure      403  {object}  httpx.ErrorEnvelope "Tenant não associado"
+// @Failure      403  {object}  httpx.ErrorEnvelope "Tenant não associado ou bloqueado"
 // @Failure      500  {object}  httpx.ErrorEnvelope "Erro interno"
 // @Router       /api/v1/reports/clients-csv [post]
 func (h *ReportHandler) ExportClientsCSV(w http.ResponseWriter, r *http.Request) {
@@ -47,6 +58,14 @@ func (h *ReportHandler) ExportClientsCSV(w http.ResponseWriter, r *http.Request)
 	}
 
 	seasonID := r.URL.Query().Get("season_id")
+
+	if err := h.service.ValidateAccess(r.Context(), tenantID, seasonID); err != nil {
+		if handleReportTenantError(w, err) {
+			return
+		}
+		httpx.Error(w, http.StatusInternalServerError, "Failed to validate report access", nil)
+		return
+	}
 
 	userID := middleware.GetUserID(r.Context())
 	var userEmail, userName string
@@ -81,7 +100,7 @@ func (h *ReportHandler) ExportClientsCSV(w http.ResponseWriter, r *http.Request)
 // @Produce      json
 // @Success      202  {object}  httpx.SuccessEnvelope
 // @Failure      401  {object}  httpx.ErrorEnvelope "Não autenticado"
-// @Failure      403  {object}  httpx.ErrorEnvelope "Tenant não associado"
+// @Failure      403  {object}  httpx.ErrorEnvelope "Tenant não associado ou bloqueado"
 // @Failure      500  {object}  httpx.ErrorEnvelope "Erro interno"
 // @Router       /api/v1/reports/unpaid-clients-csv [post]
 func (h *ReportHandler) ExportUnpaidClientsCSV(w http.ResponseWriter, r *http.Request) {
@@ -92,6 +111,14 @@ func (h *ReportHandler) ExportUnpaidClientsCSV(w http.ResponseWriter, r *http.Re
 	}
 
 	seasonID := r.URL.Query().Get("season_id")
+
+	if err := h.service.ValidateAccess(r.Context(), tenantID, seasonID); err != nil {
+		if handleReportTenantError(w, err) {
+			return
+		}
+		httpx.Error(w, http.StatusInternalServerError, "Failed to validate report access", nil)
+		return
+	}
 
 	userID := middleware.GetUserID(r.Context())
 	var userEmail, userName string
@@ -126,7 +153,7 @@ func (h *ReportHandler) ExportUnpaidClientsCSV(w http.ResponseWriter, r *http.Re
 // @Produce      json
 // @Success      202  {object}  httpx.SuccessEnvelope
 // @Failure      401  {object}  httpx.ErrorEnvelope "Não autenticado"
-// @Failure      403  {object}  httpx.ErrorEnvelope "Tenant não associado"
+// @Failure      403  {object}  httpx.ErrorEnvelope "Tenant não associado ou bloqueado"
 // @Failure      500  {object}  httpx.ErrorEnvelope "Erro interno"
 // @Router       /api/v1/reports/paid-clients-csv [post]
 func (h *ReportHandler) ExportPaidClientsCSV(w http.ResponseWriter, r *http.Request) {
@@ -137,6 +164,14 @@ func (h *ReportHandler) ExportPaidClientsCSV(w http.ResponseWriter, r *http.Requ
 	}
 
 	seasonID := r.URL.Query().Get("season_id")
+
+	if err := h.service.ValidateAccess(r.Context(), tenantID, seasonID); err != nil {
+		if handleReportTenantError(w, err) {
+			return
+		}
+		httpx.Error(w, http.StatusInternalServerError, "Failed to validate report access", nil)
+		return
+	}
 
 	userID := middleware.GetUserID(r.Context())
 	var userEmail, userName string
@@ -171,7 +206,7 @@ func (h *ReportHandler) ExportPaidClientsCSV(w http.ResponseWriter, r *http.Requ
 // @Produce      json
 // @Success      202  {object}  httpx.SuccessEnvelope
 // @Failure      401  {object}  httpx.ErrorEnvelope "Não autenticado"
-// @Failure      403  {object}  httpx.ErrorEnvelope "Tenant não associado"
+// @Failure      403  {object}  httpx.ErrorEnvelope "Tenant não associado ou bloqueado"
 // @Failure      500  {object}  httpx.ErrorEnvelope "Erro interno"
 // @Router       /api/v1/reports/clients-pdf [post]
 func (h *ReportHandler) ExportClientsPDF(w http.ResponseWriter, r *http.Request) {
@@ -182,6 +217,14 @@ func (h *ReportHandler) ExportClientsPDF(w http.ResponseWriter, r *http.Request)
 	}
 
 	seasonID := r.URL.Query().Get("season_id")
+
+	if err := h.service.ValidateAccess(r.Context(), tenantID, seasonID); err != nil {
+		if handleReportTenantError(w, err) {
+			return
+		}
+		httpx.Error(w, http.StatusInternalServerError, "Failed to validate report access", nil)
+		return
+	}
 
 	userID := middleware.GetUserID(r.Context())
 	var userEmail, userName string
@@ -216,7 +259,7 @@ func (h *ReportHandler) ExportClientsPDF(w http.ResponseWriter, r *http.Request)
 // @Produce      application/pdf
 // @Success      200  {string}  string "Arquivo PDF"
 // @Failure      401  {object}  httpx.ErrorEnvelope "Não autenticado"
-// @Failure      403  {object}  httpx.ErrorEnvelope "Tenant não associado"
+// @Failure      403  {object}  httpx.ErrorEnvelope "Tenant não associado ou bloqueado"
 // @Failure      500  {object}  httpx.ErrorEnvelope "Erro interno"
 // @Router       /api/v1/reports/clients-pdf [get]
 func (h *ReportHandler) DownloadDirectClientsPDF(w http.ResponseWriter, r *http.Request) {
@@ -230,6 +273,9 @@ func (h *ReportHandler) DownloadDirectClientsPDF(w http.ResponseWriter, r *http.
 
 	pdfData, err := h.service.GenerateDirectClientsPDF(r.Context(), tenantID, seasonID)
 	if err != nil {
+		if handleReportTenantError(w, err) {
+			return
+		}
 		httpx.Error(w, http.StatusInternalServerError, "Falha ao gerar relatório PDF", nil)
 		return
 	}
@@ -269,6 +315,9 @@ func (h *ReportHandler) DownloadReport(w http.ResponseWriter, r *http.Request) {
 
 	data, err := h.service.GetReportFile(r.Context(), tenantID, filePath)
 	if err != nil {
+		if handleReportTenantError(w, err) {
+			return
+		}
 		if errors.Is(err, reportusecase.ErrUnauthorizedTenant) || errors.Is(err, reportusecase.ErrInvalidReportPath) {
 			httpx.Error(w, http.StatusForbidden, "Acesso não autorizado a este relatório", nil)
 			return

--- a/backend/internal/interfaces/rest/handlers/report_handler_test.go
+++ b/backend/internal/interfaces/rest/handlers/report_handler_test.go
@@ -49,6 +49,30 @@ func (m *mockReportClientRepo) Update(ctx context.Context, client *clientdomain.
 func (m *mockReportClientRepo) Delete(ctx context.Context, id, tenantID string) error {
 	return nil
 }
+func (m *mockReportClientRepo) CountBySeason(ctx context.Context, tenantID, seasonID string) (int64, error) {
+	var count int64
+	for _, c := range m.clients {
+		if c.TenantID == tenantID && (seasonID == "" || c.SeasonID == seasonID) {
+			count++
+		}
+	}
+	return count, nil
+}
+func (m *mockReportClientRepo) MaxClientsPerSeason(ctx context.Context, tenantID string) (int64, error) {
+	counts := make(map[string]int64)
+	for _, c := range m.clients {
+		if c.TenantID == tenantID {
+			counts[c.SeasonID]++
+		}
+	}
+	var maxCount int64
+	for _, cnt := range counts {
+		if cnt > maxCount {
+			maxCount = cnt
+		}
+	}
+	return maxCount, nil
+}
 func (m *mockReportClientRepo) DeleteBySeasonID(ctx context.Context, seasonID, tenantID string) error {
 	return nil
 }

--- a/backend/internal/interfaces/rest/handlers/season_handler.go
+++ b/backend/internal/interfaces/rest/handlers/season_handler.go
@@ -2,9 +2,11 @@ package handlers
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"ps/internal/application/usecase/season"
 	domain "ps/internal/domain/season"
+	domaintenant "ps/internal/domain/tenant"
 	"ps/internal/shared/middleware"
 )
 
@@ -26,6 +28,7 @@ func NewSeasonHandler(service *season.Service) *SeasonHandler {
 // @Success      201  {object}  season.Season
 // @Failure      400  {string}  string "Requisição inválida"
 // @Failure      401  {string}  string "Não autenticado"
+// @Failure      403  {string}  string "Tenant bloqueado ou limite excedido"
 // @Failure      500  {string}  string "Erro interno"
 // @Router       /api/v1/seasons [post]
 func (h *SeasonHandler) Create(w http.ResponseWriter, r *http.Request) {
@@ -37,6 +40,10 @@ func (h *SeasonHandler) Create(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.service.Create(r.Context(), &req, tenantID); err != nil {
+		if errors.Is(err, domaintenant.ErrLimitExceeded) || errors.Is(err, domaintenant.ErrPaymentUnpaid) || errors.Is(err, domaintenant.ErrTrialExpired) {
+			http.Error(w, err.Error(), http.StatusForbidden)
+			return
+		}
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -112,6 +119,7 @@ func (h *SeasonHandler) GetByID(w http.ResponseWriter, r *http.Request) {
 // @Success      200     {object}  season.Season
 // @Failure      400     {string}  string "Requisição inválida"
 // @Failure      401     {string}  string "Não autenticado"
+// @Failure      403     {string}  string "Tenant bloqueado"
 // @Failure      500     {string}  string "Erro interno"
 // @Router       /api/v1/seasons/{id} [put]
 func (h *SeasonHandler) Update(w http.ResponseWriter, r *http.Request) {
@@ -130,6 +138,10 @@ func (h *SeasonHandler) Update(w http.ResponseWriter, r *http.Request) {
 	req.ID = id
 
 	if err := h.service.Update(r.Context(), &req, tenantID); err != nil {
+		if errors.Is(err, domaintenant.ErrLimitExceeded) || errors.Is(err, domaintenant.ErrPaymentUnpaid) || errors.Is(err, domaintenant.ErrTrialExpired) {
+			http.Error(w, err.Error(), http.StatusForbidden)
+			return
+		}
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -147,6 +159,7 @@ func (h *SeasonHandler) Update(w http.ResponseWriter, r *http.Request) {
 // @Success      204  {string}  string "Excluído com sucesso"
 // @Failure      400  {string}  string "ID obrigatório"
 // @Failure      401  {string}  string "Não autenticado"
+// @Failure      403  {string}  string "Tenant bloqueado"
 // @Failure      500  {string}  string "Erro interno"
 // @Router       /api/v1/seasons/{id} [delete]
 func (h *SeasonHandler) Delete(w http.ResponseWriter, r *http.Request) {
@@ -158,6 +171,10 @@ func (h *SeasonHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.service.Delete(r.Context(), id, tenantID); err != nil {
+		if errors.Is(err, domaintenant.ErrLimitExceeded) || errors.Is(err, domaintenant.ErrPaymentUnpaid) || errors.Is(err, domaintenant.ErrTrialExpired) {
+			http.Error(w, err.Error(), http.StatusForbidden)
+			return
+		}
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/backend/internal/interfaces/rest/handlers/tenant_handler.go
+++ b/backend/internal/interfaces/rest/handlers/tenant_handler.go
@@ -1,0 +1,53 @@
+package handlers
+
+import (
+	"errors"
+	"net/http"
+
+	tenantusecase "ps/internal/application/usecase/tenant"
+	"ps/internal/shared/httpx"
+	"ps/internal/shared/middleware"
+)
+
+type TenantHandler struct {
+	tenantService *tenantusecase.Service
+}
+
+func NewTenantHandler(tenantService *tenantusecase.Service) *TenantHandler {
+	return &TenantHandler{
+		tenantService: tenantService,
+	}
+}
+
+// GetCurrentTenant godoc
+// @Summary      Dados do tenant atual
+// @Description  Retorna o status, plano, período de teste e limites da organização associada ao usuário autenticado
+// @Tags         Tenant
+// @Produce      json
+// @Security     BearerAuth
+// @Success      200 {object} httpx.SuccessEnvelope
+// @Failure      401 {object} httpx.ErrorEnvelope
+// @Failure      403 {object} httpx.ErrorEnvelope
+// @Failure      404 {object} httpx.ErrorEnvelope
+// @Router       /api/v1/tenant [get]
+func (h *TenantHandler) GetCurrentTenant(w http.ResponseWriter, r *http.Request) {
+	tenantID := middleware.GetTenantID(r.Context())
+	if tenantID == "" {
+		httpx.Error(w, http.StatusForbidden, "Tenant is required", nil)
+		return
+	}
+
+	status, err := h.tenantService.GetTenantStatus(r.Context(), tenantID)
+	if err != nil {
+		if errors.Is(err, tenantusecase.ErrNotFound) {
+			httpx.Error(w, http.StatusNotFound, "Tenant not found", nil)
+			return
+		}
+		httpx.Error(w, http.StatusInternalServerError, "Failed to get tenant status", nil)
+		return
+	}
+
+	httpx.Success(w, map[string]any{
+		"tenant": status,
+	})
+}

--- a/backend/internal/interfaces/rest/router.go
+++ b/backend/internal/interfaces/rest/router.go
@@ -51,15 +51,16 @@ func NewRouter(
 	authHandler := handlers.NewAuthHandler(users, hasher, tokens, emailSender, cfg.CookieDomain, cfg.CookieSecure)
 	userHandler := handlers.NewUserHandler(users, nil, hasher, tokens)
 
-	tenantSvc := tenantusecase.NewService(tenants)
+	tenantSvc := tenantusecase.NewService(tenants, clients)
 	adminSvc := adminusecase.NewService(users, tenants)
 	adminHandler := handlers.NewAdminHandler(tenantSvc, adminSvc)
+	tenantHandler := handlers.NewTenantHandler(tenantSvc)
 
-	seasonSvc := seasonusecase.NewService(seasons, clients)
-	photographerSvc := photographerusecase.NewService(photographers)
-	personSvc := personusecase.NewService(persons)
-	clientSvc := clientusecase.NewService(clients, persons, seasons, photographers)
-	reportSvc := reportusecase.NewService(clients, persons, photographers, storageProvider, emailSender, cfg.AppBaseURL)
+	seasonSvc := seasonusecase.NewService(seasons, clients, tenantSvc)
+	photographerSvc := photographerusecase.NewService(photographers, tenantSvc)
+	personSvc := personusecase.NewService(persons, tenantSvc)
+	clientSvc := clientusecase.NewService(clients, persons, seasons, photographers, tenantSvc)
+	reportSvc := reportusecase.NewService(clients, persons, photographers, storageProvider, emailSender, cfg.AppBaseURL, tenantSvc)
 
 	seasonHandler := handlers.NewSeasonHandler(seasonSvc)
 	photographerHandler := handlers.NewPhotographerHandler(photographerSvc)
@@ -115,8 +116,13 @@ func NewRouter(
 	// Admin routes
 	mux.Handle("GET /api/v1/admin/tenants", adminChain(adminHandler.ListTenants))
 	mux.Handle("POST /api/v1/admin/tenants", adminChain(adminHandler.CreateTenant))
+	mux.Handle("PUT /api/v1/admin/tenants/{name}/plan", adminChain(adminHandler.UpdateTenantPlan))
+	mux.Handle("PUT /api/v1/admin/tenants/{name}/payment-status", adminChain(adminHandler.UpdateTenantPaymentStatus))
 	mux.Handle("GET /api/v1/admin/users", adminChain(adminHandler.ListUsers))
 	mux.Handle("PUT /api/v1/admin/users/{id}/tenant", adminChain(adminHandler.AssignTenant))
+
+	// Tenant info route (current authenticated organization)
+	mux.Handle("GET /api/v1/tenant", businessChain(tenantHandler.GetCurrentTenant))
 
 	// User routes
 	mux.Handle("GET /api/v1/user/profile", protectedChain(userHandler.GetProfile))

--- a/frontend/src/features/admin/pages/AdminTenantsPage.test.tsx
+++ b/frontend/src/features/admin/pages/AdminTenantsPage.test.tsx
@@ -8,6 +8,8 @@ vi.mock("../services/admin.service", () => ({
   adminService: {
     getTenants: vi.fn(),
     createTenant: vi.fn(),
+    updateTenantPlan: vi.fn(),
+    updateTenantPaymentStatus: vi.fn(),
   },
 }));
 
@@ -16,10 +18,20 @@ describe("AdminTenantsPage", () => {
     vi.clearAllMocks();
   });
 
-  it("renders tenants list successfully", async () => {
+  it("renders tenants list with plan and payment status successfully", async () => {
     vi.mocked(adminService.getTenants).mockResolvedValueOnce([
-      { name: "tenant-alpha", createdAt: "2026-08-28T00:00:00Z" },
-      { name: "tenant-beta", createdAt: "2026-08-28T01:00:00Z" },
+      {
+        name: "tenant-alpha",
+        plan: "free",
+        paymentStatus: "paid",
+        createdAt: "2026-08-28T00:00:00Z",
+      },
+      {
+        name: "tenant-beta",
+        plan: "standard",
+        paymentStatus: "unpaid",
+        createdAt: "2026-08-28T01:00:00Z",
+      },
     ]);
 
     render(
@@ -33,6 +45,10 @@ describe("AdminTenantsPage", () => {
     await waitFor(() => {
       expect(screen.getByText("tenant-alpha")).toBeInTheDocument();
       expect(screen.getByText("tenant-beta")).toBeInTheDocument();
+      expect(screen.getByText("Gratuito (Trial)")).toBeInTheDocument();
+      expect(screen.getByText("Padrão")).toBeInTheDocument();
+      expect(screen.getByText("Em dia")).toBeInTheDocument();
+      expect(screen.getByText("Inadimplente")).toBeInTheDocument();
     });
   });
 

--- a/frontend/src/features/admin/pages/AdminTenantsPage.tsx
+++ b/frontend/src/features/admin/pages/AdminTenantsPage.tsx
@@ -21,11 +21,19 @@ import {
   CircularProgress,
   Card,
   CardContent,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  IconButton,
+  Tooltip,
 } from "@mui/material";
 import AddIcon from "@mui/icons-material/Add";
 import SearchIcon from "@mui/icons-material/Search";
 import BusinessRoundedIcon from "@mui/icons-material/BusinessRounded";
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
+import EditRoundedIcon from "@mui/icons-material/EditRounded";
+import PaymentRoundedIcon from "@mui/icons-material/PaymentRounded";
 import { adminService } from "../services/admin.service";
 import { Tenant } from "../types/admin.types";
 import { useDocumentTitle } from "../../shared/hooks/useDocumentTitle";
@@ -36,8 +44,26 @@ export const AdminTenantsPage = () => {
   const [tenants, setTenants] = useState<Tenant[]>([]);
   const [loading, setLoading] = useState(true);
   const [searchTerm, setSearchTerm] = useState("");
+
+  // Create Modal
   const [openCreate, setOpenCreate] = useState(false);
   const [tenantName, setTenantName] = useState("");
+  const [createPlan, setCreatePlan] = useState<"free" | "standard">("free");
+  const [createPaymentStatus, setCreatePaymentStatus] = useState<
+    "paid" | "unpaid"
+  >("paid");
+
+  // Plan Edit Modal
+  const [planModalOpen, setPlanModalOpen] = useState(false);
+  const [selectedTenant, setSelectedTenant] = useState<Tenant | null>(null);
+  const [newPlan, setNewPlan] = useState<"free" | "standard">("free");
+
+  // Payment Status Edit Modal
+  const [paymentModalOpen, setPaymentModalOpen] = useState(false);
+  const [newPaymentStatus, setNewPaymentStatus] = useState<"paid" | "unpaid">(
+    "paid",
+  );
+
   const [submitting, setSubmitting] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
@@ -61,6 +87,8 @@ export const AdminTenantsPage = () => {
 
   const handleOpenCreate = () => {
     setTenantName("");
+    setCreatePlan("free");
+    setCreatePaymentStatus("paid");
     setErrorMessage(null);
     setSuccessMessage(null);
     setOpenCreate(true);
@@ -82,7 +110,11 @@ export const AdminTenantsPage = () => {
     setErrorMessage(null);
 
     try {
-      await adminService.createTenant({ name: clean });
+      await adminService.createTenant({
+        name: clean,
+        plan: createPlan,
+        paymentStatus: createPaymentStatus,
+      });
       setSuccessMessage(`Organização "${clean}" criada com sucesso.`);
       setOpenCreate(false);
       setTenantName("");
@@ -100,6 +132,73 @@ export const AdminTenantsPage = () => {
       setSubmitting(false);
     }
   };
+
+  const handleOpenPlanModal = (tenant: Tenant) => {
+    setSelectedTenant(tenant);
+    setNewPlan(tenant.plan || "free");
+    setPlanModalOpen(true);
+  };
+
+  const handleUpdatePlan = async () => {
+    if (!selectedTenant) return;
+    setSubmitting(true);
+    setErrorMessage(null);
+    try {
+      await adminService.updateTenantPlan(selectedTenant.name, {
+        plan: newPlan,
+      });
+      setSuccessMessage(
+        `Plano da organização "${selectedTenant.name}" atualizado para "${newPlan === "free" ? "Gratuito (Trial)" : "Padrão"}" com sucesso.`,
+      );
+      setPlanModalOpen(false);
+      await loadTenants();
+    } catch (err: unknown) {
+      const error = err as {
+        response?: { data?: { message?: string } };
+        message?: string;
+      };
+      setErrorMessage(
+        error.response?.data?.message || "Erro ao atualizar plano do tenant.",
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleOpenPaymentModal = (tenant: Tenant) => {
+    setSelectedTenant(tenant);
+    setNewPaymentStatus(tenant.paymentStatus || "paid");
+    setPaymentModalOpen(true);
+  };
+
+  const handleUpdatePaymentStatus = async () => {
+    if (!selectedTenant) return;
+    setSubmitting(true);
+    setErrorMessage(null);
+    try {
+      await adminService.updateTenantPaymentStatus(selectedTenant.name, {
+        paymentStatus: newPaymentStatus,
+      });
+      setSuccessMessage(
+        `Status de pagamento da organização "${selectedTenant.name}" atualizado para "${newPaymentStatus === "paid" ? "Em dia" : "Inadimplente"}".`,
+      );
+      setPaymentModalOpen(false);
+      await loadTenants();
+    } catch (err: unknown) {
+      const error = err as {
+        response?: { data?: { message?: string } };
+        message?: string;
+      };
+      setErrorMessage(
+        error.response?.data?.message ||
+          "Erro ao atualizar status de pagamento.",
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const [now] = useState(() => Date.now());
 
   const filteredTenants = tenants.filter((t) =>
     t.name.toLowerCase().includes(searchTerm.toLowerCase()),
@@ -129,8 +228,8 @@ export const AdminTenantsPage = () => {
             Organizações
           </Typography>
           <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
-            Gerencie e provisione as organizações para isolamento multi-tenant
-            da plataforma.
+            Gerencie organizações, planos de assinatura (Gratuito/Padrão),
+            expirações de trial e status financeiro.
           </Typography>
         </Box>
         <Button
@@ -223,20 +322,25 @@ export const AdminTenantsPage = () => {
           overflowX: "auto",
         }}
       >
-        <Table sx={{ minWidth: 500 }}>
+        <Table sx={{ minWidth: 700 }}>
           <TableHead sx={{ bgcolor: "grey.50" }}>
             <TableRow>
               <TableCell sx={{ fontWeight: 600 }}>
                 Nome da Organização
               </TableCell>
+              <TableCell sx={{ fontWeight: 600 }}>Plano</TableCell>
+              <TableCell sx={{ fontWeight: 600 }}>Pagamento</TableCell>
+              <TableCell sx={{ fontWeight: 600 }}>Expiração Trial</TableCell>
               <TableCell sx={{ fontWeight: 600 }}>Data de Criação</TableCell>
-              <TableCell sx={{ fontWeight: 600 }}>Status</TableCell>
+              <TableCell sx={{ fontWeight: 600, textAlign: "right" }}>
+                Ações
+              </TableCell>
             </TableRow>
           </TableHead>
           <TableBody>
             {loading ? (
               <TableRow>
-                <TableCell colSpan={3} align="center" sx={{ py: 4 }}>
+                <TableCell colSpan={6} align="center" sx={{ py: 4 }}>
                   <CircularProgress size={32} />
                   <Typography
                     variant="body2"
@@ -249,7 +353,7 @@ export const AdminTenantsPage = () => {
               </TableRow>
             ) : filteredTenants.length === 0 ? (
               <TableRow>
-                <TableCell colSpan={3} align="center" sx={{ py: 6 }}>
+                <TableCell colSpan={6} align="center" sx={{ py: 6 }}>
                   <BusinessRoundedIcon
                     sx={{ fontSize: 48, color: "text.disabled", mb: 1 }}
                   />
@@ -264,46 +368,105 @@ export const AdminTenantsPage = () => {
                 </TableCell>
               </TableRow>
             ) : (
-              filteredTenants.map((t) => (
-                <TableRow key={t.name} hover>
-                  <TableCell>
-                    <Box
-                      sx={{ display: "flex", alignItems: "center", gap: 1.5 }}
-                    >
+              filteredTenants.map((t) => {
+                const isFree = (t.plan || "free") === "free";
+                const isPaid = (t.paymentStatus || "paid") === "paid";
+                const expiresAt = t.planExpiresAt
+                  ? new Date(t.planExpiresAt)
+                  : null;
+                const isExpired =
+                  isFree && expiresAt && expiresAt.getTime() < now;
+
+                return (
+                  <TableRow key={t.name} hover>
+                    <TableCell>
+                      <Box
+                        sx={{ display: "flex", alignItems: "center", gap: 1.5 }}
+                      >
+                        <Box
+                          sx={{
+                            bgcolor: "primary.50",
+                            color: "primary.main",
+                            p: 0.8,
+                            borderRadius: 1,
+                            display: "inline-flex",
+                          }}
+                        >
+                          <BusinessRoundedIcon fontSize="small" />
+                        </Box>
+                        <Typography
+                          variant="subtitle2"
+                          sx={{ fontWeight: 600 }}
+                        >
+                          {t.name}
+                        </Typography>
+                      </Box>
+                    </TableCell>
+                    <TableCell>
+                      <Chip
+                        label={isFree ? "Gratuito (Trial)" : "Padrão"}
+                        size="small"
+                        color={isFree ? "default" : "primary"}
+                        variant={isFree ? "outlined" : "filled"}
+                        sx={{ fontWeight: 600 }}
+                      />
+                    </TableCell>
+                    <TableCell>
+                      <Chip
+                        label={isPaid ? "Em dia" : "Inadimplente"}
+                        size="small"
+                        color={isPaid ? "success" : "error"}
+                        variant="filled"
+                        sx={{ fontWeight: 600 }}
+                      />
+                    </TableCell>
+                    <TableCell>
+                      <Typography variant="body2" color="text.secondary">
+                        {isFree
+                          ? expiresAt
+                            ? `${expiresAt.toLocaleDateString("pt-BR")} ${isExpired ? "(Expirado)" : ""}`
+                            : "14 dias (Trial)"
+                          : "Sem expiração"}
+                      </Typography>
+                    </TableCell>
+                    <TableCell>
+                      <Typography variant="body2" color="text.secondary">
+                        {t.createdAt
+                          ? new Date(t.createdAt).toLocaleDateString("pt-BR")
+                          : "-"}
+                      </Typography>
+                    </TableCell>
+                    <TableCell align="right">
                       <Box
                         sx={{
-                          bgcolor: "primary.50",
-                          color: "primary.main",
-                          p: 0.8,
-                          borderRadius: 1,
-                          display: "inline-flex",
+                          display: "flex",
+                          justifyContent: "flex-end",
+                          gap: 1,
                         }}
                       >
-                        <BusinessRoundedIcon fontSize="small" />
+                        <Tooltip title="Alterar Plano">
+                          <IconButton
+                            size="small"
+                            color="primary"
+                            onClick={() => handleOpenPlanModal(t)}
+                          >
+                            <EditRoundedIcon fontSize="small" />
+                          </IconButton>
+                        </Tooltip>
+                        <Tooltip title="Alterar Status de Pagamento">
+                          <IconButton
+                            size="small"
+                            color={isPaid ? "default" : "error"}
+                            onClick={() => handleOpenPaymentModal(t)}
+                          >
+                            <PaymentRoundedIcon fontSize="small" />
+                          </IconButton>
+                        </Tooltip>
                       </Box>
-                      <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
-                        {t.name}
-                      </Typography>
-                    </Box>
-                  </TableCell>
-                  <TableCell>
-                    <Typography variant="body2" color="text.secondary">
-                      {t.createdAt
-                        ? new Date(t.createdAt).toLocaleString("pt-BR")
-                        : "-"}
-                    </Typography>
-                  </TableCell>
-                  <TableCell>
-                    <Chip
-                      label="Ativo (Imutável)"
-                      size="small"
-                      color="success"
-                      variant="outlined"
-                      sx={{ fontWeight: 500 }}
-                    />
-                  </TableCell>
-                </TableRow>
-              ))
+                    </TableCell>
+                  </TableRow>
+                );
+              })
             )}
           </TableBody>
         </Table>
@@ -345,6 +508,38 @@ export const AdminTenantsPage = () => {
               onChange={(e) => setTenantName(e.target.value.toLowerCase())}
               helperText="Apenas letras, números, hífens (-) e underscores (_)."
             />
+
+            <FormControl fullWidth size="small">
+              <InputLabel>Plano Inicial</InputLabel>
+              <Select
+                value={createPlan}
+                label="Plano Inicial"
+                onChange={(e) =>
+                  setCreatePlan(e.target.value as "free" | "standard")
+                }
+                disabled={submitting}
+              >
+                <MenuItem value="free">Gratuito (Trial de 14 dias)</MenuItem>
+                <MenuItem value="standard">
+                  Padrão (Ilimitado / Limite 300 clientes por evento)
+                </MenuItem>
+              </Select>
+            </FormControl>
+
+            <FormControl fullWidth size="small">
+              <InputLabel>Status de Pagamento</InputLabel>
+              <Select
+                value={createPaymentStatus}
+                label="Status de Pagamento"
+                onChange={(e) =>
+                  setCreatePaymentStatus(e.target.value as "paid" | "unpaid")
+                }
+                disabled={submitting}
+              >
+                <MenuItem value="paid">Em dia (Pago)</MenuItem>
+                <MenuItem value="unpaid">Inadimplente (Não pago)</MenuItem>
+              </Select>
+            </FormControl>
           </DialogContent>
           <DialogActions sx={{ p: 2.5 }}>
             <Button
@@ -367,6 +562,120 @@ export const AdminTenantsPage = () => {
             </Button>
           </DialogActions>
         </form>
+      </Dialog>
+
+      {/* Dialog Alterar Plano */}
+      <Dialog
+        open={planModalOpen}
+        onClose={() => !submitting && setPlanModalOpen(false)}
+        maxWidth="xs"
+        fullWidth
+      >
+        <DialogTitle sx={{ fontWeight: 700 }}>Alterar Plano</DialogTitle>
+        <DialogContent
+          sx={{ display: "flex", flexDirection: "column", gap: 2, pt: 2 }}
+        >
+          <Typography variant="body2" color="text.secondary">
+            Organização: <strong>{selectedTenant?.name}</strong>
+          </Typography>
+
+          <FormControl fullWidth size="small">
+            <InputLabel>Plano</InputLabel>
+            <Select
+              value={newPlan}
+              label="Plano"
+              onChange={(e) =>
+                setNewPlan(e.target.value as "free" | "standard")
+              }
+              disabled={submitting}
+            >
+              <MenuItem value="free">
+                Gratuito (Reinicia trial de 14 dias)
+              </MenuItem>
+              <MenuItem value="standard">Padrão</MenuItem>
+            </Select>
+          </FormControl>
+        </DialogContent>
+        <DialogActions sx={{ p: 2.5 }}>
+          <Button
+            onClick={() => setPlanModalOpen(false)}
+            disabled={submitting}
+            color="inherit"
+          >
+            Cancelar
+          </Button>
+          <Button
+            onClick={handleUpdatePlan}
+            variant="contained"
+            disabled={submitting}
+            startIcon={
+              submitting ? <CircularProgress size={16} /> : <EditRoundedIcon />
+            }
+            sx={{ fontWeight: 600 }}
+          >
+            {submitting ? "Salvando..." : "Salvar Plano"}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Dialog Alterar Status de Pagamento */}
+      <Dialog
+        open={paymentModalOpen}
+        onClose={() => !submitting && setPaymentModalOpen(false)}
+        maxWidth="xs"
+        fullWidth
+      >
+        <DialogTitle sx={{ fontWeight: 700 }}>
+          Alterar Status de Pagamento
+        </DialogTitle>
+        <DialogContent
+          sx={{ display: "flex", flexDirection: "column", gap: 2, pt: 2 }}
+        >
+          <Typography variant="body2" color="text.secondary">
+            Organização: <strong>{selectedTenant?.name}</strong>
+          </Typography>
+
+          <FormControl fullWidth size="small">
+            <InputLabel>Status de Pagamento</InputLabel>
+            <Select
+              value={newPaymentStatus}
+              label="Status de Pagamento"
+              onChange={(e) =>
+                setNewPaymentStatus(e.target.value as "paid" | "unpaid")
+              }
+              disabled={submitting}
+            >
+              <MenuItem value="paid">Em dia (Acesso Liberado)</MenuItem>
+              <MenuItem value="unpaid">
+                Inadimplente (Acesso e Escritas Bloqueados)
+              </MenuItem>
+            </Select>
+          </FormControl>
+        </DialogContent>
+        <DialogActions sx={{ p: 2.5 }}>
+          <Button
+            onClick={() => setPaymentModalOpen(false)}
+            disabled={submitting}
+            color="inherit"
+          >
+            Cancelar
+          </Button>
+          <Button
+            onClick={handleUpdatePaymentStatus}
+            variant="contained"
+            disabled={submitting}
+            startIcon={
+              submitting ? (
+                <CircularProgress size={16} />
+              ) : (
+                <PaymentRoundedIcon />
+              )
+            }
+            sx={{ fontWeight: 600 }}
+          >
+            {submitting ? "Salvando..." : "Salvar Status"}
+          </Button>
+        </DialogActions>
       </Dialog>
     </Box>
   );

--- a/frontend/src/features/admin/services/admin.service.ts
+++ b/frontend/src/features/admin/services/admin.service.ts
@@ -5,6 +5,8 @@ import {
   AssignTenantPayload,
   CreateTenantPayload,
   Tenant,
+  UpdateTenantPaymentStatusPayload,
+  UpdateTenantPlanPayload,
 } from "../types/admin.types";
 
 export const adminService = {
@@ -17,6 +19,28 @@ export const adminService = {
   async createTenant(payload: CreateTenantPayload): Promise<Tenant> {
     const response = await apiClient.post<ApiEnvelope<{ tenant: Tenant }>>(
       "/admin/tenants",
+      payload,
+    );
+    return response.data.data.tenant;
+  },
+
+  async updateTenantPlan(
+    name: string,
+    payload: UpdateTenantPlanPayload,
+  ): Promise<Tenant> {
+    const response = await apiClient.put<ApiEnvelope<{ tenant: Tenant }>>(
+      `/admin/tenants/${encodeURIComponent(name)}/plan`,
+      payload,
+    );
+    return response.data.data.tenant;
+  },
+
+  async updateTenantPaymentStatus(
+    name: string,
+    payload: UpdateTenantPaymentStatusPayload,
+  ): Promise<Tenant> {
+    const response = await apiClient.put<ApiEnvelope<{ tenant: Tenant }>>(
+      `/admin/tenants/${encodeURIComponent(name)}/payment-status`,
       payload,
     );
     return response.data.data.tenant;

--- a/frontend/src/features/admin/types/admin.types.ts
+++ b/frontend/src/features/admin/types/admin.types.ts
@@ -2,11 +2,26 @@ import { User } from "../../auth/types/auth.types";
 
 export interface Tenant {
   name: string;
+  plan?: "free" | "standard";
+  paymentStatus?: "paid" | "unpaid";
+  planStartedAt?: string;
+  planExpiresAt?: string;
   createdAt: string;
+  updatedAt?: string;
 }
 
 export interface CreateTenantPayload {
   name: string;
+  plan?: "free" | "standard";
+  paymentStatus?: "paid" | "unpaid";
+}
+
+export interface UpdateTenantPlanPayload {
+  plan: "free" | "standard";
+}
+
+export interface UpdateTenantPaymentStatusPayload {
+  paymentStatus: "paid" | "unpaid";
 }
 
 export interface AssignTenantPayload {

--- a/frontend/src/features/dashboard/pages/DashboardPage.tsx
+++ b/frontend/src/features/dashboard/pages/DashboardPage.tsx
@@ -29,6 +29,7 @@ import {
   MenuItem,
   ListItemIcon,
   Snackbar,
+  Tooltip,
 } from "@mui/material";
 import SearchIcon from "@mui/icons-material/Search";
 import PeopleAltRoundedIcon from "@mui/icons-material/PeopleAltRounded";
@@ -52,6 +53,7 @@ import {
 import { personService, Person } from "../../../services/api/person.service";
 import { reportService } from "../../../services/api/report.service";
 import { useSeasonStore } from "../../../store/seasonStore";
+import { useTenantStore } from "../../../store/tenantStore";
 import { LinkClientModal } from "../../clients/components/LinkClientModal";
 import { ClientDetailsModal } from "../../clients/components/ClientDetailsModal";
 import { formatPhone, maskPhone } from "../../../utils/phone";
@@ -59,6 +61,40 @@ import { formatPhone, maskPhone } from "../../../utils/phone";
 export const DashboardPage = () => {
   const navigate = useNavigate();
   const { activeSeason } = useSeasonStore();
+  const { tenantStatus } = useTenantStore();
+
+  const isWriteBlocked = Boolean(
+    tenantStatus?.isUnpaid || tenantStatus?.isTrialExpired,
+  );
+
+  const isReportsBlocked = Boolean(
+    tenantStatus?.isUnpaid ||
+    tenantStatus?.isTrialExpired ||
+    tenantStatus?.clientLimitExceeded,
+  );
+
+  const getWriteBlockedReason = () => {
+    if (tenantStatus?.isUnpaid) {
+      return "Acesso suspenso por pendência de pagamento.";
+    }
+    if (tenantStatus?.isTrialExpired) {
+      return "Período de teste gratuito expirado.";
+    }
+    return "";
+  };
+
+  const getReportsBlockedReason = () => {
+    if (tenantStatus?.isUnpaid) {
+      return "Acesso suspenso por pendência de pagamento.";
+    }
+    if (tenantStatus?.isTrialExpired) {
+      return "Período de teste gratuito expirado.";
+    }
+    if (tenantStatus?.clientLimitExceeded) {
+      return "Limite de clientes cadastrados no plano atual excedido.";
+    }
+    return "";
+  };
 
   const [loading, setLoading] = useState(false);
   const [clients, setClients] = useState<SeasonClient[]>([]);
@@ -422,32 +458,36 @@ export const DashboardPage = () => {
                 }}
               />
             )}
-            <Button
-              variant="outlined"
-              startIcon={
-                exportingReport ? (
-                  <CircularProgress size={16} color="inherit" />
-                ) : (
-                  <AssessmentIcon />
-                )
-              }
-              endIcon={<ExpandMoreIcon />}
-              onClick={(e) => setReportMenuAnchor(e.currentTarget)}
-              disabled={exportingReport}
-              sx={{
-                borderColor: "rgba(255,255,255,0.4)",
-                color: "white",
-                "&:hover": {
-                  borderColor: "white",
-                  bgcolor: "rgba(255,255,255,0.08)",
-                },
-                borderRadius: 2,
-                textTransform: "none",
-                fontWeight: 600,
-              }}
-            >
-              {exportingReport ? "Gerando..." : "Relatórios"}
-            </Button>
+            <Tooltip title={isReportsBlocked ? getReportsBlockedReason() : ""}>
+              <span>
+                <Button
+                  variant="outlined"
+                  startIcon={
+                    exportingReport ? (
+                      <CircularProgress size={16} color="inherit" />
+                    ) : (
+                      <AssessmentIcon />
+                    )
+                  }
+                  endIcon={<ExpandMoreIcon />}
+                  onClick={(e) => setReportMenuAnchor(e.currentTarget)}
+                  disabled={exportingReport || isReportsBlocked}
+                  sx={{
+                    borderColor: "rgba(255,255,255,0.4)",
+                    color: "white",
+                    "&:hover": {
+                      borderColor: "white",
+                      bgcolor: "rgba(255,255,255,0.08)",
+                    },
+                    borderRadius: 2,
+                    textTransform: "none",
+                    fontWeight: 600,
+                  }}
+                >
+                  {exportingReport ? "Gerando..." : "Relatórios"}
+                </Button>
+              </span>
+            </Tooltip>
             <Menu
               anchorEl={reportMenuAnchor}
               open={Boolean(reportMenuAnchor)}
@@ -768,37 +808,46 @@ export const DashboardPage = () => {
                   },
                 }}
               />
-              <Button
-                variant="contained"
-                startIcon={<AddIcon />}
-                onClick={() => setLinkModalOpen(true)}
-                disabled={!activeSeason}
-                sx={{
-                  bgcolor: "primary.main",
-                  "&:hover": { bgcolor: "primary.dark" },
-                  borderRadius: 2,
-                  textTransform: "none",
-                  fontWeight: 700,
-                  px: 2,
-                  whiteSpace: "nowrap",
-                }}
-              >
-                Vincular Cliente
-              </Button>
-              <Button
-                variant="outlined"
-                startIcon={<PersonAddAlt1Icon />}
-                onClick={() => setNewPersonOpen(true)}
-                sx={{
-                  borderRadius: 2,
-                  textTransform: "none",
-                  fontWeight: 600,
-                  px: 2,
-                  whiteSpace: "nowrap",
-                }}
-              >
-                Nova Pessoa
-              </Button>
+              <Tooltip title={isWriteBlocked ? getWriteBlockedReason() : ""}>
+                <span>
+                  <Button
+                    variant="contained"
+                    startIcon={<AddIcon />}
+                    onClick={() => setLinkModalOpen(true)}
+                    disabled={!activeSeason || isWriteBlocked}
+                    sx={{
+                      bgcolor: "primary.main",
+                      "&:hover": { bgcolor: "primary.dark" },
+                      borderRadius: 2,
+                      textTransform: "none",
+                      fontWeight: 700,
+                      px: 2,
+                      whiteSpace: "nowrap",
+                    }}
+                  >
+                    Vincular Cliente
+                  </Button>
+                </span>
+              </Tooltip>
+              <Tooltip title={isWriteBlocked ? getWriteBlockedReason() : ""}>
+                <span>
+                  <Button
+                    variant="outlined"
+                    startIcon={<PersonAddAlt1Icon />}
+                    onClick={() => setNewPersonOpen(true)}
+                    disabled={isWriteBlocked}
+                    sx={{
+                      borderRadius: 2,
+                      textTransform: "none",
+                      fontWeight: 600,
+                      px: 2,
+                      whiteSpace: "nowrap",
+                    }}
+                  >
+                    Nova Pessoa
+                  </Button>
+                </span>
+              </Tooltip>
             </Box>
           </Box>
 

--- a/frontend/src/features/seasons/pages/SeasonsPage.tsx
+++ b/frontend/src/features/seasons/pages/SeasonsPage.tsx
@@ -34,9 +34,12 @@ import {
   Photographer,
 } from "../../../services/api/photographer.service";
 import { useSeasonStore } from "../../../store/seasonStore";
+import { useTenantStore } from "../../../store/tenantStore";
 
 export const SeasonsPage = () => {
   const { activeSeason, setActiveSeason } = useSeasonStore();
+  const { tenantStatus } = useTenantStore();
+
   const [seasons, setSeasons] = useState<Season[]>([]);
   const [photographers, setPhotographers] = useState<Photographer[]>([]);
   const [open, setOpen] = useState(false);
@@ -50,6 +53,29 @@ export const SeasonsPage = () => {
 
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
   const [deletingSeason, setDeletingSeason] = useState<Season | null>(null);
+
+  const isCreateBlocked = Boolean(
+    tenantStatus?.isUnpaid ||
+    tenantStatus?.isTrialExpired ||
+    tenantStatus?.clientLimitExceeded,
+  );
+
+  const isWriteBlocked = Boolean(
+    tenantStatus?.isUnpaid || tenantStatus?.isTrialExpired,
+  );
+
+  const getCreateBlockedReason = () => {
+    if (tenantStatus?.isUnpaid) {
+      return "Acesso suspenso por pendência de pagamento.";
+    }
+    if (tenantStatus?.isTrialExpired) {
+      return "Período de teste gratuito expirado.";
+    }
+    if (tenantStatus?.clientLimitExceeded) {
+      return "Limite de clientes cadastrados no plano atual excedido.";
+    }
+    return "";
+  };
 
   const load = async () => {
     try {
@@ -69,6 +95,7 @@ export const SeasonsPage = () => {
   }, []);
 
   const handleOpenCreate = () => {
+    if (isCreateBlocked) return;
     setEditingId(null);
     setName("");
     setSelectedPhotographers([]);
@@ -78,6 +105,7 @@ export const SeasonsPage = () => {
   };
 
   const handleOpenEdit = (s: Season) => {
+    if (isWriteBlocked) return;
     setEditingId(s.id);
     setName(s.name);
     setSelectedPhotographers(s.photographer_ids || []);
@@ -126,6 +154,7 @@ export const SeasonsPage = () => {
   };
 
   const handleOpenDelete = (s: Season) => {
+    if (isWriteBlocked) return;
     setDeletingSeason(s);
     setDeleteConfirmOpen(true);
   };
@@ -167,14 +196,19 @@ export const SeasonsPage = () => {
         >
           Eventos
         </Typography>
-        <Button
-          variant="contained"
-          startIcon={<AddIcon />}
-          onClick={handleOpenCreate}
-          sx={{ width: { xs: "100%", sm: "auto" }, whiteSpace: "nowrap" }}
-        >
-          Novo Evento
-        </Button>
+        <Tooltip title={isCreateBlocked ? getCreateBlockedReason() : ""}>
+          <span>
+            <Button
+              variant="contained"
+              startIcon={<AddIcon />}
+              onClick={handleOpenCreate}
+              disabled={isCreateBlocked}
+              sx={{ width: { xs: "100%", sm: "auto" }, whiteSpace: "nowrap" }}
+            >
+              Novo Evento
+            </Button>
+          </span>
+        </Tooltip>
       </Box>
 
       <TableContainer
@@ -247,24 +281,44 @@ export const SeasonsPage = () => {
                       )}
                     </TableCell>
                     <TableCell align="right">
-                      <Tooltip title="Editar">
-                        <IconButton
-                          color="primary"
-                          size="small"
-                          onClick={() => handleOpenEdit(s)}
-                          sx={{ mr: 1 }}
-                        >
-                          <EditIcon fontSize="small" />
-                        </IconButton>
+                      <Tooltip
+                        title={
+                          isWriteBlocked
+                            ? "Ação bloqueada pelo status do plano/pagamento."
+                            : "Editar"
+                        }
+                      >
+                        <span>
+                          <IconButton
+                            aria-label="Editar"
+                            color="primary"
+                            size="small"
+                            onClick={() => handleOpenEdit(s)}
+                            disabled={isWriteBlocked}
+                            sx={{ mr: 1 }}
+                          >
+                            <EditIcon fontSize="small" />
+                          </IconButton>
+                        </span>
                       </Tooltip>
-                      <Tooltip title="Excluir">
-                        <IconButton
-                          color="error"
-                          size="small"
-                          onClick={() => handleOpenDelete(s)}
-                        >
-                          <DeleteIcon fontSize="small" />
-                        </IconButton>
+                      <Tooltip
+                        title={
+                          isWriteBlocked
+                            ? "Ação bloqueada pelo status do plano/pagamento."
+                            : "Excluir"
+                        }
+                      >
+                        <span>
+                          <IconButton
+                            aria-label="Excluir"
+                            color="error"
+                            size="small"
+                            onClick={() => handleOpenDelete(s)}
+                            disabled={isWriteBlocked}
+                          >
+                            <DeleteIcon fontSize="small" />
+                          </IconButton>
+                        </span>
                       </Tooltip>
                     </TableCell>
                   </TableRow>

--- a/frontend/src/features/shared/components/TenantStatusBanner.tsx
+++ b/frontend/src/features/shared/components/TenantStatusBanner.tsx
@@ -1,0 +1,111 @@
+import { Alert, Box, Typography } from "@mui/material";
+import ErrorOutlineRoundedIcon from "@mui/icons-material/ErrorOutlineRounded";
+import WarningRoundedIcon from "@mui/icons-material/WarningRounded";
+import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
+import { useTenantStore } from "../../../store/tenantStore";
+
+export const TenantStatusBanner = () => {
+  const { tenantStatus } = useTenantStore();
+
+  if (!tenantStatus) {
+    return null;
+  }
+
+  // 1. Block: Unpaid
+  if (tenantStatus.isUnpaid || tenantStatus.paymentStatus === "unpaid") {
+    return (
+      <Box sx={{ mb: 2.5 }}>
+        <Alert
+          severity="error"
+          icon={<ErrorOutlineRoundedIcon fontSize="inherit" />}
+          sx={{
+            borderRadius: 2,
+            border: "1px solid",
+            borderColor: "error.light",
+            fontWeight: 500,
+          }}
+        >
+          <Typography variant="body2" sx={{ fontWeight: 600 }}>
+            Acesso suspenso por pendência de pagamento da assinatura. Entre em
+            contato com o suporte para regularizar.
+          </Typography>
+        </Alert>
+      </Box>
+    );
+  }
+
+  // 2. Block: Free Trial Expired
+  if (tenantStatus.isTrialExpired) {
+    return (
+      <Box sx={{ mb: 2.5 }}>
+        <Alert
+          severity="error"
+          icon={<ErrorOutlineRoundedIcon fontSize="inherit" />}
+          sx={{
+            borderRadius: 2,
+            border: "1px solid",
+            borderColor: "error.light",
+            fontWeight: 500,
+          }}
+        >
+          <Typography variant="body2" sx={{ fontWeight: 600 }}>
+            O período de teste gratuito de 14 dias da sua organização encerrou.
+            A edição de clientes e exportação de relatórios estão bloqueadas.
+            Entre em contato com o suporte para assinar um plano.
+          </Typography>
+        </Alert>
+      </Box>
+    );
+  }
+
+  // 3. Block: Client Quota Limit Exceeded (>= 300 clients in an event)
+  if (tenantStatus.clientLimitExceeded) {
+    return (
+      <Box sx={{ mb: 2.5 }}>
+        <Alert
+          severity="warning"
+          icon={<WarningRoundedIcon fontSize="inherit" />}
+          sx={{
+            borderRadius: 2,
+            border: "1px solid",
+            borderColor: "warning.light",
+            fontWeight: 500,
+          }}
+        >
+          <Typography variant="body2" sx={{ fontWeight: 600 }}>
+            A sua organização excedeu o limite de clientes cadastrados no plano
+            atual. A criação de novos eventos e a exportação de relatórios estão
+            suspensas. Entre em contato com o suporte para regularizar.
+          </Typography>
+        </Alert>
+      </Box>
+    );
+  }
+
+  // 4. Info: Free Trial Active
+  if (tenantStatus.plan === "free" && !tenantStatus.isTrialExpired) {
+    const days = tenantStatus.trialDaysRemaining;
+    const daysText = days === 1 ? "resta 1 dia" : `restam ${days} dias`;
+    return (
+      <Box sx={{ mb: 2.5 }}>
+        <Alert
+          severity="info"
+          icon={<InfoOutlinedIcon fontSize="inherit" />}
+          sx={{
+            borderRadius: 2,
+            border: "1px solid",
+            borderColor: "info.light",
+            fontWeight: 500,
+          }}
+        >
+          <Typography variant="body2">
+            Período de teste gratuito ativo: <strong>{daysText}</strong> de
+            teste.
+          </Typography>
+        </Alert>
+      </Box>
+    );
+  }
+
+  return null;
+};

--- a/frontend/src/features/shared/index.ts
+++ b/frontend/src/features/shared/index.ts
@@ -1,2 +1,3 @@
 export { useDocumentTitle } from "./hooks/useDocumentTitle";
 export { PageLoadingFallback } from "./components/PageLoadingFallback";
+export { TenantStatusBanner } from "./components/TenantStatusBanner";

--- a/frontend/src/layouts/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout.tsx
@@ -1,12 +1,24 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Box } from "@mui/material";
 import { Outlet } from "react-router-dom";
 import { Sidebar } from "./Sidebar";
 import { Topbar } from "./Topbar";
+import { useAuthStore } from "../features/auth/state/auth.store";
+import { useTenantStore } from "../store/tenantStore";
+import { TenantStatusBanner } from "../features/shared";
 
 export function AppLayout() {
   const [mobileOpen, setMobileOpen] = useState(false);
   const drawerWidth = 280;
+
+  const { user } = useAuthStore();
+  const { fetchTenantStatus } = useTenantStore();
+
+  useEffect(() => {
+    if (user?.tenantId) {
+      fetchTenantStatus();
+    }
+  }, [user?.tenantId, fetchTenantStatus]);
 
   const handleDrawerToggle = () => {
     setMobileOpen((prev) => !prev);
@@ -51,6 +63,7 @@ export function AppLayout() {
             maxWidth: "100%",
           }}
         >
+          <TenantStatusBanner />
           <Outlet />
         </Box>
       </Box>

--- a/frontend/src/services/api/tenant.service.ts
+++ b/frontend/src/services/api/tenant.service.ts
@@ -1,0 +1,25 @@
+import { apiClient } from "./client";
+import { ApiEnvelope } from "../../features/auth/types/auth.types";
+
+export interface TenantStatus {
+  name: string;
+  plan: "free" | "standard";
+  paymentStatus: "paid" | "unpaid";
+  planStartedAt?: string;
+  planExpiresAt?: string;
+  isTrialExpired: boolean;
+  trialDaysRemaining: number;
+  isUnpaid: boolean;
+  clientLimitExceeded: boolean;
+  maxClientsInSeason: number;
+  createdAt: string;
+  updatedAt?: string;
+}
+
+export const tenantService = {
+  async getCurrentTenant(): Promise<TenantStatus> {
+    const response =
+      await apiClient.get<ApiEnvelope<{ tenant: TenantStatus }>>("/tenant");
+    return response.data.data.tenant;
+  },
+};

--- a/frontend/src/store/tenantStore.ts
+++ b/frontend/src/store/tenantStore.ts
@@ -1,0 +1,32 @@
+import { create } from "zustand";
+import { TenantStatus, tenantService } from "../services/api/tenant.service";
+
+interface TenantState {
+  tenantStatus: TenantStatus | null;
+  loading: boolean;
+  error: string | null;
+  fetchTenantStatus: () => Promise<TenantStatus | null>;
+  setTenantStatus: (status: TenantStatus | null) => void;
+}
+
+export const useTenantStore = create<TenantState>((set) => ({
+  tenantStatus: null,
+  loading: false,
+  error: null,
+  fetchTenantStatus: async () => {
+    set({ loading: true, error: null });
+    try {
+      const status = await tenantService.getCurrentTenant();
+      set({ tenantStatus: status, loading: false });
+      return status;
+    } catch (err: unknown) {
+      const e = err as { message?: string };
+      set({
+        error: e.message || "Erro ao obter dados da organização",
+        loading: false,
+      });
+      return null;
+    }
+  },
+  setTenantStatus: (status) => set({ tenantStatus: status }),
+}));


### PR DESCRIPTION
## Descrição da Tarefa (Issue #54)

Implementação completa das regras de negócio de governança de planos por organização/tenant (`"free"` vs `"standard"`), expiração automática do período de teste gratuito (14 dias), bloqueio por inadimplência (`"unpaid"`) e bloqueio por quota de clientes cadastrados no evento (≥ 300 clientes).

---

### Principais Alterações

#### Backend (Go Clean Architecture)
- **Domínio (`domain/tenant`)**: Adicionados campos `Plan`, `PaymentStatus`, `PlanStartedAt`, `PlanExpiresAt` e `UpdatedAt`. Mapeamento de erros de domínio HTTP 403 Forbidden para cada regra com mensagens exatas.
- **Portas & Repositórios (`ports/tenant`, `ports/client`, `infrastructure/...`)**:
  - Implementado `Update` em `tenantDoc` MongoDB.
  - Implementado `CountBySeason` e agregação de `MaxClientsPerSeason` em `clientDoc` MongoDB.
  - Criada interface `tenantport.Validator` injetada em todos os usecases.
- **Casos de Uso (`usecase/...`)**:
  - `tenantusecase.Service`: Implementado gerenciamento de planos, expiração de trial e validações centralizadas (`ValidateCanCreateSeason`, `ValidateCanExportReport`, `ValidateCanWriteClients`, `ValidateCanWriteEntities`, `GetTenantStatus`).
  - Usecases de `season`, `client`, `person`, `photographer` e `report` validando o tenant em operações de escrita/exportação.
- **REST API (`interfaces/rest/handlers`)**:
  - `AdminHandler`: Endpoints `PUT /api/v1/admin/tenants/{name}/plan` e `PUT /api/v1/admin/tenants/{name}/payment-status`.
  - `TenantHandler`: Endpoint `GET /api/v1/tenant` para consulta do status pelo tenant autenticado.
  - Mapeamento uniforme dos erros para HTTP 403 Forbidden.
- **Swagger Docs**: Atualizado via `./scripts/swagger.sh`.

#### Frontend (React / TypeScript / Material UI)
- **Tipos e Serviços (`admin.service.ts`, `tenant.service.ts`)**:
  - Suporte à atualização de plano e status financeiro pelo SuperAdmin.
  - Integração com `GET /api/v1/tenant` via Zustand (`useTenantStore`).
- **Banner de Status (`TenantStatusBanner.tsx`)**:
  - Exibido no topo do layout global (`AppLayout.tsx`) alertando sobre inadimplência, trial expirado, limite de clientes atingido ou período restante de teste.
- **Painel Admin (`AdminTenantsPage.tsx`)**:
  - Colunas de Plano, Status de Pagamento, Expiração do Trial e modais de alteração rápida.
- **Bloqueio Visual de Ações**:
  - `DashboardPage.tsx` e `SeasonsPage.tsx`: Botões desabilitados quando bloqueados, acompanhados de Tooltips explicativos.

---

### Testes & Qualidade
- `./scripts/swagger.sh` executado com sucesso.
- `./scripts/check.sh all` executado com 100% de sucesso (backend vet + 11 pacotes de testes, frontend typecheck + lint + prettier + testes vitest, terraform fmt).

Closes #54.