### PR TITLE
fix(frontend): remover manualChunks para eliminar dependencias circulares em producao

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -75,31 +75,6 @@ export default defineConfig({
   build: {
     target: "esnext",
     cssCodeSplit: true,
-    chunkSizeWarningLimit: 600,
-    rollupOptions: {
-      output: {
-        manualChunks(id) {
-          if (id.includes("node_modules")) {
-            if (id.includes("@mui/icons-material")) {
-              return "vendor-icons";
-            }
-            if (
-              id.includes("@mui/material") ||
-              id.includes("@emotion/react") ||
-              id.includes("@emotion/styled")
-            ) {
-              return "vendor-mui";
-            }
-            if (
-              id.includes("react") ||
-              id.includes("react-dom") ||
-              id.includes("react-router-dom")
-            ) {
-              return "vendor-react";
-            }
-          }
-        },
-      },
-    },
+    chunkSizeWarningLimit: 1000,
   },
 });


### PR DESCRIPTION
### Descrição do Problema
Após os últimos merges na `main` integrando o banner de status e validações de planos/inadimplência (`TenantStatusBanner`), a tela de produção do frontend (`https://ps.yurinogueira.dev.br`) passou a exibir tela branca com erro em tempo de execução na inicialização:
```text
TypeError: t is not a function at vendor-icons.js:1:55
(ou ReferenceError: i is not defined)
```

### Causa Raiz
1. O `TenantStatusBanner` incluiu ícones do `@mui/icons-material` no layout síncrono da aplicação (`AppLayout`) junto do `client.ts` e stores Zustand.
2. A configuração de `manualChunks` no `vite.config.ts` separava artificialmente `@mui/icons-material` (`vendor-icons`), `@mui/material` (`vendor-mui`) e `react` (`vendor-react`).
3. O bundler do Vite 8 (Rolldown) alocou os helpers de interoperabilidade CommonJS (`__commonJSMin` / `__toESM`) no chunk `client`, gerando um ciclo de dependências circulares entre `client`, `vendor-icons`, `vendor-react` e `vendor-mui`.
4. No navegador, durante a resolução inicial dos módulos ES com dependências circulares, a função exportada pelo `client` estava como `undefined` no momento em que o `vendor-icons` tentava executá-la, abortando o script.

### Solução Aplicada
- Remoção da configuração artificial de `manualChunks` em `frontend/vite.config.ts`.
- O code splitting baseado nas rotas (`React.lazy` e `Suspense` em `src/routes/index.tsx`) permanece 100% ativo, garantindo divisão granular por página e excelente performance sem riscos de dependências circulares.
- Ajuste do `chunkSizeWarningLimit` para 1000 kB.

### Validações
- [x] `./scripts/check.sh all` (Backend, Frontend Typecheck, Lint, Formatação e Testes Unitários 100% aprovados).
- [x] Teste de inicialização e renderização do bundle de produção com **Puppeteer** via `vite preview` validando o carregamento completo da tela de Login sem erros no console.