### PR TITLE
feat(mcp): add brave-devtools mcp server to ps-tools plugin

### DIFF
--- a/.agents/plugins/ps-tools/mcp_config.json
+++ b/.agents/plugins/ps-tools/mcp_config.json
@@ -13,6 +13,19 @@
         "-c",
         "export GITHUB_PERSONAL_ACCESS_TOKEN=\"$(gh auth token 2>/dev/null || echo \"$GITHUB_PERSONAL_ACCESS_TOKEN\")\" && npx -y @modelcontextprotocol/server-github"
       ]
+    },
+    "brave-devtools": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "brave-mcp@latest",
+        "--slim",
+        "--headless",
+        "--isolated"
+      ],
+      "env": {
+        "BRAVE_PATH": "/usr/bin/brave-origin"
+      }
     }
   }
 }


### PR DESCRIPTION
## 📌 Descrição

Adiciona a configuração do servidor MCP `brave-devtools` (`brave-mcp`) ao plugin de workspace `ps-tools` (`.agents/plugins/ps-tools/mcp_config.json`).

### Alterações Realizadas:
- Inclusão do servidor MCP `brave-devtools` apontando para o binário do Brave Browser local (`/usr/bin/brave-origin`) com flags `--slim`, `--headless` e `--isolated`.
- Teste prático de navegação e captura de telas de login em resoluções Mobile, Tablet e Desktop.

## 🚀 Validações Executadas
- [x] `./scripts/check.sh all` (Backend, Frontend e Terraform 100% aprovados)
