### PR TITLE
feat(clients): campo de seleção de moeda e condicionalidade nos campos de pagamento (#50)

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -2282,6 +2282,9 @@ const docTemplate = `{
                 "created_at": {
                     "type": "string"
                 },
+                "currency": {
+                    "type": "string"
+                },
                 "file_number": {
                     "type": "string"
                 },

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -2276,6 +2276,9 @@
                 "created_at": {
                     "type": "string"
                 },
+                "currency": {
+                    "type": "string"
+                },
                 "file_number": {
                     "type": "string"
                 },

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -42,6 +42,8 @@ definitions:
         type: number
       created_at:
         type: string
+      currency:
+        type: string
       file_number:
         type: string
       judges:

--- a/backend/internal/application/usecase/client/service.go
+++ b/backend/internal/application/usecase/client/service.go
@@ -17,6 +17,7 @@ var (
 	ErrSeasonNotFound       = errors.New("season not found or does not belong to tenant")
 	ErrPhotographerNotFound = errors.New("photographer not found or does not belong to tenant")
 	ErrClientNotFound       = errors.New("client not found or does not belong to tenant")
+	ErrInvalidAmountPaid    = errors.New("amount_paid cannot be negative")
 )
 
 type Service struct {
@@ -89,6 +90,25 @@ func (s *Service) validateReferences(ctx context.Context, c *domain.SeasonClient
 	return nil
 }
 
+func (s *Service) validateAndNormalizePhotos(c *domain.SeasonClient) error {
+	for i := range c.Dogs {
+		for j := range c.Dogs[i].Photos {
+			photo := &c.Dogs[i].Photos[j]
+			if photo.AmountPaid != nil && *photo.AmountPaid < 0 {
+				return ErrInvalidAmountPaid
+			}
+			if photo.PaymentMethod == "Não pago" {
+				photo.AmountPaid = nil
+			} else {
+				if photo.Currency == "" {
+					photo.Currency = "BRL"
+				}
+			}
+		}
+	}
+	return nil
+}
+
 func (s *Service) Create(ctx context.Context, client *domain.SeasonClient, tenantID string) error {
 	if s.tenantValidator != nil {
 		if err := s.tenantValidator.ValidateCanWriteClients(ctx, tenantID); err != nil {
@@ -96,6 +116,9 @@ func (s *Service) Create(ctx context.Context, client *domain.SeasonClient, tenan
 		}
 	}
 	client.TenantID = tenantID
+	if err := s.validateAndNormalizePhotos(client); err != nil {
+		return err
+	}
 	if err := s.validateReferences(ctx, client, tenantID); err != nil {
 		return err
 	}
@@ -128,6 +151,9 @@ func (s *Service) Update(ctx context.Context, client *domain.SeasonClient, tenan
 	client.TenantID = tenantID
 	if _, err := s.repo.GetByID(ctx, client.ID, tenantID); err != nil {
 		return ErrClientNotFound
+	}
+	if err := s.validateAndNormalizePhotos(client); err != nil {
+		return err
 	}
 	if err := s.validateReferences(ctx, client, tenantID); err != nil {
 		return err

--- a/backend/internal/application/usecase/client/service_test.go
+++ b/backend/internal/application/usecase/client/service_test.go
@@ -501,3 +501,142 @@ func TestClientService_CrossTenantValidation(t *testing.T) {
 		}
 	})
 }
+
+func TestClientService_PhotoCurrencyAndAmountValidation(t *testing.T) {
+	repo := newMockRepo()
+	personRepo := newMockPersonRepo()
+	seasonRepo := newMockSeasonRepo()
+	photogRepo := newMockPhotographerRepo()
+
+	svc := client.NewService(repo, personRepo, seasonRepo, photogRepo)
+	ctx := context.Background()
+	tenantID := "tenant-test"
+
+	personRepo.items["person-1"] = &persondomain.Person{ID: "person-1", TenantID: tenantID, Name: "Owner 1"}
+	seasonRepo.items["season-1"] = &seasondomain.Season{ID: "season-1", TenantID: tenantID, Name: "Season 1"}
+	photogRepo.items["photo-1"] = &photographerdomain.Photographer{ID: "photo-1", TenantID: tenantID, Name: "Photo 1"}
+
+	t.Run("Create - negative amount paid rejected", func(t *testing.T) {
+		negVal := -10.5
+		c := &domain.SeasonClient{
+			PersonID: "person-1",
+			SeasonID: "season-1",
+			Dogs: []domain.Dog{
+				{
+					Breed: "Husky",
+					Photos: []domain.Photo{
+						{
+							FileNumber:     "F1",
+							PhotographerID: "photo-1",
+							PaymentMethod:  "Pix",
+							AmountPaid:     &negVal,
+						},
+					},
+				},
+			},
+		}
+		err := svc.Create(ctx, c, tenantID)
+		if !errors.Is(err, client.ErrInvalidAmountPaid) {
+			t.Fatalf("expected ErrInvalidAmountPaid, got %v", err)
+		}
+	})
+
+	t.Run("Update - negative amount paid rejected", func(t *testing.T) {
+		c := &domain.SeasonClient{
+			ID:       "client-valid",
+			PersonID: "person-1",
+			SeasonID: "season-1",
+			Dogs:     []domain.Dog{{Breed: "Pug"}},
+		}
+		if err := svc.Create(ctx, c, tenantID); err != nil {
+			t.Fatalf("unexpected error creating client: %v", err)
+		}
+
+		negVal := -5.0
+		c.Dogs[0].Photos = []domain.Photo{
+			{
+				FileNumber:     "F2",
+				PhotographerID: "photo-1",
+				PaymentMethod:  "Dinheiro",
+				AmountPaid:     &negVal,
+			},
+		}
+		err := svc.Update(ctx, c, tenantID)
+		if !errors.Is(err, client.ErrInvalidAmountPaid) {
+			t.Fatalf("expected ErrInvalidAmountPaid on Update, got %v", err)
+		}
+	})
+
+	t.Run("Create - default currency BRL and custom USD", func(t *testing.T) {
+		valBrl := 50.0
+		valUsd := 20.0
+		c := &domain.SeasonClient{
+			ID:       "client-curr",
+			PersonID: "person-1",
+			SeasonID: "season-1",
+			Dogs: []domain.Dog{
+				{
+					Breed: "Beagle",
+					Photos: []domain.Photo{
+						{
+							FileNumber:     "BRL_01",
+							PhotographerID: "photo-1",
+							PaymentMethod:  "Pix",
+							AmountPaid:     &valBrl,
+							// Currency empty -> should default to BRL
+						},
+						{
+							FileNumber:     "USD_01",
+							PhotographerID: "photo-1",
+							PaymentMethod:  "Cartão de Crédito",
+							Currency:       "USD",
+							AmountPaid:     &valUsd,
+						},
+					},
+				},
+			},
+		}
+		if err := svc.Create(ctx, c, tenantID); err != nil {
+			t.Fatalf("unexpected error creating client with currencies: %v", err)
+		}
+
+		created, err := svc.GetByID(ctx, "client-curr", tenantID)
+		if err != nil {
+			t.Fatalf("unexpected error getting client: %v", err)
+		}
+		if created.Dogs[0].Photos[0].Currency != "BRL" {
+			t.Fatalf("expected default Currency BRL, got %s", created.Dogs[0].Photos[0].Currency)
+		}
+		if created.Dogs[0].Photos[1].Currency != "USD" {
+			t.Fatalf("expected Currency USD, got %s", created.Dogs[0].Photos[1].Currency)
+		}
+	})
+
+	t.Run("Create & Update - 'Não pago' resets amount_paid", func(t *testing.T) {
+		val := 100.0
+		c := &domain.SeasonClient{
+			ID:       "client-unpaid",
+			PersonID: "person-1",
+			SeasonID: "season-1",
+			Dogs: []domain.Dog{
+				{
+					Breed: "Bulldog",
+					Photos: []domain.Photo{
+						{
+							FileNumber:     "UNPAID_01",
+							PhotographerID: "photo-1",
+							PaymentMethod:  "Não pago",
+							AmountPaid:     &val, // Residual value should be nulled
+						},
+					},
+				},
+			},
+		}
+		if err := svc.Create(ctx, c, tenantID); err != nil {
+			t.Fatalf("unexpected error creating unpaid client: %v", err)
+		}
+		if c.Dogs[0].Photos[0].AmountPaid != nil {
+			t.Fatalf("expected AmountPaid to be nil for 'Não pago', got %v", *c.Dogs[0].Photos[0].AmountPaid)
+		}
+	})
+}

--- a/backend/internal/domain/client/client.go
+++ b/backend/internal/domain/client/client.go
@@ -28,6 +28,7 @@ type Photo struct {
 	FileNumber     string     `json:"file_number" bson:"file_number"`
 	PhotographerID string     `json:"photographer_id" bson:"photographer_id"`
 	PaymentMethod  string     `json:"payment_method" bson:"payment_method"` // Pix, Cartão de Crédito, Cartão de Débito, Dinheiro, Não pago
+	Currency       string     `json:"currency,omitempty" bson:"currency,omitempty"`
 	AmountPaid     *float64   `json:"amount_paid" bson:"amount_paid"`
 	Judges         []string   `json:"judges,omitempty" bson:"judges,omitempty"`
 	CreatedAt      *time.Time `json:"created_at,omitempty" bson:"created_at,omitempty"`

--- a/backend/internal/interfaces/rest/handlers/client_handler.go
+++ b/backend/internal/interfaces/rest/handlers/client_handler.go
@@ -49,7 +49,8 @@ func (h *SeasonClientHandler) Create(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, err.Error(), http.StatusForbidden)
 		case errors.Is(err, client.ErrPersonNotFound),
 			errors.Is(err, client.ErrSeasonNotFound),
-			errors.Is(err, client.ErrPhotographerNotFound):
+			errors.Is(err, client.ErrPhotographerNotFound),
+			errors.Is(err, client.ErrInvalidAmountPaid):
 			http.Error(w, err.Error(), http.StatusBadRequest)
 		default:
 			http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -179,7 +180,8 @@ func (h *SeasonClientHandler) Update(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, err.Error(), http.StatusNotFound)
 		case errors.Is(err, client.ErrPersonNotFound),
 			errors.Is(err, client.ErrSeasonNotFound),
-			errors.Is(err, client.ErrPhotographerNotFound):
+			errors.Is(err, client.ErrPhotographerNotFound),
+			errors.Is(err, client.ErrInvalidAmountPaid):
 			http.Error(w, err.Error(), http.StatusBadRequest)
 		default:
 			http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/frontend/src/features/clients/components/ClientDetailsModal.tsx
+++ b/frontend/src/features/clients/components/ClientDetailsModal.tsx
@@ -31,6 +31,8 @@ import EmojiEventsIcon from "@mui/icons-material/EmojiEvents";
 import {
   clientService,
   SeasonClient,
+  Photo,
+  CURRENCIES,
 } from "../../../services/api/client.service";
 import { personService, Person } from "../../../services/api/person.service";
 import {
@@ -200,6 +202,7 @@ export const ClientDetailsModal = ({
       file_number: "",
       photographer_id: "",
       payment_method: "Pix",
+      currency: "BRL",
       amount_paid: 0,
     });
     newDogs[dogIndex] = { ...newDogs[dogIndex], photos };
@@ -209,16 +212,23 @@ export const ClientDetailsModal = ({
   const updatePhoto = (
     dogIndex: number,
     photoIndex: number,
-    field: string,
-    value: unknown,
+    fieldOrObj: string | Partial<Photo>,
+    value?: unknown,
   ) => {
     if (!client) return;
     const newDogs = [...(client.dogs || [])];
     const photos = [...(newDogs[dogIndex].photos || [])];
-    photos[photoIndex] = {
-      ...photos[photoIndex],
-      [field]: value,
-    };
+    if (typeof fieldOrObj === "string") {
+      photos[photoIndex] = {
+        ...photos[photoIndex],
+        [fieldOrObj]: value,
+      };
+    } else {
+      photos[photoIndex] = {
+        ...photos[photoIndex],
+        ...fieldOrObj,
+      };
+    }
     newDogs[dogIndex] = { ...newDogs[dogIndex], photos };
     setClient({ ...client, dogs: newDogs });
   };
@@ -590,14 +600,20 @@ export const ClientDetailsModal = ({
                             labelId={`modal-payment-label-${dIdx}-${pIdx}`}
                             value={photo.payment_method || "Pix"}
                             label="Pagamento"
-                            onChange={(e) =>
-                              updatePhoto(
-                                dIdx,
-                                pIdx,
-                                "payment_method",
-                                e.target.value,
-                              )
-                            }
+                            onChange={(e) => {
+                              const newMethod = e.target.value;
+                              if (newMethod === "Não pago") {
+                                updatePhoto(dIdx, pIdx, {
+                                  payment_method: newMethod,
+                                  amount_paid: 0,
+                                });
+                              } else {
+                                updatePhoto(dIdx, pIdx, {
+                                  payment_method: newMethod,
+                                  currency: photo.currency || "BRL",
+                                });
+                              }
+                            }}
                           >
                             {PAYMENT_METHODS.map((m) => (
                               <MenuItem key={m} value={m}>
@@ -606,21 +622,55 @@ export const ClientDetailsModal = ({
                             ))}
                           </Select>
                         </FormControl>
-                        <TextField
-                          size="small"
-                          type="number"
-                          label="Valor Pago"
-                          value={photo.amount_paid ?? 0}
-                          onChange={(e) =>
-                            updatePhoto(
-                              dIdx,
-                              pIdx,
-                              "amount_paid",
-                              parseFloat(e.target.value) || 0,
-                            )
-                          }
-                          sx={{ width: 120 }}
-                        />
+                        {photo.payment_method !== "Não pago" && (
+                          <>
+                            <FormControl size="small" sx={{ minWidth: 120 }}>
+                              <InputLabel
+                                id={`modal-currency-label-${dIdx}-${pIdx}`}
+                              >
+                                Moeda
+                              </InputLabel>
+                              <Select
+                                labelId={`modal-currency-label-${dIdx}-${pIdx}`}
+                                value={photo.currency || "BRL"}
+                                label="Moeda"
+                                onChange={(e) =>
+                                  updatePhoto(
+                                    dIdx,
+                                    pIdx,
+                                    "currency",
+                                    e.target.value,
+                                  )
+                                }
+                              >
+                                {CURRENCIES.map((c) => (
+                                  <MenuItem key={c.value} value={c.value}>
+                                    {c.label}
+                                  </MenuItem>
+                                ))}
+                              </Select>
+                            </FormControl>
+                            <TextField
+                              size="small"
+                              type="number"
+                              label="Valor Pago"
+                              slotProps={{
+                                htmlInput: { min: 0, step: "0.01" },
+                              }}
+                              value={photo.amount_paid ?? 0}
+                              onChange={(e) => {
+                                const val = parseFloat(e.target.value);
+                                updatePhoto(
+                                  dIdx,
+                                  pIdx,
+                                  "amount_paid",
+                                  isNaN(val) ? 0 : Math.max(0, val),
+                                );
+                              }}
+                              sx={{ width: 120 }}
+                            />
+                          </>
+                        )}
                         <IconButton
                           size="small"
                           color="error"

--- a/frontend/src/features/clients/components/LinkClientModal.tsx
+++ b/frontend/src/features/clients/components/LinkClientModal.tsx
@@ -23,7 +23,12 @@ import {
 import AddIcon from "@mui/icons-material/Add";
 import DeleteIcon from "@mui/icons-material/Delete";
 import EmojiEventsIcon from "@mui/icons-material/EmojiEvents";
-import { clientService, Dog } from "../../../services/api/client.service";
+import {
+  clientService,
+  Dog,
+  Photo,
+  CURRENCIES,
+} from "../../../services/api/client.service";
 import { personService, Person } from "../../../services/api/person.service";
 import {
   photographerService,
@@ -162,6 +167,7 @@ export const LinkClientModal = ({
       file_number: "",
       photographer_id: "",
       payment_method: "Pix",
+      currency: "BRL",
       amount_paid: 0,
     });
     newDogs[dogIndex] = { ...newDogs[dogIndex], photos };
@@ -171,15 +177,22 @@ export const LinkClientModal = ({
   const updatePhoto = (
     dogIndex: number,
     photoIndex: number,
-    field: string,
-    value: unknown,
+    fieldOrObj: string | Partial<Photo>,
+    value?: unknown,
   ) => {
     const newDogs = [...dogs];
     const photos = [...newDogs[dogIndex].photos];
-    photos[photoIndex] = {
-      ...photos[photoIndex],
-      [field]: value,
-    };
+    if (typeof fieldOrObj === "string") {
+      photos[photoIndex] = {
+        ...photos[photoIndex],
+        [fieldOrObj]: value,
+      };
+    } else {
+      photos[photoIndex] = {
+        ...photos[photoIndex],
+        ...fieldOrObj,
+      };
+    }
     newDogs[dogIndex] = { ...newDogs[dogIndex], photos };
     setDogs(newDogs);
   };
@@ -484,9 +497,20 @@ export const LinkClientModal = ({
                     labelId={`payment-label-${dIdx}-${pIdx}`}
                     value={photo.payment_method || "Pix"}
                     label="Pagamento"
-                    onChange={(e) =>
-                      updatePhoto(dIdx, pIdx, "payment_method", e.target.value)
-                    }
+                    onChange={(e) => {
+                      const newMethod = e.target.value;
+                      if (newMethod === "Não pago") {
+                        updatePhoto(dIdx, pIdx, {
+                          payment_method: newMethod,
+                          amount_paid: 0,
+                        });
+                      } else {
+                        updatePhoto(dIdx, pIdx, {
+                          payment_method: newMethod,
+                          currency: photo.currency || "BRL",
+                        });
+                      }
+                    }}
                   >
                     {PAYMENT_METHODS.map((m) => (
                       <MenuItem key={m} value={m}>
@@ -495,21 +519,46 @@ export const LinkClientModal = ({
                     ))}
                   </Select>
                 </FormControl>
-                <TextField
-                  size="small"
-                  type="number"
-                  label="Valor Pago"
-                  value={photo.amount_paid ?? 0}
-                  onChange={(e) =>
-                    updatePhoto(
-                      dIdx,
-                      pIdx,
-                      "amount_paid",
-                      parseFloat(e.target.value) || 0,
-                    )
-                  }
-                  sx={{ width: 120 }}
-                />
+                {photo.payment_method !== "Não pago" && (
+                  <>
+                    <FormControl size="small" sx={{ minWidth: 120 }}>
+                      <InputLabel id={`currency-label-${dIdx}-${pIdx}`}>
+                        Moeda
+                      </InputLabel>
+                      <Select
+                        labelId={`currency-label-${dIdx}-${pIdx}`}
+                        value={photo.currency || "BRL"}
+                        label="Moeda"
+                        onChange={(e) =>
+                          updatePhoto(dIdx, pIdx, "currency", e.target.value)
+                        }
+                      >
+                        {CURRENCIES.map((c) => (
+                          <MenuItem key={c.value} value={c.value}>
+                            {c.label}
+                          </MenuItem>
+                        ))}
+                      </Select>
+                    </FormControl>
+                    <TextField
+                      size="small"
+                      type="number"
+                      label="Valor Pago"
+                      slotProps={{ htmlInput: { min: 0, step: "0.01" } }}
+                      value={photo.amount_paid ?? 0}
+                      onChange={(e) => {
+                        const val = parseFloat(e.target.value);
+                        updatePhoto(
+                          dIdx,
+                          pIdx,
+                          "amount_paid",
+                          isNaN(val) ? 0 : Math.max(0, val),
+                        );
+                      }}
+                      sx={{ width: 120 }}
+                    />
+                  </>
+                )}
                 <IconButton
                   size="small"
                   color="error"

--- a/frontend/src/features/clients/pages/ClientDetailsPage.tsx
+++ b/frontend/src/features/clients/pages/ClientDetailsPage.tsx
@@ -35,6 +35,7 @@ import {
   SeasonClient,
   Photo,
   Dog,
+  CURRENCIES,
 } from "../../../services/api/client.service";
 import { personService, Person } from "../../../services/api/person.service";
 import {
@@ -204,24 +205,32 @@ export const ClientDetailsPage = () => {
       file_number: "",
       photographer_id: "",
       payment_method: "Pix",
+      currency: "BRL",
       amount_paid: 0,
     } as Photo);
     newDogs[dogIndex] = { ...newDogs[dogIndex], photos };
     setClient({ ...client, dogs: newDogs });
   };
 
-  const updatePhoto = <K extends keyof Photo>(
+  const updatePhoto = (
     dogIndex: number,
     photoIndex: number,
-    field: K,
-    value: Photo[K],
+    fieldOrObj: keyof Photo | Partial<Photo>,
+    value?: unknown,
   ) => {
     if (!client) return;
     const newDogs = [...client.dogs];
-    newDogs[dogIndex].photos[photoIndex] = {
-      ...newDogs[dogIndex].photos[photoIndex],
-      [field]: value,
-    };
+    if (typeof fieldOrObj === "string") {
+      newDogs[dogIndex].photos[photoIndex] = {
+        ...newDogs[dogIndex].photos[photoIndex],
+        [fieldOrObj]: value,
+      };
+    } else {
+      newDogs[dogIndex].photos[photoIndex] = {
+        ...newDogs[dogIndex].photos[photoIndex],
+        ...fieldOrObj,
+      };
+    }
     setClient({ ...client, dogs: newDogs });
   };
 
@@ -561,9 +570,20 @@ export const ClientDetailsPage = () => {
                   <Select
                     value={photo.payment_method || "Pix"}
                     label="Forma de Pagamento *"
-                    onChange={(e) =>
-                      updatePhoto(dIdx, pIdx, "payment_method", e.target.value)
-                    }
+                    onChange={(e) => {
+                      const newMethod = e.target.value;
+                      if (newMethod === "Não pago") {
+                        updatePhoto(dIdx, pIdx, {
+                          payment_method: newMethod,
+                          amount_paid: 0,
+                        });
+                      } else {
+                        updatePhoto(dIdx, pIdx, {
+                          payment_method: newMethod,
+                          currency: photo.currency || "BRL",
+                        });
+                      }
+                    }}
                   >
                     {PAYMENT_METHODS.map((m) => (
                       <MenuItem key={m} value={m}>
@@ -572,31 +592,58 @@ export const ClientDetailsPage = () => {
                     ))}
                   </Select>
                 </FormControl>
-                <TextField
-                  size="small"
-                  type="number"
-                  label="Valor Pago (Opcional)"
-                  value={
-                    photo.amount_paid === undefined ||
-                    photo.amount_paid === null
-                      ? ""
-                      : photo.amount_paid
-                  }
-                  onChange={(e) =>
-                    updatePhoto(
-                      dIdx,
-                      pIdx,
-                      "amount_paid",
-                      e.target.value === ""
-                        ? 0
-                        : parseFloat(e.target.value) || 0,
-                    )
-                  }
-                  sx={{
-                    flex: { xs: "1 1 100%", sm: "1 1 150px" },
-                    minWidth: "140px",
-                  }}
-                />
+                {photo.payment_method !== "Não pago" && (
+                  <>
+                    <FormControl
+                      size="small"
+                      required
+                      sx={{
+                        flex: { xs: "1 1 100%", sm: "1 1 140px" },
+                        minWidth: "120px",
+                      }}
+                    >
+                      <InputLabel required>Moeda</InputLabel>
+                      <Select
+                        value={photo.currency || "BRL"}
+                        label="Moeda *"
+                        onChange={(e) =>
+                          updatePhoto(dIdx, pIdx, "currency", e.target.value)
+                        }
+                      >
+                        {CURRENCIES.map((c) => (
+                          <MenuItem key={c.value} value={c.value}>
+                            {c.label}
+                          </MenuItem>
+                        ))}
+                      </Select>
+                    </FormControl>
+                    <TextField
+                      size="small"
+                      type="number"
+                      label="Valor Pago (Opcional)"
+                      slotProps={{ htmlInput: { min: 0, step: "0.01" } }}
+                      value={
+                        photo.amount_paid === undefined ||
+                        photo.amount_paid === null
+                          ? ""
+                          : photo.amount_paid
+                      }
+                      onChange={(e) => {
+                        const val = parseFloat(e.target.value);
+                        updatePhoto(
+                          dIdx,
+                          pIdx,
+                          "amount_paid",
+                          isNaN(val) ? 0 : Math.max(0, val),
+                        );
+                      }}
+                      sx={{
+                        flex: { xs: "1 1 100%", sm: "1 1 150px" },
+                        minWidth: "140px",
+                      }}
+                    />
+                  </>
+                )}
                 <IconButton
                   color="error"
                   size="small"

--- a/frontend/src/features/clients/pages/ClientsPage.tsx
+++ b/frontend/src/features/clients/pages/ClientsPage.tsx
@@ -43,6 +43,7 @@ import {
   SeasonClient,
   Dog,
   Photo,
+  CURRENCIES,
 } from "../../../services/api/client.service";
 import { personService, Person } from "../../../services/api/person.service";
 import {
@@ -183,23 +184,31 @@ export const ClientsPage = () => {
       file_number: "",
       photographer_id: "",
       payment_method: "Pix",
+      currency: "BRL",
       amount_paid: 0,
     } as Photo);
     newDogs[dogIndex] = { ...newDogs[dogIndex], photos };
     setDogs(newDogs);
   };
 
-  const updatePhoto = <K extends keyof Photo>(
+  const updatePhoto = (
     dogIndex: number,
     photoIndex: number,
-    field: K,
-    value: Photo[K],
+    fieldOrObj: keyof Photo | Partial<Photo>,
+    value?: unknown,
   ) => {
     const newDogs = [...dogs];
-    newDogs[dogIndex].photos[photoIndex] = {
-      ...newDogs[dogIndex].photos[photoIndex],
-      [field]: value,
-    };
+    if (typeof fieldOrObj === "string") {
+      newDogs[dogIndex].photos[photoIndex] = {
+        ...newDogs[dogIndex].photos[photoIndex],
+        [fieldOrObj]: value,
+      };
+    } else {
+      newDogs[dogIndex].photos[photoIndex] = {
+        ...newDogs[dogIndex].photos[photoIndex],
+        ...fieldOrObj,
+      };
+    }
     setDogs(newDogs);
   };
 
@@ -756,14 +765,20 @@ export const ClientsPage = () => {
                     <Select
                       value={photo.payment_method}
                       label="Forma de Pagamento *"
-                      onChange={(e) =>
-                        updatePhoto(
-                          dIdx,
-                          pIdx,
-                          "payment_method",
-                          e.target.value,
-                        )
-                      }
+                      onChange={(e) => {
+                        const newMethod = e.target.value;
+                        if (newMethod === "Não pago") {
+                          updatePhoto(dIdx, pIdx, {
+                            payment_method: newMethod,
+                            amount_paid: 0,
+                          });
+                        } else {
+                          updatePhoto(dIdx, pIdx, {
+                            payment_method: newMethod,
+                            currency: photo.currency || "BRL",
+                          });
+                        }
+                      }}
                     >
                       {PAYMENT_METHODS.map((m) => (
                         <MenuItem key={m} value={m}>
@@ -772,31 +787,58 @@ export const ClientsPage = () => {
                       ))}
                     </Select>
                   </FormControl>
-                  <TextField
-                    size="small"
-                    type="number"
-                    label="Valor Pago (Opcional)"
-                    value={
-                      photo.amount_paid === undefined ||
-                      photo.amount_paid === null
-                        ? ""
-                        : photo.amount_paid
-                    }
-                    onChange={(e) =>
-                      updatePhoto(
-                        dIdx,
-                        pIdx,
-                        "amount_paid",
-                        e.target.value === ""
-                          ? 0
-                          : parseFloat(e.target.value) || 0,
-                      )
-                    }
-                    sx={{
-                      flex: { xs: "1 1 100%", sm: "1 1 150px" },
-                      minWidth: "140px",
-                    }}
-                  />
+                  {photo.payment_method !== "Não pago" && (
+                    <>
+                      <FormControl
+                        size="small"
+                        required
+                        sx={{
+                          flex: { xs: "1 1 100%", sm: "1 1 140px" },
+                          minWidth: "120px",
+                        }}
+                      >
+                        <InputLabel required>Moeda</InputLabel>
+                        <Select
+                          value={photo.currency || "BRL"}
+                          label="Moeda *"
+                          onChange={(e) =>
+                            updatePhoto(dIdx, pIdx, "currency", e.target.value)
+                          }
+                        >
+                          {CURRENCIES.map((c) => (
+                            <MenuItem key={c.value} value={c.value}>
+                              {c.label}
+                            </MenuItem>
+                          ))}
+                        </Select>
+                      </FormControl>
+                      <TextField
+                        size="small"
+                        type="number"
+                        label="Valor Pago (Opcional)"
+                        slotProps={{ htmlInput: { min: 0, step: "0.01" } }}
+                        value={
+                          photo.amount_paid === undefined ||
+                          photo.amount_paid === null
+                            ? ""
+                            : photo.amount_paid
+                        }
+                        onChange={(e) => {
+                          const val = parseFloat(e.target.value);
+                          updatePhoto(
+                            dIdx,
+                            pIdx,
+                            "amount_paid",
+                            isNaN(val) ? 0 : Math.max(0, val),
+                          );
+                        }}
+                        sx={{
+                          flex: { xs: "1 1 100%", sm: "1 1 150px" },
+                          minWidth: "140px",
+                        }}
+                      />
+                    </>
+                  )}
                   <IconButton
                     color="error"
                     size="small"

--- a/frontend/src/features/people/pages/PersonDetailsPage.test.tsx
+++ b/frontend/src/features/people/pages/PersonDetailsPage.test.tsx
@@ -19,6 +19,10 @@ vi.mock("../../../services/api/client.service", () => ({
     create: vi.fn(),
     update: vi.fn(),
   },
+  CURRENCIES: [
+    { label: "Real (R$)", value: "BRL" },
+    { label: "Dólar ($)", value: "USD" },
+  ],
 }));
 
 vi.mock("../../../services/api/photographer.service", () => ({
@@ -106,5 +110,54 @@ describe("PersonDetailsPage", () => {
     expect(screen.getByText("Vitórias:")).toBeInTheDocument();
     expect(screen.getByText("Best in Show 2026")).toBeInTheDocument();
     expect(screen.getByText("Nacional Canina")).toBeInTheDocument();
+  });
+
+  it("renders photos with custom USD currency and unpaid status correctly", async () => {
+    vi.mocked(clientService.list).mockResolvedValue({
+      data: [
+        {
+          id: "client-1",
+          person_id: "p123",
+          season_id: "s1",
+          dogs: [
+            {
+              breed: "Beagle",
+              is_owner: true,
+              competitions_won: 0,
+              photos: [
+                {
+                  file_number: "DSC_0001",
+                  photographer_id: "ph1",
+                  payment_method: "Cartão de Crédito",
+                  currency: "USD",
+                  amount_paid: 25.5,
+                },
+                {
+                  file_number: "DSC_0002",
+                  photographer_id: "ph1",
+                  payment_method: "Não pago",
+                  amount_paid: 0,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      total: 1,
+      page: 1,
+      limit: 10,
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/people/p123"]}>
+        <Routes>
+          <Route path="/people/:id" element={<PersonDetailsPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("Arquivo: DSC_0001")).toBeInTheDocument();
+    expect(screen.getByText("$ 25.50")).toBeInTheDocument();
+    expect(screen.getByText("Arquivo: DSC_0002")).toBeInTheDocument();
   });
 });

--- a/frontend/src/features/people/pages/PersonDetailsPage.tsx
+++ b/frontend/src/features/people/pages/PersonDetailsPage.tsx
@@ -50,6 +50,7 @@ import {
   SeasonClient,
   Dog,
   Photo,
+  CURRENCIES,
 } from "../../../services/api/client.service";
 import { personService, Person } from "../../../services/api/person.service";
 import {
@@ -124,12 +125,14 @@ export const PersonDetailsPage = () => {
     fileNumbersText: string;
     photographer_id: string;
     payment_method: string;
+    currency: string;
     amount_paid: number;
     judges: string[];
   }>({
     fileNumbersText: "",
     photographer_id: "",
     payment_method: "Pix",
+    currency: "BRL",
     amount_paid: 0,
     judges: [],
   });
@@ -137,6 +140,7 @@ export const PersonDetailsPage = () => {
     file_number: "",
     photographer_id: "",
     payment_method: "Pix",
+    currency: "BRL",
     amount_paid: 0,
     judges: [],
   });
@@ -150,6 +154,7 @@ export const PersonDetailsPage = () => {
     file_number: "",
     photographer_id: "",
     payment_method: "Pix",
+    currency: "BRL",
     amount_paid: 0,
     judges: [],
   });
@@ -380,6 +385,7 @@ export const PersonDetailsPage = () => {
       fileNumbersText: "",
       photographer_id: defaultPhotog,
       payment_method: "Pix",
+      currency: "BRL",
       amount_paid: 0,
       judges: [],
     });
@@ -387,6 +393,7 @@ export const PersonDetailsPage = () => {
       file_number: "",
       photographer_id: defaultPhotog,
       payment_method: "Pix",
+      currency: "BRL",
       amount_paid: 0,
       judges: [],
     });
@@ -415,11 +422,15 @@ export const PersonDetailsPage = () => {
         return;
       }
 
+      const isUnpaid = batchPhotoForm.payment_method === "Não pago";
       const newPhotos: Photo[] = numbers.map((num) => ({
         file_number: num,
         photographer_id: batchPhotoForm.photographer_id,
         payment_method: batchPhotoForm.payment_method,
-        amount_paid: Number(batchPhotoForm.amount_paid) || 0,
+        currency: isUnpaid ? undefined : batchPhotoForm.currency || "BRL",
+        amount_paid: isUnpaid
+          ? 0
+          : Math.max(0, Number(batchPhotoForm.amount_paid) || 0),
         judges:
           batchPhotoForm.judges && batchPhotoForm.judges.length > 0
             ? batchPhotoForm.judges
@@ -433,11 +444,15 @@ export const PersonDetailsPage = () => {
         return;
       }
 
+      const isUnpaid = singlePhotoForm.payment_method === "Não pago";
       currentPhotos.unshift({
         file_number: singlePhotoForm.file_number.trim(),
         photographer_id: singlePhotoForm.photographer_id,
         payment_method: singlePhotoForm.payment_method,
-        amount_paid: Number(singlePhotoForm.amount_paid) || 0,
+        currency: isUnpaid ? undefined : singlePhotoForm.currency || "BRL",
+        amount_paid: isUnpaid
+          ? 0
+          : Math.max(0, Number(singlePhotoForm.amount_paid) || 0),
         judges:
           singlePhotoForm.judges && singlePhotoForm.judges.length > 0
             ? singlePhotoForm.judges
@@ -461,6 +476,7 @@ export const PersonDetailsPage = () => {
       file_number: photo.file_number || "",
       photographer_id: photo.photographer_id || "",
       payment_method: photo.payment_method || "Pix",
+      currency: photo.currency || "BRL",
       amount_paid: photo.amount_paid || 0,
       judges: photo.judges || [],
     });
@@ -478,13 +494,17 @@ export const PersonDetailsPage = () => {
     const currentDog = { ...newDogs[selectedDogIndex] };
     const currentPhotos = [...(currentDog.photos || [])];
     const existingPhoto = currentPhotos[editingPhotoIndex];
+    const isUnpaid = editPhotoForm.payment_method === "Não pago";
 
     currentPhotos[editingPhotoIndex] = {
       ...existingPhoto,
       file_number: editPhotoForm.file_number.trim(),
       photographer_id: editPhotoForm.photographer_id,
       payment_method: editPhotoForm.payment_method,
-      amount_paid: Number(editPhotoForm.amount_paid) || 0,
+      currency: isUnpaid ? undefined : editPhotoForm.currency || "BRL",
+      amount_paid: isUnpaid
+        ? 0
+        : Math.max(0, Number(editPhotoForm.amount_paid) || 0),
       judges:
         editPhotoForm.judges && editPhotoForm.judges.length > 0
           ? editPhotoForm.judges
@@ -1248,9 +1268,11 @@ export const PersonDetailsPage = () => {
                               variant="subtitle2"
                               sx={{ fontWeight: 700, color: "text.primary" }}
                             >
-                              {photo.amount_paid !== undefined
-                                ? `R$ ${Number(photo.amount_paid).toFixed(2)}`
-                                : "R$ 0.00"}
+                              {photo.payment_method === "Não pago"
+                                ? "Não pago"
+                                : photo.amount_paid !== undefined
+                                  ? `${photo.currency === "USD" ? "$" : "R$"} ${Number(photo.amount_paid).toFixed(2)}`
+                                  : `${photo.currency === "USD" ? "$" : "R$"} 0.00`}
                             </Typography>
                           </Box>
 
@@ -1600,18 +1622,28 @@ export const PersonDetailsPage = () => {
                 )}
               />
               <Grid container spacing={2}>
-                <Grid size={{ xs: 12, sm: 6 }}>
+                <Grid
+                  size={{
+                    xs: 12,
+                    sm: batchPhotoForm.payment_method === "Não pago" ? 12 : 4,
+                  }}
+                >
                   <FormControl fullWidth size="small">
                     <InputLabel>Forma de Pagamento</InputLabel>
                     <Select
                       value={batchPhotoForm.payment_method}
                       label="Forma de Pagamento"
-                      onChange={(e) =>
+                      onChange={(e) => {
+                        const newMethod = e.target.value;
                         setBatchPhotoForm({
                           ...batchPhotoForm,
-                          payment_method: e.target.value,
-                        })
-                      }
+                          payment_method: newMethod,
+                          amount_paid:
+                            newMethod === "Não pago"
+                              ? 0
+                              : batchPhotoForm.amount_paid,
+                        });
+                      }}
                     >
                       {PAYMENT_METHODS.map((m) => (
                         <MenuItem key={m} value={m}>
@@ -1621,24 +1653,50 @@ export const PersonDetailsPage = () => {
                     </Select>
                   </FormControl>
                 </Grid>
-                <Grid size={{ xs: 12, sm: 6 }}>
-                  <TextField
-                    label="Valor por Foto (R$)"
-                    type="number"
-                    size="small"
-                    fullWidth
-                    value={batchPhotoForm.amount_paid}
-                    onChange={(e) =>
-                      setBatchPhotoForm({
-                        ...batchPhotoForm,
-                        amount_paid: Math.max(
-                          0,
-                          parseFloat(e.target.value) || 0,
-                        ),
-                      })
-                    }
-                  />
-                </Grid>
+                {batchPhotoForm.payment_method !== "Não pago" && (
+                  <>
+                    <Grid size={{ xs: 12, sm: 4 }}>
+                      <FormControl fullWidth size="small">
+                        <InputLabel>Moeda</InputLabel>
+                        <Select
+                          value={batchPhotoForm.currency || "BRL"}
+                          label="Moeda"
+                          onChange={(e) =>
+                            setBatchPhotoForm({
+                              ...batchPhotoForm,
+                              currency: e.target.value,
+                            })
+                          }
+                        >
+                          {CURRENCIES.map((c) => (
+                            <MenuItem key={c.value} value={c.value}>
+                              {c.label}
+                            </MenuItem>
+                          ))}
+                        </Select>
+                      </FormControl>
+                    </Grid>
+                    <Grid size={{ xs: 12, sm: 4 }}>
+                      <TextField
+                        label="Valor por Foto"
+                        type="number"
+                        size="small"
+                        fullWidth
+                        slotProps={{ htmlInput: { min: 0, step: "0.01" } }}
+                        value={batchPhotoForm.amount_paid}
+                        onChange={(e) =>
+                          setBatchPhotoForm({
+                            ...batchPhotoForm,
+                            amount_paid: Math.max(
+                              0,
+                              parseFloat(e.target.value) || 0,
+                            ),
+                          })
+                        }
+                      />
+                    </Grid>
+                  </>
+                )}
               </Grid>
             </>
           ) : (
@@ -1710,18 +1768,28 @@ export const PersonDetailsPage = () => {
                 )}
               />
               <Grid container spacing={2}>
-                <Grid size={{ xs: 12, sm: 6 }}>
+                <Grid
+                  size={{
+                    xs: 12,
+                    sm: singlePhotoForm.payment_method === "Não pago" ? 12 : 4,
+                  }}
+                >
                   <FormControl fullWidth size="small">
                     <InputLabel>Forma de Pagamento</InputLabel>
                     <Select
                       value={singlePhotoForm.payment_method}
                       label="Forma de Pagamento"
-                      onChange={(e) =>
+                      onChange={(e) => {
+                        const newMethod = e.target.value;
                         setSinglePhotoForm({
                           ...singlePhotoForm,
-                          payment_method: e.target.value,
-                        })
-                      }
+                          payment_method: newMethod,
+                          amount_paid:
+                            newMethod === "Não pago"
+                              ? 0
+                              : singlePhotoForm.amount_paid,
+                        });
+                      }}
                     >
                       {PAYMENT_METHODS.map((m) => (
                         <MenuItem key={m} value={m}>
@@ -1731,24 +1799,50 @@ export const PersonDetailsPage = () => {
                     </Select>
                   </FormControl>
                 </Grid>
-                <Grid size={{ xs: 12, sm: 6 }}>
-                  <TextField
-                    label="Valor Pago (R$)"
-                    type="number"
-                    size="small"
-                    fullWidth
-                    value={singlePhotoForm.amount_paid}
-                    onChange={(e) =>
-                      setSinglePhotoForm({
-                        ...singlePhotoForm,
-                        amount_paid: Math.max(
-                          0,
-                          parseFloat(e.target.value) || 0,
-                        ),
-                      })
-                    }
-                  />
-                </Grid>
+                {singlePhotoForm.payment_method !== "Não pago" && (
+                  <>
+                    <Grid size={{ xs: 12, sm: 4 }}>
+                      <FormControl fullWidth size="small">
+                        <InputLabel>Moeda</InputLabel>
+                        <Select
+                          value={singlePhotoForm.currency || "BRL"}
+                          label="Moeda"
+                          onChange={(e) =>
+                            setSinglePhotoForm({
+                              ...singlePhotoForm,
+                              currency: e.target.value,
+                            })
+                          }
+                        >
+                          {CURRENCIES.map((c) => (
+                            <MenuItem key={c.value} value={c.value}>
+                              {c.label}
+                            </MenuItem>
+                          ))}
+                        </Select>
+                      </FormControl>
+                    </Grid>
+                    <Grid size={{ xs: 12, sm: 4 }}>
+                      <TextField
+                        label="Valor Pago"
+                        type="number"
+                        size="small"
+                        fullWidth
+                        slotProps={{ htmlInput: { min: 0, step: "0.01" } }}
+                        value={singlePhotoForm.amount_paid}
+                        onChange={(e) =>
+                          setSinglePhotoForm({
+                            ...singlePhotoForm,
+                            amount_paid: Math.max(
+                              0,
+                              parseFloat(e.target.value) || 0,
+                            ),
+                          })
+                        }
+                      />
+                    </Grid>
+                  </>
+                )}
               </Grid>
             </>
           )}
@@ -1847,18 +1941,28 @@ export const PersonDetailsPage = () => {
             )}
           />
           <Grid container spacing={2}>
-            <Grid size={{ xs: 12, sm: 6 }}>
+            <Grid
+              size={{
+                xs: 12,
+                sm: editPhotoForm.payment_method === "Não pago" ? 12 : 4,
+              }}
+            >
               <FormControl fullWidth size="small">
                 <InputLabel>Forma de Pagamento</InputLabel>
                 <Select
                   value={editPhotoForm.payment_method}
                   label="Forma de Pagamento"
-                  onChange={(e) =>
+                  onChange={(e) => {
+                    const newMethod = e.target.value;
                     setEditPhotoForm({
                       ...editPhotoForm,
-                      payment_method: e.target.value,
-                    })
-                  }
+                      payment_method: newMethod,
+                      amount_paid:
+                        newMethod === "Não pago"
+                          ? 0
+                          : editPhotoForm.amount_paid,
+                    });
+                  }}
                 >
                   {PAYMENT_METHODS.map((m) => (
                     <MenuItem key={m} value={m}>
@@ -1868,21 +1972,50 @@ export const PersonDetailsPage = () => {
                 </Select>
               </FormControl>
             </Grid>
-            <Grid size={{ xs: 12, sm: 6 }}>
-              <TextField
-                label="Valor Pago (R$)"
-                type="number"
-                size="small"
-                fullWidth
-                value={editPhotoForm.amount_paid}
-                onChange={(e) =>
-                  setEditPhotoForm({
-                    ...editPhotoForm,
-                    amount_paid: Math.max(0, parseFloat(e.target.value) || 0),
-                  })
-                }
-              />
-            </Grid>
+            {editPhotoForm.payment_method !== "Não pago" && (
+              <>
+                <Grid size={{ xs: 12, sm: 4 }}>
+                  <FormControl fullWidth size="small">
+                    <InputLabel>Moeda</InputLabel>
+                    <Select
+                      value={editPhotoForm.currency || "BRL"}
+                      label="Moeda"
+                      onChange={(e) =>
+                        setEditPhotoForm({
+                          ...editPhotoForm,
+                          currency: e.target.value,
+                        })
+                      }
+                    >
+                      {CURRENCIES.map((c) => (
+                        <MenuItem key={c.value} value={c.value}>
+                          {c.label}
+                        </MenuItem>
+                      ))}
+                    </Select>
+                  </FormControl>
+                </Grid>
+                <Grid size={{ xs: 12, sm: 4 }}>
+                  <TextField
+                    label="Valor Pago"
+                    type="number"
+                    size="small"
+                    fullWidth
+                    slotProps={{ htmlInput: { min: 0, step: "0.01" } }}
+                    value={editPhotoForm.amount_paid}
+                    onChange={(e) =>
+                      setEditPhotoForm({
+                        ...editPhotoForm,
+                        amount_paid: Math.max(
+                          0,
+                          parseFloat(e.target.value) || 0,
+                        ),
+                      })
+                    }
+                  />
+                </Grid>
+              </>
+            )}
           </Grid>
         </DialogContent>
         <DialogActions sx={{ p: 2.5 }}>

--- a/frontend/src/services/api/client.service.ts
+++ b/frontend/src/services/api/client.service.ts
@@ -1,9 +1,15 @@
 import { apiClient } from "./client";
 
+export const CURRENCIES = [
+  { label: "Real (R$)", value: "BRL" },
+  { label: "Dólar ($)", value: "USD" },
+];
+
 export interface Photo {
   file_number: string;
   photographer_id: string;
   payment_method: string;
+  currency?: "BRL" | "USD" | string;
   amount_paid?: number;
   judges?: string[];
   created_at?: string;


### PR DESCRIPTION
### 📌 Resumo das Alterações

Implementação da funcionalidade de seleção de moeda (Real/Dólar), condicionalidade nos campos de pagamento de fotos e proteção rigorosa contra valores negativos no frontend e backend, atendendo a todos os requisitos da issue #50.

#### 🔧 Backend:
- **Domínio**: Adicionado campo `Currency string` na struct `Photo` (`backend/internal/domain/client/client.go`).
- **Casos de Uso**: Implementada validação de `amount_paid >= 0` (retornando `ErrInvalidAmountPaid` -> 400 Bad Request), preenchimento automático de default `"BRL"` para fotos com pagamento e normalização de fotos com `"Não pago"` (anulando `amount_paid`).
- **Testes Unitários**: Criada suíte `TestClientService_PhotoCurrencyAndAmountValidation` em `service_test.go`.
- **OpenAPI/Swagger**: Regenerada documentação Swagger com o novo campo `currency`.

#### 🎨 Frontend:
- **Serviços & Tipos**: Atualizada interface `Photo` e exportada constante `CURRENCIES = [{ label: "Real (R$)", value: "BRL" }, { label: "Dólar ($)", value: "USD" }]` em `client.service.ts`.
- **Modais e Telas**:
  - `LinkClientModal.tsx`: Seletor de moeda, condicionalidade para ocultar moeda/valor quando `"Não pago"` e proteção no input contra valores negativos.
  - `ClientDetailsModal.tsx`: Padronização da condicionalidade e seleção de moeda na edição de fotos do cliente.
  - `ClientDetailsPage.tsx`: Condicionalidade e seleção de moeda na visualização completa de detalhes do cliente.
  - `ClientsPage.tsx`: Condicionalidade e seleção de moeda no modal de cadastro rápido na listagem.
  - `PersonDetailsPage.tsx`: Atualizados modais em lote, individual e de edição, bem como o card de foto formatando o valor com a moeda correspondente (`$` ou `R$`).
- **Testes**: Atualizado `PersonDetailsPage.test.tsx` com mocks e testes para moedas e status de pagamento.

---

### 🧪 Checklist de Validação
- [x] `./scripts/swagger.sh` executado com sucesso
- [x] `./scripts/check.sh all` executado com 100% de aprovação (Backend, Frontend e Terraform)
- [x] Commits semânticos e rebase com a `main`

Closes #50
