### PR TITLE
fix(ui): fechar menus e popovers sobrepostos entre relatorios e perfil do usuario (#64)

### DIFF
--- a/frontend/src/components/LanguageSelector.tsx
+++ b/frontend/src/components/LanguageSelector.tsx
@@ -7,6 +7,7 @@ import {
   SelectChangeEvent,
   Tooltip,
 } from "@mui/material";
+import { useMenuStore } from "../store/menuStore";
 import { BrazilFlag } from "./flags/BrazilFlag";
 import { USAFlag } from "./flags/USAFlag";
 
@@ -44,6 +45,7 @@ export function LanguageSelector({
         <Select
           value={currentLanguageCode}
           onChange={handleChange}
+          onOpen={() => useMenuStore.getState().closeAll()}
           size="small"
           variant="outlined"
           inputProps={{ "aria-label": t("language.select") }}

--- a/frontend/src/features/clients/pages/ClientsPage.tsx
+++ b/frontend/src/features/clients/pages/ClientsPage.tsx
@@ -53,6 +53,7 @@ import {
 } from "../../../services/api/photographer.service";
 import { reportService } from "../../../services/api/report.service";
 import { useSeasonStore } from "../../../store/seasonStore";
+import { useMenuAnchor } from "../../../hooks/useMenuAnchor";
 
 const PAYMENT_METHODS = [
   "Pix",
@@ -74,9 +75,12 @@ export const ClientsPage = () => {
   const [personId, setPersonId] = useState("");
   const [dogs, setDogs] = useState<Omit<Dog, "id">[]>([]);
 
-  const [reportMenuAnchor, setReportMenuAnchor] = useState<null | HTMLElement>(
-    null,
-  );
+  const {
+    anchorEl: reportMenuAnchor,
+    isOpen: isReportMenuOpen,
+    handleOpen: handleOpenReportMenu,
+    handleClose: handleCloseReportMenu,
+  } = useMenuAnchor("clients-reports-menu");
   const [exportingReport, setExportingReport] = useState(false);
   const [snackbar, setSnackbar] = useState<{
     open: boolean;
@@ -231,7 +235,7 @@ export const ClientsPage = () => {
 
   const handleExportPdfReport = async () => {
     if (!activeSeason) return;
-    setReportMenuAnchor(null);
+    handleCloseReportMenu();
     setExportingReport(true);
     try {
       const res = await reportService.exportClientsPdf(activeSeason.id);
@@ -256,7 +260,7 @@ export const ClientsPage = () => {
 
   const handleExportClientsCsvReport = async () => {
     if (!activeSeason) return;
-    setReportMenuAnchor(null);
+    handleCloseReportMenu();
     setExportingReport(true);
     try {
       const res = await reportService.exportClientsCsv(activeSeason.id);
@@ -281,7 +285,7 @@ export const ClientsPage = () => {
 
   const handleExportUnpaidClientsCsvReport = async () => {
     if (!activeSeason) return;
-    setReportMenuAnchor(null);
+    handleCloseReportMenu();
     setExportingReport(true);
     try {
       const res = await reportService.exportUnpaidClientsCsv(activeSeason.id);
@@ -306,7 +310,7 @@ export const ClientsPage = () => {
 
   const handleExportPaidClientsCsvReport = async () => {
     if (!activeSeason) return;
-    setReportMenuAnchor(null);
+    handleCloseReportMenu();
     setExportingReport(true);
     try {
       const res = await reportService.exportPaidClientsCsv(activeSeason.id);
@@ -377,7 +381,7 @@ export const ClientsPage = () => {
               )
             }
             endIcon={<ExpandMoreIcon />}
-            onClick={(e) => setReportMenuAnchor(e.currentTarget)}
+            onClick={handleOpenReportMenu}
             disabled={exportingReport}
             sx={{ width: { xs: "100%", sm: "auto" }, whiteSpace: "nowrap" }}
           >
@@ -388,8 +392,8 @@ export const ClientsPage = () => {
 
           <Menu
             anchorEl={reportMenuAnchor}
-            open={Boolean(reportMenuAnchor)}
-            onClose={() => setReportMenuAnchor(null)}
+            open={isReportMenuOpen}
+            onClose={handleCloseReportMenu}
             slotProps={{
               paper: {
                 elevation: 3,

--- a/frontend/src/features/dashboard/pages/DashboardMenuOverlapping.test.tsx
+++ b/frontend/src/features/dashboard/pages/DashboardMenuOverlapping.test.tsx
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { BrowserRouter } from "react-router-dom";
+import { Topbar } from "../../../layouts/Topbar";
+import { DashboardPage } from "./DashboardPage";
+import { useSeasonStore } from "../../../store/seasonStore";
+import { useAuthStore } from "../../auth/state/auth.store";
+import { useTenantStore } from "../../../store/tenantStore";
+import { useMenuStore } from "../../../store/menuStore";
+import { clientService } from "../../../services/api/client.service";
+import { personService } from "../../../services/api/person.service";
+import { seasonService } from "../../../services/api/season.service";
+import i18n from "../../../i18n";
+
+describe("Dashboard and Topbar Menu Overlapping (Issue #64)", () => {
+  beforeEach(async () => {
+    vi.restoreAllMocks();
+    await i18n.changeLanguage("pt-BR");
+    useMenuStore.setState({ activeMenuId: null });
+    useSeasonStore.setState({
+      activeSeason: { id: "season-1", name: "Temporada Oficial 2026" },
+    });
+    useAuthStore.setState({
+      user: {
+        id: "user-1",
+        name: "Yuri Nogueira",
+        email: "yuri@example.com",
+        tenantId: "tenant-1",
+      },
+      isAuthenticated: true,
+    });
+    useTenantStore.setState({ tenantStatus: null });
+
+    vi.spyOn(seasonService, "list").mockResolvedValue([
+      {
+        id: "season-1",
+        name: "Temporada Oficial 2026",
+        photographer_ids: [],
+        judges: [],
+      },
+    ]);
+    vi.spyOn(personService, "list").mockResolvedValue([]);
+    vi.spyOn(clientService, "list").mockResolvedValue({
+      data: [],
+      total: 0,
+      page: 1,
+      limit: 10,
+    });
+  });
+
+  it("automatically closes reports menu when user avatar menu is clicked and vice-versa", async () => {
+    const { container } = render(
+      <BrowserRouter>
+        <div>
+          <Topbar onDrawerToggle={vi.fn()} />
+          <DashboardPage />
+        </div>
+      </BrowserRouter>,
+    );
+
+    // 1. Initially neither menu is open
+    expect(
+      screen.queryByText("Exportar Clientes (.csv)"),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Meu Perfil")).not.toBeInTheDocument();
+
+    // 2. Open Reports Menu in Dashboard
+    const reportsBtn = await screen.findByRole("button", {
+      name: /relatórios/i,
+    });
+    fireEvent.click(reportsBtn);
+
+    // Reports dropdown should be visible
+    expect(
+      await screen.findByText("Exportar Clientes (.csv)"),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Meu Perfil")).not.toBeInTheDocument();
+
+    // 3. Click the user avatar button in the Topbar WITHOUT closing reports menu first
+    const avatarButton = container.querySelector(
+      '[data-testid="topbar-avatar-btn"]',
+    ) as HTMLElement;
+    expect(avatarButton).toBeTruthy();
+    fireEvent.click(avatarButton);
+
+    // 4. Verify User Profile menu opened and Reports menu closed automatically!
+    await waitFor(() => {
+      expect(screen.getByText("Meu Perfil")).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByText("Exportar Clientes (.csv)"),
+    ).not.toBeInTheDocument();
+
+    // 5. Click Reports button again -> User menu closes and Reports menu opens!
+    fireEvent.click(reportsBtn);
+
+    await waitFor(() => {
+      expect(screen.getByText("Exportar Clientes (.csv)")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Meu Perfil")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/dashboard/pages/DashboardMenuOverlapping.test.tsx
+++ b/frontend/src/features/dashboard/pages/DashboardMenuOverlapping.test.tsx
@@ -86,17 +86,17 @@ describe("Dashboard and Topbar Menu Overlapping (Issue #64)", () => {
     // 4. Verify User Profile menu opened and Reports menu closed automatically!
     await waitFor(() => {
       expect(screen.getByText("Meu Perfil")).toBeInTheDocument();
+      expect(
+        screen.queryByText("Exportar Clientes (.csv)"),
+      ).not.toBeInTheDocument();
     });
-    expect(
-      screen.queryByText("Exportar Clientes (.csv)"),
-    ).not.toBeInTheDocument();
 
     // 5. Click Reports button again -> User menu closes and Reports menu opens!
     fireEvent.click(reportsBtn);
 
     await waitFor(() => {
       expect(screen.getByText("Exportar Clientes (.csv)")).toBeInTheDocument();
+      expect(screen.queryByText("Meu Perfil")).not.toBeInTheDocument();
     });
-    expect(screen.queryByText("Meu Perfil")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/features/dashboard/pages/DashboardPage.tsx
+++ b/frontend/src/features/dashboard/pages/DashboardPage.tsx
@@ -58,6 +58,7 @@ import { personService, Person } from "../../../services/api/person.service";
 import { reportService } from "../../../services/api/report.service";
 import { useSeasonStore } from "../../../store/seasonStore";
 import { useTenantStore } from "../../../store/tenantStore";
+import { useMenuAnchor } from "../../../hooks/useMenuAnchor";
 import { LinkClientModal } from "../../clients/components/LinkClientModal";
 import { ClientDetailsModal } from "../../clients/components/ClientDetailsModal";
 import { formatPhone, maskPhone } from "../../../utils/phone";
@@ -137,9 +138,12 @@ export const DashboardPage = () => {
   });
 
   // Report Export Menu & Snackbar state
-  const [reportMenuAnchor, setReportMenuAnchor] = useState<null | HTMLElement>(
-    null,
-  );
+  const {
+    anchorEl: reportMenuAnchor,
+    isOpen: isReportMenuOpen,
+    handleOpen: handleOpenReportMenu,
+    handleClose: handleCloseReportMenu,
+  } = useMenuAnchor("dashboard-reports-menu");
   const [exportingReport, setExportingReport] = useState(false);
   const [snackbar, setSnackbar] = useState<{
     open: boolean;
@@ -164,7 +168,7 @@ export const DashboardPage = () => {
 
   const handleExportClientsPdf = async () => {
     if (!seasonId) return;
-    setReportMenuAnchor(null);
+    handleCloseReportMenu();
     setExportingReport(true);
     try {
       const res = await reportService.exportClientsPdf(seasonId);
@@ -189,7 +193,7 @@ export const DashboardPage = () => {
 
   const handleExportClientsCsv = async () => {
     if (!seasonId) return;
-    setReportMenuAnchor(null);
+    handleCloseReportMenu();
     setExportingReport(true);
     try {
       const res = await reportService.exportClientsCsv(seasonId);
@@ -214,7 +218,7 @@ export const DashboardPage = () => {
 
   const handleExportPaidClientsCsv = async () => {
     if (!seasonId) return;
-    setReportMenuAnchor(null);
+    handleCloseReportMenu();
     setExportingReport(true);
     try {
       const res = await reportService.exportPaidClientsCsv(seasonId);
@@ -239,7 +243,7 @@ export const DashboardPage = () => {
 
   const handleExportUnpaidClientsCsv = async () => {
     if (!seasonId) return;
-    setReportMenuAnchor(null);
+    handleCloseReportMenu();
     setExportingReport(true);
     try {
       const res = await reportService.exportUnpaidClientsCsv(seasonId);
@@ -562,7 +566,7 @@ export const DashboardPage = () => {
                       )
                     }
                     endIcon={<ExpandMoreIcon />}
-                    onClick={(e) => setReportMenuAnchor(e.currentTarget)}
+                    onClick={handleOpenReportMenu}
                     disabled={exportingReport || isReportsBlocked}
                     sx={{
                       borderColor: "rgba(255,255,255,0.4)",
@@ -584,8 +588,8 @@ export const DashboardPage = () => {
               </Tooltip>
               <Menu
                 anchorEl={reportMenuAnchor}
-                open={Boolean(reportMenuAnchor)}
-                onClose={() => setReportMenuAnchor(null)}
+                open={isReportMenuOpen}
+                onClose={handleCloseReportMenu}
               >
                 <MenuItem onClick={handleExportClientsPdf}>
                   <ListItemIcon>

--- a/frontend/src/hooks/useMenuAnchor.ts
+++ b/frontend/src/hooks/useMenuAnchor.ts
@@ -1,0 +1,38 @@
+import { useState, useCallback, useEffect } from "react";
+import { useMenuStore } from "../store/menuStore";
+
+export function useMenuAnchor(menuId: string) {
+  const activeMenuId = useMenuStore((state) => state.activeMenuId);
+  const openMenu = useMenuStore((state) => state.openMenu);
+  const closeMenu = useMenuStore((state) => state.closeMenu);
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+
+  const isOpen = activeMenuId === menuId && Boolean(anchorEl);
+
+  const handleOpen = useCallback(
+    (event: React.MouseEvent<HTMLElement>) => {
+      setAnchorEl(event.currentTarget);
+      openMenu(menuId);
+    },
+    [menuId, openMenu],
+  );
+
+  const handleClose = useCallback(() => {
+    setAnchorEl(null);
+    closeMenu(menuId);
+  }, [menuId, closeMenu]);
+
+  useEffect(() => {
+    if (activeMenuId !== menuId && anchorEl !== null) {
+      setAnchorEl(null);
+    }
+  }, [activeMenuId, menuId, anchorEl]);
+
+  return {
+    anchorEl,
+    isOpen,
+    handleOpen,
+    handleClose,
+    setAnchorEl,
+  };
+}

--- a/frontend/src/layouts/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout.tsx
@@ -1,18 +1,24 @@
 import { useState, useEffect } from "react";
 import { Box } from "@mui/material";
-import { Outlet } from "react-router-dom";
+import { Outlet, useLocation } from "react-router-dom";
 import { Sidebar } from "./Sidebar";
 import { Topbar } from "./Topbar";
 import { useAuthStore } from "../features/auth/state/auth.store";
 import { useTenantStore } from "../store/tenantStore";
+import { useMenuStore } from "../store/menuStore";
 import { TenantStatusBanner } from "../features/shared";
 
 export function AppLayout() {
   const [mobileOpen, setMobileOpen] = useState(false);
   const drawerWidth = 280;
+  const location = useLocation();
 
   const { user } = useAuthStore();
   const { fetchTenantStatus } = useTenantStore();
+
+  useEffect(() => {
+    useMenuStore.getState().closeAll();
+  }, [location.pathname]);
 
   useEffect(() => {
     if (user?.tenantId) {

--- a/frontend/src/layouts/Topbar.tsx
+++ b/frontend/src/layouts/Topbar.tsx
@@ -24,6 +24,8 @@ import { useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { useAuthStore } from "../features/auth/state/auth.store";
 import { useSeasonStore } from "../store/seasonStore";
+import { useMenuStore } from "../store/menuStore";
+import { useMenuAnchor } from "../hooks/useMenuAnchor";
 import { seasonService, Season } from "../services/api/season.service";
 import { LanguageSelector } from "../components/LanguageSelector";
 
@@ -33,7 +35,12 @@ interface TopbarProps {
 
 export function Topbar({ onDrawerToggle }: TopbarProps) {
   const { t } = useTranslation();
-  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const {
+    anchorEl,
+    isOpen: isUserMenuOpen,
+    handleOpen: handleMenu,
+    handleClose,
+  } = useMenuAnchor("topbar-user-menu");
   const [seasons, setSeasons] = useState<Season[]>([]);
   const navigate = useNavigate();
   const { user, clear } = useAuthStore();
@@ -67,14 +74,6 @@ export function Topbar({ onDrawerToggle }: TopbarProps) {
         setActiveSeason(null);
       });
   }, [setActiveSeason]);
-
-  const handleMenu = (event: React.MouseEvent<HTMLElement>) => {
-    setAnchorEl(event.currentTarget);
-  };
-
-  const handleClose = () => {
-    setAnchorEl(null);
-  };
 
   const handleLogout = () => {
     handleClose();
@@ -149,6 +148,7 @@ export function Topbar({ onDrawerToggle }: TopbarProps) {
               label={t("layout.activeSeason")}
               notched
               displayEmpty
+              onOpen={() => useMenuStore.getState().closeAll()}
               renderValue={(selected) => {
                 if (!selected || seasons.length === 0) {
                   return (
@@ -245,14 +245,20 @@ export function Topbar({ onDrawerToggle }: TopbarProps) {
           >
             {user?.name || t("layout.user")}
           </Typography>
-          <IconButton onClick={handleMenu} size="small" sx={{ ml: 1 }}>
+          <IconButton
+            onClick={handleMenu}
+            size="small"
+            sx={{ ml: 1 }}
+            aria-label={t("layout.user")}
+            data-testid="topbar-avatar-btn"
+          >
             <Avatar sx={{ width: 32, height: 32, bgcolor: "primary.main" }}>
               {user?.name?.charAt(0).toUpperCase() || <AccountCircleIcon />}
             </Avatar>
           </IconButton>
           <Menu
             anchorEl={anchorEl}
-            open={Boolean(anchorEl)}
+            open={isUserMenuOpen}
             onClose={handleClose}
             transformOrigin={{ horizontal: "right", vertical: "top" }}
             anchorOrigin={{ horizontal: "right", vertical: "bottom" }}

--- a/frontend/src/store/menuStore.test.ts
+++ b/frontend/src/store/menuStore.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useMenuStore } from "./menuStore";
+import { useMenuAnchor } from "../hooks/useMenuAnchor";
+
+describe("menuStore and useMenuAnchor", () => {
+  beforeEach(() => {
+    useMenuStore.setState({ activeMenuId: null });
+  });
+
+  it("should open and close menus properly in store", () => {
+    expect(useMenuStore.getState().activeMenuId).toBeNull();
+
+    useMenuStore.getState().openMenu("menu-a");
+    expect(useMenuStore.getState().activeMenuId).toBe("menu-a");
+    expect(useMenuStore.getState().isMenuOpen("menu-a")).toBe(true);
+    expect(useMenuStore.getState().isMenuOpen("menu-b")).toBe(false);
+
+    useMenuStore.getState().openMenu("menu-b");
+    expect(useMenuStore.getState().activeMenuId).toBe("menu-b");
+    expect(useMenuStore.getState().isMenuOpen("menu-a")).toBe(false);
+    expect(useMenuStore.getState().isMenuOpen("menu-b")).toBe(true);
+
+    useMenuStore.getState().closeMenu("menu-b");
+    expect(useMenuStore.getState().activeMenuId).toBeNull();
+  });
+
+  it("closeMenu only closes if matching id or no id passed", () => {
+    useMenuStore.getState().openMenu("menu-a");
+    useMenuStore.getState().closeMenu("menu-b");
+    expect(useMenuStore.getState().activeMenuId).toBe("menu-a");
+
+    useMenuStore.getState().closeMenu("menu-a");
+    expect(useMenuStore.getState().activeMenuId).toBeNull();
+  });
+
+  it("closeAll resets activeMenuId", () => {
+    useMenuStore.getState().openMenu("menu-a");
+    expect(useMenuStore.getState().activeMenuId).toBe("menu-a");
+
+    useMenuStore.getState().closeAll();
+    expect(useMenuStore.getState().activeMenuId).toBeNull();
+  });
+
+  it("useMenuAnchor closes other menus when a new menu opens", () => {
+    const dummyElement1 = document.createElement("button");
+    const dummyElement2 = document.createElement("button");
+
+    const { result: hookA } = renderHook(() => useMenuAnchor("menu-a"));
+    const { result: hookB } = renderHook(() => useMenuAnchor("menu-b"));
+
+    expect(hookA.current.isOpen).toBe(false);
+    expect(hookB.current.isOpen).toBe(false);
+
+    // Open Menu A
+    act(() => {
+      hookA.current.handleOpen({
+        currentTarget: dummyElement1,
+      } as unknown as React.MouseEvent<HTMLElement>);
+    });
+
+    expect(hookA.current.isOpen).toBe(true);
+    expect(hookA.current.anchorEl).toBe(dummyElement1);
+    expect(hookB.current.isOpen).toBe(false);
+    expect(hookB.current.anchorEl).toBeNull();
+
+    // Open Menu B -> Menu A should automatically close
+    act(() => {
+      hookB.current.handleOpen({
+        currentTarget: dummyElement2,
+      } as unknown as React.MouseEvent<HTMLElement>);
+    });
+
+    expect(hookA.current.isOpen).toBe(false);
+    expect(hookA.current.anchorEl).toBeNull();
+    expect(hookB.current.isOpen).toBe(true);
+    expect(hookB.current.anchorEl).toBe(dummyElement2);
+
+    // Close Menu B
+    act(() => {
+      hookB.current.handleClose();
+    });
+
+    expect(hookA.current.isOpen).toBe(false);
+    expect(hookB.current.isOpen).toBe(false);
+  });
+});

--- a/frontend/src/store/menuStore.ts
+++ b/frontend/src/store/menuStore.ts
@@ -1,0 +1,22 @@
+import { create } from "zustand";
+
+interface MenuState {
+  activeMenuId: string | null;
+  openMenu: (id: string) => void;
+  closeMenu: (id?: string) => void;
+  closeAll: () => void;
+  isMenuOpen: (id: string) => boolean;
+}
+
+export const useMenuStore = create<MenuState>((set, get) => ({
+  activeMenuId: null,
+  openMenu: (id: string) => set({ activeMenuId: id }),
+  closeMenu: (id?: string) => {
+    const current = get().activeMenuId;
+    if (!id || current === id) {
+      set({ activeMenuId: null });
+    }
+  },
+  closeAll: () => set({ activeMenuId: null }),
+  isMenuOpen: (id: string) => get().activeMenuId === id,
+}));


### PR DESCRIPTION
## Resumo das Alterações

- **Store Global de Menus (`useMenuStore`)**: Criada store Zustand para gerenciar atomicamente o `activeMenuId` na aplicação, impedindo menus ou popovers abertos concorrentemente.
- **Hook `useMenuAnchor`**: Hook reutilizável que mantém o `anchorEl` em sincronia com o estado ativo global, fechando instantaneamente qualquer menu prévio assim que outro é acionado.
- **Integração no Topbar e Seletor de Idioma**: Conexão do menu de usuário ao `useMenuAnchor` e fechamento de menus ao abrir selects de eventos e idiomas.
- **Integração no Dashboard e Clientes**: Conexão dos menus de relatórios do `DashboardPage` e `ClientsPage` ao `useMenuAnchor`.
- **Fechamento em Troca de Rotas**: Adicionado `closeAll()` ao `AppLayout` disparado na transição de rotas.
- **Testes**: Criados testes unitários para a store (`menuStore.test.ts`) e teste de integração simulando o cenário exato da issue no Dashboard (`DashboardMenuOverlapping.test.tsx`).

Closes #64
Resolves #64

## Checklist de Validação
- [x] `./scripts/check.sh frontend` (typecheck, lint, format & vitest 100% aprovados)
- [x] `./scripts/check.sh all` (backend, frontend e terraform 100% aprovados)
