### PR TITLE
fix(reports): formatar moedas nos relatorios e separar receita em dolar e real

### DIFF
--- a/backend/internal/application/usecase/report/service.go
+++ b/backend/internal/application/usecase/report/service.go
@@ -110,6 +110,18 @@ func NormalizePaymentMethod(method string) string {
 	}
 }
 
+// FormatPaidAmount formats the amount paid with the proper currency symbol ($ for USD, R$ for BRL / default)
+func FormatPaidAmount(amount *float64, currency string) string {
+	if amount == nil {
+		return ""
+	}
+	symbol := "R$"
+	if strings.ToUpper(strings.TrimSpace(currency)) == "USD" {
+		symbol = "$"
+	}
+	return fmt.Sprintf("%s %.2f", symbol, *amount)
+}
+
 // SanitizeCSVField prevents CSV Formula Injection (CWE-1236)
 func SanitizeCSVField(val string) string {
 	if len(val) == 0 {
@@ -303,9 +315,7 @@ func (s *Service) GenerateClientsCSV(ctx context.Context, tenantID, seasonID, us
 						photographerName = photo.PhotographerID
 					}
 					paymentMethod = NormalizePaymentMethod(photo.PaymentMethod)
-					if photo.AmountPaid != nil {
-						amountPaid = fmt.Sprintf("%.2f", *photo.AmountPaid)
-					}
+					amountPaid = FormatPaidAmount(photo.AmountPaid, photo.Currency)
 					photoDate = formatPhotoDate(&photo, c.CreatedAt)
 					if i < numPhotos {
 						judgeStr = formatJudges(&photo)
@@ -466,10 +476,7 @@ func (s *Service) GenerateUnpaidClientsCSV(ctx context.Context, tenantID, season
 					paymentStatus = "Não pago"
 				}
 
-				var amount string
-				if photo.AmountPaid != nil {
-					amount = fmt.Sprintf("%.2f", *photo.AmountPaid)
-				}
+				amount := FormatPaidAmount(photo.AmountPaid, photo.Currency)
 
 				judgeStr := formatJudges(&photo)
 
@@ -619,11 +626,7 @@ func (s *Service) GeneratePaidClientsCSV(ctx context.Context, tenantID, seasonID
 					photographerName = photo.PhotographerID
 				}
 
-				var amountPaid string
-				if photo.AmountPaid != nil {
-					amountPaid = fmt.Sprintf("%.2f", *photo.AmountPaid)
-				}
-
+				amountPaid := FormatPaidAmount(photo.AmountPaid, photo.Currency)
 				photoDate := formatPhotoDate(&photo, c.CreatedAt)
 				judgeStr := formatJudges(&photo)
 
@@ -932,9 +935,7 @@ func (s *Service) buildClientsPDF(ctx context.Context, tenantID, seasonID string
 						photo := dog.Photos[rIdx]
 						colFile = photo.FileNumber
 						colPayment = NormalizePaymentMethod(photo.PaymentMethod)
-						if photo.AmountPaid != nil {
-							colAmount = fmt.Sprintf("R$ %.2f", *photo.AmountPaid)
-						}
+						colAmount = FormatPaidAmount(photo.AmountPaid, photo.Currency)
 						colDate = formatPhotoDate(&photo, client.CreatedAt)
 						colJudge = formatJudgesPDF(&photo)
 					}

--- a/backend/internal/application/usecase/report/service_test.go
+++ b/backend/internal/application/usecase/report/service_test.go
@@ -197,6 +197,7 @@ func TestGenerateClientsCSV_FullExpansionAndRules(t *testing.T) {
 								FileNumber:     "IMG_002",
 								PhotographerID: "photog-2",
 								PaymentMethod:  "Credit Card",
+								Currency:       "USD",
 								AmountPaid:     &amount200,
 								Judges:         []string{"Juiz Silva"},
 							},
@@ -319,11 +320,11 @@ func TestGenerateClientsCSV_FullExpansionAndRules(t *testing.T) {
 	// Check dog-1 rows (2 rows)
 	// Headers: Nome[0], Email[1], AltEmail[2], Phone[3], Dono[4], Raca[5], Juiz[6], Comp[7], Arquivo[8], Fotografo[9], Pagamento[10], Valor[11], Data[12]
 	row1 := records[1]
-	if row1[0] != "Maria Souza" || row1[3] != "(11) 99999-8888" || row1[4] != "Sim" || row1[5] != "Border Collie" || row1[6] != "Juiz Silva" || row1[7] != "Melhor da Raça" || row1[8] != "IMG_001" || row1[9] != "Fotógrafo Alpha" || row1[10] != "Pix" || row1[11] != "100.50" {
+	if row1[0] != "Maria Souza" || row1[3] != "(11) 99999-8888" || row1[4] != "Sim" || row1[5] != "Border Collie" || row1[6] != "Juiz Silva" || row1[7] != "Melhor da Raça" || row1[8] != "IMG_001" || row1[9] != "Fotógrafo Alpha" || row1[10] != "Pix" || row1[11] != "R$ 100.50" {
 		t.Fatalf("row 1 mismatch: %v", row1)
 	}
 	row2 := records[2]
-	if row2[3] != "(11) 99999-8888" || row2[7] != "Campeão Adulto" || row2[8] != "IMG_002" || row2[9] != "Fotógrafo Beta" || row2[10] != "Cartão de Crédito" || row2[11] != "200.00" {
+	if row2[3] != "(11) 99999-8888" || row2[7] != "Campeão Adulto" || row2[8] != "IMG_002" || row2[9] != "Fotógrafo Beta" || row2[10] != "Cartão de Crédito" || row2[11] != "$ 200.00" {
 		t.Fatalf("row 2 mismatch: %v", row2)
 	}
 
@@ -512,6 +513,32 @@ func TestNormalizePaymentMethod(t *testing.T) {
 	}
 }
 
+func TestFormatPaidAmount(t *testing.T) {
+	val100 := 100.50
+	valZero := 0.0
+	cases := []struct {
+		amount   *float64
+		currency string
+		expected string
+	}{
+		{nil, "BRL", ""},
+		{nil, "USD", ""},
+		{&val100, "USD", "$ 100.50"},
+		{&val100, "usd", "$ 100.50"},
+		{&val100, "BRL", "R$ 100.50"},
+		{&val100, "", "R$ 100.50"},
+		{&valZero, "USD", "$ 0.00"},
+		{&valZero, "BRL", "R$ 0.00"},
+	}
+
+	for _, tc := range cases {
+		got := FormatPaidAmount(tc.amount, tc.currency)
+		if got != tc.expected {
+			t.Errorf("FormatPaidAmount(%v, %q) = %q, expected %q", tc.amount, tc.currency, got, tc.expected)
+		}
+	}
+}
+
 func TestGenerateUnpaidClientsCSV(t *testing.T) {
 	tenantID := "tenant-456"
 	amount50 := 50.0
@@ -673,7 +700,7 @@ func TestGenerateUnpaidClientsCSV(t *testing.T) {
 
 	// Row 1: client-1 photo 2
 	row1 := records[1]
-	if row1[0] != "Carlos Lima" || row1[3] != "(11) 98888-7777" || row1[4] != "Golden" || row1[5] != "Juiz A" || row1[6] != "'=CMD_INJECTION" || row1[7] != "Fotógrafo Beta" || row1[8] != "Não pago" || row1[9] != "150.00" {
+	if row1[0] != "Carlos Lima" || row1[3] != "(11) 98888-7777" || row1[4] != "Golden" || row1[5] != "Juiz A" || row1[6] != "'=CMD_INJECTION" || row1[7] != "Fotógrafo Beta" || row1[8] != "Não pago" || row1[9] != "R$ 150.00" {
 		t.Fatalf("row 1 mismatch: %v", row1)
 	}
 
@@ -864,6 +891,7 @@ func TestGeneratePaidClientsCSV(t *testing.T) {
 								FileNumber:     "IMG_101",
 								PhotographerID: "photog-2",
 								PaymentMethod:  "Cartão de Crédito",
+								Currency:       "USD",
 								AmountPaid:     &amount250,
 								Judges:         []string{"Juiz Santos", "Juiz Oliveira"},
 							},
@@ -992,19 +1020,19 @@ func TestGeneratePaidClientsCSV(t *testing.T) {
 
 	// Row 1 (IMG_100): Pix
 	row1 := records[1]
-	if row1[0] != "Carlos Albuquerque" || row1[3] != "(11) 98888-9999" || row1[4] != "Sim" || row1[5] != "Golden Retriever" || row1[6] != "Juiz Santos" || row1[7] != "Campeão Jovem, Melhor da Raça" || row1[8] != "IMG_100" || row1[9] != "Fotógrafo Principal" || row1[10] != "Pix" || row1[11] != "100.00" {
+	if row1[0] != "Carlos Albuquerque" || row1[3] != "(11) 98888-9999" || row1[4] != "Sim" || row1[5] != "Golden Retriever" || row1[6] != "Juiz Santos" || row1[7] != "Campeão Jovem, Melhor da Raça" || row1[8] != "IMG_100" || row1[9] != "Fotógrafo Principal" || row1[10] != "Pix" || row1[11] != "R$ 100.00" {
 		t.Fatalf("unexpected row 1: %v", row1)
 	}
 
-	// Row 2 (IMG_101): Cartão de Crédito
+	// Row 2 (IMG_101): Cartão de Crédito (USD)
 	row2 := records[2]
-	if row2[8] != "IMG_101" || row2[9] != "Fotógrafo Secundário" || row2[10] != "Cartão de Crédito" || row2[11] != "250.50" || row2[6] != "Juiz Santos, Juiz Oliveira" {
+	if row2[8] != "IMG_101" || row2[9] != "Fotógrafo Secundário" || row2[10] != "Cartão de Crédito" || row2[11] != "$ 250.50" || row2[6] != "Juiz Santos, Juiz Oliveira" {
 		t.Fatalf("unexpected row 2: %v", row2)
 	}
 
 	// Row 3 (Malicious formula sanitized): Dinheiro
 	row3 := records[3]
-	if row3[4] != "Não" || row3[5] != "Border Collie" || row3[7] != "Sim" || row3[8] != "'=MALICIOUS_CMD" || row3[10] != "Dinheiro" || row3[11] != "50.00" {
+	if row3[4] != "Não" || row3[5] != "Border Collie" || row3[7] != "Sim" || row3[8] != "'=MALICIOUS_CMD" || row3[10] != "Dinheiro" || row3[11] != "R$ 50.00" {
 		t.Fatalf("unexpected row 3: %v", row3)
 	}
 

--- a/frontend/src/features/dashboard/pages/DashboardPage.test.tsx
+++ b/frontend/src/features/dashboard/pages/DashboardPage.test.tsx
@@ -395,4 +395,72 @@ describe("DashboardPage", () => {
       screen.getByRole("button", { name: /Exibir Visão Geral/i }),
     ).toBeInTheDocument();
   });
+
+  it("renders revenue separated into BRL and USD without summing them", async () => {
+    useSeasonStore.setState({
+      activeSeason: { id: "season-1", name: "Temporada 2026" },
+    });
+
+    vi.spyOn(clientService, "list").mockResolvedValue({
+      data: [
+        {
+          id: "client-1",
+          person_id: "person-1",
+          season_id: "season-1",
+          dogs: [
+            {
+              breed: "Border Collie",
+              competitions_won: 0,
+              photos: [
+                {
+                  file_number: "DSC_001",
+                  photographer_id: "photog-1",
+                  payment_method: "Pix",
+                  currency: "BRL",
+                  amount_paid: 250,
+                },
+                {
+                  file_number: "DSC_002",
+                  photographer_id: "photog-1",
+                  payment_method: "Cartão de Crédito",
+                  currency: "USD",
+                  amount_paid: 75,
+                },
+                {
+                  file_number: "DSC_003",
+                  photographer_id: "photog-1",
+                  payment_method: "Não pago",
+                  amount_paid: 100,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      total: 1,
+      page: 1,
+      limit: 10,
+    });
+
+    vi.spyOn(personService, "list").mockResolvedValue([
+      {
+        id: "person-1",
+        name: "Carlos Ferreira",
+        email: "carlos@example.com",
+        alternative_email: "",
+        phone: "1199999999",
+      },
+    ]);
+
+    render(
+      <BrowserRouter>
+        <DashboardPage />
+      </BrowserRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("R$ 250.00")).toBeInTheDocument();
+      expect(screen.getByText("$ 75.00")).toBeInTheDocument();
+    });
+  });
 });

--- a/frontend/src/features/dashboard/pages/DashboardPage.tsx
+++ b/frontend/src/features/dashboard/pages/DashboardPage.tsx
@@ -352,7 +352,8 @@ export const DashboardPage = () => {
   const metrics = useMemo(() => {
     let totalDogs = 0;
     let totalPhotos = 0;
-    let totalRevenue = 0;
+    let totalRevenueBRL = 0;
+    let totalRevenueUSD = 0;
 
     allSeasonClients.forEach((c) => {
       const dogs = c.dogs || [];
@@ -361,7 +362,13 @@ export const DashboardPage = () => {
         const photos = d.photos || [];
         totalPhotos += photos.length;
         photos.forEach((p) => {
-          totalRevenue += p.amount_paid || 0;
+          if (p.payment_method !== "Não pago" && p.amount_paid) {
+            if (p.currency === "USD") {
+              totalRevenueUSD += p.amount_paid;
+            } else {
+              totalRevenueBRL += p.amount_paid;
+            }
+          }
         });
       });
     });
@@ -371,7 +378,8 @@ export const DashboardPage = () => {
       activeSeasonClients: allSeasonClients.length,
       totalDogs,
       totalPhotos,
-      totalRevenue,
+      totalRevenueBRL,
+      totalRevenueUSD,
     };
   }, [people.length, allSeasonClients]);
 
@@ -790,12 +798,35 @@ export const DashboardPage = () => {
                     >
                       {t("dashboard.kpi.totalRevenue")}
                     </Typography>
-                    <Typography
-                      variant="h4"
-                      sx={{ fontWeight: 800, mt: 0.5, color: "success.main" }}
+                    <Box
+                      sx={{
+                        mt: 0.5,
+                        display: "flex",
+                        flexDirection: "column",
+                        gap: 0.25,
+                      }}
                     >
-                      R$ {metrics.totalRevenue.toFixed(2)}
-                    </Typography>
+                      <Typography
+                        variant="h5"
+                        sx={{
+                          fontWeight: 800,
+                          color: "success.main",
+                          whiteSpace: "nowrap",
+                        }}
+                      >
+                        R$ {metrics.totalRevenueBRL.toFixed(2)}
+                      </Typography>
+                      <Typography
+                        variant="h6"
+                        sx={{
+                          fontWeight: 800,
+                          color: "success.main",
+                          whiteSpace: "nowrap",
+                        }}
+                      >
+                        $ {metrics.totalRevenueUSD.toFixed(2)}
+                      </Typography>
+                    </Box>
                     <Typography variant="caption" color="text.secondary">
                       {t("dashboard.kpiDescriptions.paidPhotos")}
                     </Typography>

--- a/frontend/src/features/people/pages/PersonDetailsPage.test.tsx
+++ b/frontend/src/features/people/pages/PersonDetailsPage.test.tsx
@@ -160,4 +160,55 @@ describe("PersonDetailsPage", () => {
     expect(screen.getByText("$ 25.50")).toBeInTheDocument();
     expect(screen.getByText("Arquivo: DSC_0002")).toBeInTheDocument();
   });
+
+  it("renders separate total collected chips for USD and BRL on a dog", async () => {
+    vi.mocked(clientService.list).mockResolvedValue({
+      data: [
+        {
+          id: "client-1",
+          person_id: "p123",
+          season_id: "s1",
+          dogs: [
+            {
+              breed: "Pug",
+              is_owner: true,
+              competitions_won: 0,
+              photos: [
+                {
+                  file_number: "DSC_1001",
+                  photographer_id: "ph1",
+                  payment_method: "Pix",
+                  currency: "BRL",
+                  amount_paid: 120,
+                },
+                {
+                  file_number: "DSC_1002",
+                  photographer_id: "ph1",
+                  payment_method: "Cartão de Crédito",
+                  currency: "USD",
+                  amount_paid: 40,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      total: 1,
+      page: 1,
+      limit: 10,
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/people/p123"]}>
+        <Routes>
+          <Route path="/people/:id" element={<PersonDetailsPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(
+      await screen.findByText("Total Arrecadado: R$ 120.00"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Total Arrecadado: $ 40.00")).toBeInTheDocument();
+  });
 });

--- a/frontend/src/features/people/pages/PersonDetailsPage.tsx
+++ b/frontend/src/features/people/pages/PersonDetailsPage.tsx
@@ -532,12 +532,24 @@ export const PersonDetailsPage = () => {
   }, [photographers]);
 
   const dogStats = useMemo(() => {
-    if (!selectedDog) return { totalPhotos: 0, totalPaid: 0 };
+    if (!selectedDog)
+      return { totalPhotos: 0, totalPaidBRL: 0, totalPaidUSD: 0 };
     const photos = selectedDog.photos || [];
-    const totalPaid = photos.reduce((sum, p) => sum + (p.amount_paid || 0), 0);
+    let totalPaidBRL = 0;
+    let totalPaidUSD = 0;
+    photos.forEach((p) => {
+      if (p.payment_method !== "Não pago" && p.amount_paid) {
+        if (p.currency === "USD") {
+          totalPaidUSD += p.amount_paid;
+        } else {
+          totalPaidBRL += p.amount_paid;
+        }
+      }
+    });
     return {
       totalPhotos: photos.length,
-      totalPaid,
+      totalPaidBRL,
+      totalPaidUSD,
     };
   }, [selectedDog]);
 
@@ -1068,17 +1080,44 @@ export const PersonDetailsPage = () => {
                     })}
                   </Typography>
                 </Box>
-                <Box sx={{ display: "flex", gap: 1 }}>
-                  <Chip
-                    icon={<AttachMoneyIcon />}
-                    label={t("personDetails.totalCollected", {
-                      currency: "R$",
-                      amount: dogStats.totalPaid.toFixed(2),
-                    })}
-                    color="success"
-                    variant="outlined"
-                    sx={{ fontWeight: 700 }}
-                  />
+                <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap" }}>
+                  {dogStats.totalPaidUSD > 0 && (
+                    <Chip
+                      icon={<AttachMoneyIcon />}
+                      label={t("personDetails.totalCollected", {
+                        currency: "$",
+                        amount: dogStats.totalPaidUSD.toFixed(2),
+                      })}
+                      color="success"
+                      variant="outlined"
+                      sx={{ fontWeight: 700 }}
+                    />
+                  )}
+                  {dogStats.totalPaidBRL > 0 && (
+                    <Chip
+                      icon={<AttachMoneyIcon />}
+                      label={t("personDetails.totalCollected", {
+                        currency: "R$",
+                        amount: dogStats.totalPaidBRL.toFixed(2),
+                      })}
+                      color="success"
+                      variant="outlined"
+                      sx={{ fontWeight: 700 }}
+                    />
+                  )}
+                  {dogStats.totalPaidBRL === 0 &&
+                    dogStats.totalPaidUSD === 0 && (
+                      <Chip
+                        icon={<AttachMoneyIcon />}
+                        label={t("personDetails.totalCollected", {
+                          currency: "R$",
+                          amount: "0.00",
+                        })}
+                        color="success"
+                        variant="outlined"
+                        sx={{ fontWeight: 700 }}
+                      />
+                    )}
                 </Box>
               </Box>
 


### PR DESCRIPTION
### Resumo das Alterações

1. **Formatação de Moeda em Relatórios (Backend Go)**:
   - Adicionada a função auxiliar `FormatPaidAmount(amount *float64, currency string) string` em `report.Service`.
   - Formatação consistente de valores pagos nos relatórios CSV (`GenerateClientsCSV`, `GeneratePaidClientsCSV`, `GenerateUnpaidClientsCSV`) e PDF (`buildClientsPDF`) com símbolo `$` para USD e `R$` para BRL (ou padrão).
   - Atualizados testes unitários em `service_test.go` para validar relatórios multi-moeda.

2. **Separação de Receita em Real e Dólar no Dashboard e Detalhes da Pessoa (Frontend React)**:
   - No `DashboardPage.tsx`, recalculada a agregação de receita para separar `totalRevenueBRL` e `totalRevenueUSD`, garantindo que Real e Dólar nunca sejam somados na mesma métrica.
   - Atualizado o card de Arrecadação Total no Dashboard para exibir ambas as moedas separadamente com tipografia legível e proteção contra quebra de linha.
   - Em `PersonDetailsPage.tsx`, separados os chips de arrecadação por cão em `R$` e `$`.
   - Adicionados testes automatizados cobrindo o comportamento multi-moeda em `DashboardPage.test.tsx` e `PersonDetailsPage.test.tsx`.

### Checklist de Validação
- [x] `./scripts/swagger.sh` executado com sucesso.
- [x] `./scripts/check.sh all` passou com 100% de sucesso (Backend Go vet/tests, Frontend TypeScript/lint/format/tests, Terraform fmt).