### PR TITLE
feat(i18n): exibir bandeiras do brasil e eua no seletor de idiomas

### DIFF
--- a/frontend/src/components/LanguageSelector.test.tsx
+++ b/frontend/src/components/LanguageSelector.test.tsx
@@ -9,12 +9,13 @@ describe("LanguageSelector", () => {
     i18n.changeLanguage("pt-BR");
   });
 
-  it("renders with default variant showing current language label", () => {
+  it("renders with default variant showing current language label and Brazil flag", () => {
     render(<LanguageSelector />);
 
     const combobox = screen.getByRole("combobox");
     expect(combobox).toBeInTheDocument();
     expect(screen.getByText("PT-BR")).toBeInTheDocument();
+    expect(screen.getByTestId("brazil-flag")).toBeInTheDocument();
   });
 
   it("renders with auth variant", () => {
@@ -23,9 +24,10 @@ describe("LanguageSelector", () => {
     const combobox = screen.getByRole("combobox");
     expect(combobox).toBeInTheDocument();
     expect(screen.getByText("PT-BR")).toBeInTheDocument();
+    expect(screen.getByTestId("brazil-flag")).toBeInTheDocument();
   });
 
-  it("changes language to en-US on selection and persists to localStorage", () => {
+  it("changes language to en-US on selection and persists to localStorage with USA flag", () => {
     render(<LanguageSelector />);
 
     const combobox = screen.getByRole("combobox");
@@ -33,6 +35,8 @@ describe("LanguageSelector", () => {
 
     const enOption = screen.getByRole("option", { name: /EN-US/i });
     expect(enOption).toBeInTheDocument();
+    expect(screen.getByTestId("usa-flag")).toBeInTheDocument();
+
     fireEvent.click(enOption);
 
     expect(localStorage.getItem("ps_language")).toBe("en-US");

--- a/frontend/src/components/LanguageSelector.tsx
+++ b/frontend/src/components/LanguageSelector.tsx
@@ -1,3 +1,4 @@
+import { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import {
   Box,
@@ -6,16 +7,23 @@ import {
   SelectChangeEvent,
   Tooltip,
 } from "@mui/material";
-import LanguageIcon from "@mui/icons-material/Language";
+import { BrazilFlag } from "./flags/BrazilFlag";
+import { USAFlag } from "./flags/USAFlag";
 
 interface LanguageSelectorProps {
   /** "default" = outlined Select (Topbar); "auth" = compact for auth pages */
   variant?: "default" | "auth";
 }
 
-const LANGUAGES = [
-  { code: "pt-BR", label: "PT-BR" },
-  { code: "en-US", label: "EN-US" },
+interface LanguageOption {
+  code: "pt-BR" | "en-US";
+  label: string;
+  flag: ReactNode;
+}
+
+const LANGUAGES: readonly LanguageOption[] = [
+  { code: "pt-BR", label: "PT-BR", flag: <BrazilFlag /> },
+  { code: "en-US", label: "EN-US", flag: <USAFlag /> },
 ] as const;
 
 export function LanguageSelector({
@@ -27,29 +35,32 @@ export function LanguageSelector({
     i18n.changeLanguage(event.target.value);
   };
 
+  const currentLanguageCode =
+    i18n.language in { "pt-BR": 1, "en-US": 1 } ? i18n.language : "pt-BR";
+
   return (
     <Tooltip title={t("language.select")}>
       <Box sx={{ display: "flex", alignItems: "center" }}>
         <Select
-          value={
-            i18n.language in { "pt-BR": 1, "en-US": 1 }
-              ? i18n.language
-              : "pt-BR"
-          }
+          value={currentLanguageCode}
           onChange={handleChange}
           size="small"
           variant="outlined"
           inputProps={{ "aria-label": t("language.select") }}
-          renderValue={(val) => (
-            <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
-              <LanguageIcon sx={{ fontSize: 16 }} />
-              <span>{LANGUAGES.find((l) => l.code === val)?.label ?? val}</span>
-            </Box>
-          )}
+          renderValue={(val) => {
+            const selected =
+              LANGUAGES.find((l) => l.code === val) ?? LANGUAGES[0];
+            return (
+              <Box sx={{ display: "flex", alignItems: "center", gap: 0.75 }}>
+                {selected.flag}
+                <span>{selected.label}</span>
+              </Box>
+            );
+          }}
           sx={{
             fontSize: "0.8rem",
             fontWeight: 600,
-            minWidth: variant === "auth" ? 90 : 100,
+            minWidth: variant === "auth" ? 100 : 110,
             "& .MuiOutlinedInput-notchedOutline": {
               borderColor: "divider",
             },
@@ -66,9 +77,15 @@ export function LanguageSelector({
             <MenuItem
               key={lang.code}
               value={lang.code}
-              sx={{ fontSize: "0.875rem" }}
+              sx={{
+                fontSize: "0.875rem",
+                display: "flex",
+                alignItems: "center",
+                gap: 1,
+              }}
             >
-              {lang.label}
+              {lang.flag}
+              <span>{lang.label}</span>
             </MenuItem>
           ))}
         </Select>

--- a/frontend/src/components/flags/BrazilFlag.tsx
+++ b/frontend/src/components/flags/BrazilFlag.tsx
@@ -1,0 +1,32 @@
+import { Box, BoxProps } from "@mui/material";
+
+export function BrazilFlag({ sx, ...props }: BoxProps<"svg">) {
+  return (
+    <Box
+      component="svg"
+      viewBox="0 0 640 480"
+      aria-hidden="true"
+      data-testid="brazil-flag"
+      sx={{
+        width: 18,
+        height: 13,
+        borderRadius: "2px",
+        display: "inline-block",
+        flexShrink: 0,
+        boxShadow: "0 0 0 1px rgba(0,0,0,0.12)",
+        overflow: "hidden",
+        verticalAlign: "middle",
+        ...sx,
+      }}
+      {...props}
+    >
+      <path fill="#009b3a" d="M0 0h640v480H0z" />
+      <path fill="#fedf00" d="M640 240L320 448 0 240 320 32l320 208z" />
+      <circle cx="320" cy="240" r="105" fill="#002776" />
+      <path
+        fill="#fff"
+        d="M228 274a105 105 0 0 0 185-70 106 106 0 0 1-185 70z"
+      />
+    </Box>
+  );
+}

--- a/frontend/src/components/flags/USAFlag.tsx
+++ b/frontend/src/components/flags/USAFlag.tsx
@@ -1,0 +1,103 @@
+import { Box, BoxProps } from "@mui/material";
+
+export function USAFlag({ sx, ...props }: BoxProps<"svg">) {
+  return (
+    <Box
+      component="svg"
+      viewBox="0 0 640 480"
+      aria-hidden="true"
+      data-testid="usa-flag"
+      sx={{
+        width: 18,
+        height: 13,
+        borderRadius: "2px",
+        display: "inline-block",
+        flexShrink: 0,
+        boxShadow: "0 0 0 1px rgba(0,0,0,0.12)",
+        overflow: "hidden",
+        verticalAlign: "middle",
+        ...sx,
+      }}
+      {...props}
+    >
+      {/* 13 red and white stripes */}
+      <path fill="#bd3d44" d="M0 0h640v480H0z" />
+      <path
+        stroke="#fff"
+        strokeWidth="36.92"
+        d="M0 55.38h640M0 129.23h640M0 203.08h640M0 276.92h640M0 350.77h640M0 424.62h640"
+      />
+      {/* Blue canton */}
+      <path fill="#192f5d" d="M0 0h256v258.5H0z" />
+      {/* 50 Stars Grid */}
+      <g fill="#fff">
+        {[
+          // Row 1 (6 stars)
+          [21.3, 26],
+          [64, 26],
+          [106.7, 26],
+          [149.3, 26],
+          [192, 26],
+          [234.7, 26],
+          // Row 2 (5 stars)
+          [42.7, 52],
+          [85.3, 52],
+          [128, 52],
+          [170.7, 52],
+          [213.3, 52],
+          // Row 3 (6 stars)
+          [21.3, 78],
+          [64, 78],
+          [106.7, 78],
+          [149.3, 78],
+          [192, 78],
+          [234.7, 78],
+          // Row 4 (5 stars)
+          [42.7, 104],
+          [85.3, 104],
+          [128, 104],
+          [170.7, 104],
+          [213.3, 104],
+          // Row 5 (6 stars)
+          [21.3, 130],
+          [64, 130],
+          [106.7, 130],
+          [149.3, 130],
+          [192, 130],
+          [234.7, 130],
+          // Row 6 (5 stars)
+          [42.7, 156],
+          [85.3, 156],
+          [128, 156],
+          [170.7, 156],
+          [213.3, 156],
+          // Row 7 (6 stars)
+          [21.3, 182],
+          [64, 182],
+          [106.7, 182],
+          [149.3, 182],
+          [192, 182],
+          [234.7, 182],
+          // Row 8 (5 stars)
+          [42.7, 208],
+          [85.3, 208],
+          [128, 208],
+          [170.7, 208],
+          [213.3, 208],
+          // Row 9 (6 stars)
+          [21.3, 234],
+          [64, 234],
+          [106.7, 234],
+          [149.3, 234],
+          [192, 234],
+          [234.7, 234],
+        ].map(([cx, cy], idx) => (
+          <polygon
+            key={idx}
+            points={`${cx},${cy - 8} ${cx + 2.4},${cy - 2.5} ${cx + 8},${cy - 2.5} ${cx + 3.6},${cy + 1.2} ${cx + 5.2},${cy + 7} ${cx},${cy + 3.2} ${cx - 5.2},${cy + 7} ${cx - 3.6},${cy + 1.2} ${cx - 8},${cy - 2.5} ${cx - 2.4},${cy - 2.5}`}
+          />
+        ))}
+      </g>
+    </Box>
+  );
+}


### PR DESCRIPTION
### 🇧🇷 🇺🇸 Resumo das Alterações

Adiciona a exibição de bandeiras dos respectivos países ao seletor de idiomas (`LanguageSelector`):
- **PT-BR**: Bandeira do Brasil 🇧🇷 (vetorial SVG de alta fidelidade).
- **EN-US**: Bandeira dos Estados Unidos 🇺🇸 (vetorial SVG de alta fidelidade).

#### Detalhes Técnicos:
1. **Componentes SVG Vetoriais**:
   - `BrazilFlag.tsx`: Implementação SVG do pavilhão nacional brasileiro com cores e proporções oficiais.
   - `USAFlag.tsx`: Implementação SVG da bandeira americana com 13 faixas e 50 estrelas.
2. **Atualização do `LanguageSelector`**:
   - Exibição da bandeira ativa diretamente no botão de seleção (`renderValue`).
   - Exibição de cada bandeira ao lado de seu respectivo rótulo dentro das opções do menu (`MenuItem`).
3. **Testes Unitários**:
   - Testes atualizados em `LanguageSelector.test.tsx` garantindo a renderização e alternância das bandeiras.

---

### Checklist de Validação
- [x] `./scripts/check.sh frontend` aprovado com 100% de sucesso.
- [x] `./scripts/check.sh all` aprovado (Backend, Frontend e Terraform).
