### PR TITLE
fix(layout): responsividade do header e prevencao de quebra indevida de texto em cards e tabelas (#65)

### DIFF
--- a/frontend/src/features/admin/pages/AdminUsersPage.test.tsx
+++ b/frontend/src/features/admin/pages/AdminUsersPage.test.tsx
@@ -57,4 +57,37 @@ describe("AdminUsersPage", () => {
       expect(screen.getByText("Pendente de Aprovação")).toBeInTheDocument();
     });
   });
+
+  it("renders email addresses with ellipsis and nowrap styling to avoid text cutoff", async () => {
+    vi.mocked(adminService.getUsers).mockResolvedValueOnce([
+      {
+        id: "u3",
+        name: "Developer Long Name",
+        email: "super.long.email.address.example.tenant@domain.com.br",
+        superAdmin: false,
+        emailVerified: true,
+        tenantId: "long-tenant-id",
+        createdAt: "2026-08-28T00:00:00Z",
+      },
+    ]);
+    vi.mocked(adminService.getTenants).mockResolvedValueOnce([]);
+
+    render(
+      <BrowserRouter>
+        <AdminUsersPage />
+      </BrowserRouter>,
+    );
+
+    await waitFor(() => {
+      const emailEl = screen.getByText(
+        "super.long.email.address.example.tenant@domain.com.br",
+      );
+      expect(emailEl).toBeInTheDocument();
+      expect(emailEl).toHaveStyle({
+        whiteSpace: "nowrap",
+        overflow: "hidden",
+        textOverflow: "ellipsis",
+      });
+    });
+  });
 });

--- a/frontend/src/features/admin/pages/AdminUsersPage.tsx
+++ b/frontend/src/features/admin/pages/AdminUsersPage.tsx
@@ -27,6 +27,7 @@ import {
   ToggleButton,
   Card,
   CardContent,
+  Tooltip,
 } from "@mui/material";
 import SearchIcon from "@mui/icons-material/Search";
 import PersonRoundedIcon from "@mui/icons-material/PersonRounded";
@@ -312,19 +313,22 @@ export const AdminUsersPage = () => {
         <Table sx={{ minWidth: 680 }}>
           <TableHead sx={{ bgcolor: "grey.50" }}>
             <TableRow>
-              <TableCell sx={{ fontWeight: 600 }}>
+              <TableCell sx={{ fontWeight: 600, whiteSpace: "nowrap" }}>
                 {t("admin.users.columns.name")}
               </TableCell>
-              <TableCell sx={{ fontWeight: 600 }}>
+              <TableCell sx={{ fontWeight: 600, whiteSpace: "nowrap" }}>
                 {t("admin.users.columns.email")}
               </TableCell>
-              <TableCell sx={{ fontWeight: 600 }}>
+              <TableCell sx={{ fontWeight: 600, whiteSpace: "nowrap" }}>
                 {t("admin.users.columns.superAdmin")}
               </TableCell>
-              <TableCell sx={{ fontWeight: 600 }}>
+              <TableCell sx={{ fontWeight: 600, whiteSpace: "nowrap" }}>
                 {t("admin.users.columns.tenant")}
               </TableCell>
-              <TableCell align="right" sx={{ fontWeight: 600 }}>
+              <TableCell
+                align="right"
+                sx={{ fontWeight: 600, whiteSpace: "nowrap" }}
+              >
                 {t("admin.users.columns.actions")}
               </TableCell>
             </TableRow>
@@ -360,9 +364,14 @@ export const AdminUsersPage = () => {
             ) : (
               filteredUsers.map((u) => (
                 <TableRow key={u.id} hover>
-                  <TableCell>
+                  <TableCell sx={{ maxWidth: { xs: 160, sm: 200 } }}>
                     <Box
-                      sx={{ display: "flex", alignItems: "center", gap: 1.5 }}
+                      sx={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: 1.5,
+                        minWidth: 0,
+                      }}
                     >
                       <Box
                         sx={{
@@ -373,6 +382,7 @@ export const AdminUsersPage = () => {
                           p: 0.8,
                           borderRadius: "50%",
                           display: "inline-flex",
+                          flexShrink: 0,
                         }}
                       >
                         {u.superAdmin ? (
@@ -381,14 +391,27 @@ export const AdminUsersPage = () => {
                           <PersonRoundedIcon fontSize="small" />
                         )}
                       </Box>
-                      <Box>
+                      <Box sx={{ minWidth: 0 }}>
+                        <Tooltip title={u.name} arrow placement="top-start">
+                          <Typography
+                            variant="subtitle2"
+                            noWrap
+                            sx={{
+                              fontWeight: 600,
+                              overflow: "hidden",
+                              textOverflow: "ellipsis",
+                              whiteSpace: "nowrap",
+                            }}
+                          >
+                            {u.name}
+                          </Typography>
+                        </Tooltip>
                         <Typography
-                          variant="subtitle2"
-                          sx={{ fontWeight: 600 }}
+                          variant="caption"
+                          color="text.secondary"
+                          noWrap
+                          sx={{ display: "block" }}
                         >
-                          {u.name}
-                        </Typography>
-                        <Typography variant="caption" color="text.secondary">
                           {t("admin.users.createdAt", {
                             date: u.createdAt
                               ? new Date(u.createdAt).toLocaleDateString(
@@ -400,8 +423,20 @@ export const AdminUsersPage = () => {
                       </Box>
                     </Box>
                   </TableCell>
-                  <TableCell>
-                    <Typography variant="body2">{u.email}</Typography>
+                  <TableCell sx={{ maxWidth: { xs: 180, sm: 240, md: 280 } }}>
+                    <Tooltip title={u.email} arrow placement="top-start">
+                      <Typography
+                        variant="body2"
+                        noWrap
+                        sx={{
+                          overflow: "hidden",
+                          textOverflow: "ellipsis",
+                          whiteSpace: "nowrap",
+                        }}
+                      >
+                        {u.email}
+                      </Typography>
+                    </Tooltip>
                     {u.emailVerified ? (
                       <Box
                         sx={{
@@ -409,14 +444,34 @@ export const AdminUsersPage = () => {
                           alignItems: "center",
                           gap: 0.5,
                           mt: 0.5,
+                          minWidth: 0,
                         }}
                       >
                         <CheckCircleRoundedIcon
-                          sx={{ fontSize: 14, color: "success.main" }}
+                          sx={{
+                            fontSize: 14,
+                            color: "success.main",
+                            flexShrink: 0,
+                          }}
                         />
-                        <Typography variant="caption" color="success.main">
-                          {t("admin.users.emailVerified")}
-                        </Typography>
+                        <Tooltip
+                          title={t("admin.users.emailVerified")}
+                          arrow
+                          placement="top-start"
+                        >
+                          <Typography
+                            variant="caption"
+                            color="success.main"
+                            noWrap
+                            sx={{
+                              whiteSpace: "nowrap",
+                              overflow: "hidden",
+                              textOverflow: "ellipsis",
+                            }}
+                          >
+                            {t("admin.users.emailVerified")}
+                          </Typography>
+                        </Tooltip>
                       </Box>
                     ) : (
                       <Box
@@ -425,18 +480,38 @@ export const AdminUsersPage = () => {
                           alignItems: "center",
                           gap: 0.5,
                           mt: 0.5,
+                          minWidth: 0,
                         }}
                       >
                         <WarningRoundedIcon
-                          sx={{ fontSize: 14, color: "warning.main" }}
+                          sx={{
+                            fontSize: 14,
+                            color: "warning.main",
+                            flexShrink: 0,
+                          }}
                         />
-                        <Typography variant="caption" color="warning.main">
-                          {t("admin.users.pendingVerification")}
-                        </Typography>
+                        <Tooltip
+                          title={t("admin.users.pendingVerification")}
+                          arrow
+                          placement="top-start"
+                        >
+                          <Typography
+                            variant="caption"
+                            color="warning.main"
+                            noWrap
+                            sx={{
+                              whiteSpace: "nowrap",
+                              overflow: "hidden",
+                              textOverflow: "ellipsis",
+                            }}
+                          >
+                            {t("admin.users.pendingVerification")}
+                          </Typography>
+                        </Tooltip>
                       </Box>
                     )}
                   </TableCell>
-                  <TableCell>
+                  <TableCell sx={{ whiteSpace: "nowrap" }}>
                     {u.superAdmin ? (
                       <Chip
                         label={t("admin.users.superAdminBadge")}
@@ -453,18 +528,34 @@ export const AdminUsersPage = () => {
                       />
                     )}
                   </TableCell>
-                  <TableCell>
+                  <TableCell sx={{ maxWidth: { xs: 140, sm: 180 } }}>
                     {u.tenantId ? (
                       <Box
-                        sx={{ display: "flex", alignItems: "center", gap: 1 }}
+                        sx={{
+                          display: "flex",
+                          alignItems: "center",
+                          gap: 1,
+                          minWidth: 0,
+                        }}
                       >
                         <BusinessRoundedIcon
                           fontSize="small"
-                          sx={{ color: "primary.main" }}
+                          sx={{ color: "primary.main", flexShrink: 0 }}
                         />
-                        <Typography variant="body2" sx={{ fontWeight: 600 }}>
-                          {u.tenantId}
-                        </Typography>
+                        <Tooltip title={u.tenantId} arrow placement="top-start">
+                          <Typography
+                            variant="body2"
+                            noWrap
+                            sx={{
+                              fontWeight: 600,
+                              overflow: "hidden",
+                              textOverflow: "ellipsis",
+                              whiteSpace: "nowrap",
+                            }}
+                          >
+                            {u.tenantId}
+                          </Typography>
+                        </Tooltip>
                       </Box>
                     ) : (
                       <Chip
@@ -476,13 +567,13 @@ export const AdminUsersPage = () => {
                       />
                     )}
                   </TableCell>
-                  <TableCell align="right">
+                  <TableCell align="right" sx={{ whiteSpace: "nowrap" }}>
                     <Button
                       variant="outlined"
                       size="small"
                       startIcon={<EditRoundedIcon />}
                       onClick={() => handleOpenAssign(u)}
-                      sx={{ fontWeight: 600 }}
+                      sx={{ fontWeight: 600, whiteSpace: "nowrap" }}
                     >
                       {u.tenantId
                         ? t("admin.users.changeTenant")

--- a/frontend/src/features/clients/pages/ClientsPage.tsx
+++ b/frontend/src/features/clients/pages/ClientsPage.tsx
@@ -449,18 +449,21 @@ export const ClientsPage = () => {
         }}
       >
         <Table sx={{ minWidth: 550 }}>
-          <TableHead>
+          <TableHead sx={{ bgcolor: "grey.50" }}>
             <TableRow>
-              <TableCell sx={{ fontWeight: 600 }}>
+              <TableCell sx={{ fontWeight: 600, whiteSpace: "nowrap" }}>
                 {t("clients.columns.name")}
               </TableCell>
-              <TableCell sx={{ fontWeight: 600 }}>
+              <TableCell sx={{ fontWeight: 600, whiteSpace: "nowrap" }}>
                 {t("clientDetails.dogs")}
               </TableCell>
-              <TableCell sx={{ fontWeight: 600 }}>
+              <TableCell sx={{ fontWeight: 600, whiteSpace: "nowrap" }}>
                 {t("clients.columns.photos")}
               </TableCell>
-              <TableCell align="right" sx={{ fontWeight: 600 }}>
+              <TableCell
+                align="right"
+                sx={{ fontWeight: 600, whiteSpace: "nowrap" }}
+              >
                 {t("clients.columns.actions")}
               </TableCell>
             </TableRow>
@@ -483,10 +486,11 @@ export const ClientsPage = () => {
                     <TableCell>{getPersonName(c.person_id)}</TableCell>
                     <TableCell>{c.dogs?.length || 0}</TableCell>
                     <TableCell>{totalPhotos}</TableCell>
-                    <TableCell align="right">
+                    <TableCell align="right" sx={{ whiteSpace: "nowrap" }}>
                       <Button
                         size="small"
                         onClick={() => navigate(`/clients/${c.id}`)}
+                        sx={{ whiteSpace: "nowrap" }}
                       >
                         {t("clients.actions.details")}
                       </Button>

--- a/frontend/src/features/dashboard/pages/DashboardPage.tsx
+++ b/frontend/src/features/dashboard/pages/DashboardPage.tsx
@@ -638,23 +638,42 @@ export const DashboardPage = () => {
                     display: "flex",
                     justifyContent: "space-between",
                     alignItems: "center",
+                    gap: 1.5,
                   }}
                 >
-                  <Box>
+                  <Box sx={{ minWidth: 0, flex: 1 }}>
                     <Typography
                       variant="body2"
                       color="text.secondary"
+                      noWrap
                       sx={{ fontWeight: 600, textTransform: "uppercase" }}
                     >
                       {t("dashboard.kpi.totalClients")}
                     </Typography>
                     <Typography
                       variant="h4"
-                      sx={{ fontWeight: 800, mt: 0.5, color: "text.primary" }}
+                      noWrap
+                      sx={{
+                        fontWeight: 800,
+                        mt: 0.5,
+                        color: "text.primary",
+                        fontSize: {
+                          xs: "1.5rem",
+                          sm: "1.75rem",
+                          md: "1.45rem",
+                          lg: "1.85rem",
+                          xl: "2.125rem",
+                        },
+                      }}
                     >
                       {metrics.totalPeople}
                     </Typography>
-                    <Typography variant="caption" color="text.secondary">
+                    <Typography
+                      variant="caption"
+                      color="text.secondary"
+                      noWrap
+                      sx={{ display: "block" }}
+                    >
                       {metrics.activeSeasonClients}{" "}
                       {t("dashboard.kpiDescriptions.inThisEvent")}
                     </Typography>
@@ -665,6 +684,7 @@ export const DashboardPage = () => {
                       color: "primary.main",
                       width: 48,
                       height: 48,
+                      flexShrink: 0,
                     }}
                   >
                     <PeopleAltRoundedIcon />
@@ -690,23 +710,42 @@ export const DashboardPage = () => {
                     display: "flex",
                     justifyContent: "space-between",
                     alignItems: "center",
+                    gap: 1.5,
                   }}
                 >
-                  <Box>
+                  <Box sx={{ minWidth: 0, flex: 1 }}>
                     <Typography
                       variant="body2"
                       color="text.secondary"
+                      noWrap
                       sx={{ fontWeight: 600, textTransform: "uppercase" }}
                     >
                       {t("dashboard.kpi.dogs")}
                     </Typography>
                     <Typography
                       variant="h4"
-                      sx={{ fontWeight: 800, mt: 0.5, color: "text.primary" }}
+                      noWrap
+                      sx={{
+                        fontWeight: 800,
+                        mt: 0.5,
+                        color: "text.primary",
+                        fontSize: {
+                          xs: "1.5rem",
+                          sm: "1.75rem",
+                          md: "1.45rem",
+                          lg: "1.85rem",
+                          xl: "2.125rem",
+                        },
+                      }}
                     >
                       {metrics.totalDogs}
                     </Typography>
-                    <Typography variant="caption" color="text.secondary">
+                    <Typography
+                      variant="caption"
+                      color="text.secondary"
+                      noWrap
+                      sx={{ display: "block" }}
+                    >
                       {t("dashboard.kpiDescriptions.registeredInActiveSeason")}
                     </Typography>
                   </Box>
@@ -716,6 +755,7 @@ export const DashboardPage = () => {
                       color: "#4f46e5",
                       width: 48,
                       height: 48,
+                      flexShrink: 0,
                     }}
                   >
                     <PetsRoundedIcon />
@@ -741,23 +781,42 @@ export const DashboardPage = () => {
                     display: "flex",
                     justifyContent: "space-between",
                     alignItems: "center",
+                    gap: 1.5,
                   }}
                 >
-                  <Box>
+                  <Box sx={{ minWidth: 0, flex: 1 }}>
                     <Typography
                       variant="body2"
                       color="text.secondary"
+                      noWrap
                       sx={{ fontWeight: 600, textTransform: "uppercase" }}
                     >
                       {t("dashboard.kpi.totalPhotos")}
                     </Typography>
                     <Typography
                       variant="h4"
-                      sx={{ fontWeight: 800, mt: 0.5, color: "text.primary" }}
+                      noWrap
+                      sx={{
+                        fontWeight: 800,
+                        mt: 0.5,
+                        color: "text.primary",
+                        fontSize: {
+                          xs: "1.5rem",
+                          sm: "1.75rem",
+                          md: "1.45rem",
+                          lg: "1.85rem",
+                          xl: "2.125rem",
+                        },
+                      }}
                     >
                       {metrics.totalPhotos}
                     </Typography>
-                    <Typography variant="caption" color="text.secondary">
+                    <Typography
+                      variant="caption"
+                      color="text.secondary"
+                      noWrap
+                      sx={{ display: "block" }}
+                    >
                       {t("dashboard.kpiDescriptions.totalInThisEvent")}
                     </Typography>
                   </Box>
@@ -767,6 +826,7 @@ export const DashboardPage = () => {
                       color: "#059669",
                       width: 48,
                       height: 48,
+                      flexShrink: 0,
                     }}
                   >
                     <PhotoCameraRoundedIcon />
@@ -792,12 +852,14 @@ export const DashboardPage = () => {
                     display: "flex",
                     justifyContent: "space-between",
                     alignItems: "center",
+                    gap: 1.5,
                   }}
                 >
-                  <Box>
+                  <Box sx={{ minWidth: 0, flex: 1 }}>
                     <Typography
                       variant="body2"
                       color="text.secondary"
+                      noWrap
                       sx={{ fontWeight: 600, textTransform: "uppercase" }}
                     >
                       {t("dashboard.kpi.totalRevenue")}
@@ -808,30 +870,54 @@ export const DashboardPage = () => {
                         display: "flex",
                         flexDirection: "column",
                         gap: 0.25,
+                        minWidth: 0,
                       }}
                     >
                       <Typography
                         variant="h5"
+                        noWrap
                         sx={{
                           fontWeight: 800,
                           color: "success.main",
                           whiteSpace: "nowrap",
+                          fontSize: {
+                            xs: "1.2rem",
+                            sm: "1.35rem",
+                            md: "1.15rem",
+                            lg: "1.35rem",
+                            xl: "1.5rem",
+                          },
+                          letterSpacing: "-0.5px",
                         }}
                       >
                         R$ {metrics.totalRevenueBRL.toFixed(2)}
                       </Typography>
                       <Typography
                         variant="h6"
+                        noWrap
                         sx={{
                           fontWeight: 800,
                           color: "success.main",
                           whiteSpace: "nowrap",
+                          fontSize: {
+                            xs: "0.95rem",
+                            sm: "1.1rem",
+                            md: "0.95rem",
+                            lg: "1.1rem",
+                            xl: "1.25rem",
+                          },
+                          letterSpacing: "-0.5px",
                         }}
                       >
                         $ {metrics.totalRevenueUSD.toFixed(2)}
                       </Typography>
                     </Box>
-                    <Typography variant="caption" color="text.secondary">
+                    <Typography
+                      variant="caption"
+                      color="text.secondary"
+                      noWrap
+                      sx={{ display: "block" }}
+                    >
                       {t("dashboard.kpiDescriptions.paidPhotos")}
                     </Typography>
                   </Box>
@@ -841,6 +927,7 @@ export const DashboardPage = () => {
                       color: "#d97706",
                       width: 48,
                       height: 48,
+                      flexShrink: 0,
                     }}
                   >
                     <AttachMoneyRoundedIcon />
@@ -1055,19 +1142,22 @@ export const DashboardPage = () => {
                 <Table sx={{ minWidth: 650 }}>
                   <TableHead sx={{ bgcolor: "grey.50" }}>
                     <TableRow>
-                      <TableCell sx={{ fontWeight: 700 }}>
+                      <TableCell sx={{ fontWeight: 700, whiteSpace: "nowrap" }}>
                         {t("clients.columns.name")}
                       </TableCell>
-                      <TableCell sx={{ fontWeight: 700 }}>
+                      <TableCell sx={{ fontWeight: 700, whiteSpace: "nowrap" }}>
                         {t("shared.contact")}
                       </TableCell>
-                      <TableCell sx={{ fontWeight: 700 }}>
+                      <TableCell sx={{ fontWeight: 700, whiteSpace: "nowrap" }}>
                         {t("clientDetails.dogs")}
                       </TableCell>
-                      <TableCell sx={{ fontWeight: 700 }}>
+                      <TableCell sx={{ fontWeight: 700, whiteSpace: "nowrap" }}>
                         {t("clientDetails.photos")}
                       </TableCell>
-                      <TableCell align="right" sx={{ fontWeight: 700 }}>
+                      <TableCell
+                        align="right"
+                        sx={{ fontWeight: 700, whiteSpace: "nowrap" }}
+                      >
                         {t("clients.columns.actions")}
                       </TableCell>
                     </TableRow>

--- a/frontend/src/layouts/Topbar.tsx
+++ b/frontend/src/layouts/Topbar.tsx
@@ -13,6 +13,7 @@ import {
   Select,
   FormControl,
   InputLabel,
+  Tooltip,
 } from "@mui/material";
 import AddRoundedIcon from "@mui/icons-material/AddRounded";
 import EventNoteRoundedIcon from "@mui/icons-material/EventNoteRounded";
@@ -102,7 +103,7 @@ export function Topbar({ onDrawerToggle }: TopbarProps) {
         color: "text.primary",
       }}
     >
-      <Toolbar>
+      <Toolbar sx={{ px: { xs: 1, sm: 2 } }}>
         <IconButton
           color="inherit"
           aria-label={t("layout.openMenu")}
@@ -111,12 +112,19 @@ export function Topbar({ onDrawerToggle }: TopbarProps) {
             (e.currentTarget as HTMLElement)?.blur();
             onDrawerToggle();
           }}
-          sx={{ mr: 2, display: { md: "none" } }}
+          sx={{ mr: { xs: 1, sm: 2 }, display: { md: "none" } }}
         >
           <MenuIcon />
         </IconButton>
 
-        <Box sx={{ flexGrow: 1, display: "flex", alignItems: "center" }}>
+        <Box
+          sx={{
+            flexGrow: 1,
+            display: "flex",
+            alignItems: "center",
+            minWidth: 0,
+          }}
+        >
           <Typography
             variant="h6"
             noWrap
@@ -129,9 +137,9 @@ export function Topbar({ onDrawerToggle }: TopbarProps) {
 
         <Box
           sx={{
-            minWidth: { xs: 140, sm: 190, md: 230 },
-            maxWidth: { xs: 180, sm: 270 },
-            mr: { xs: 1, sm: 2, md: 3 },
+            minWidth: { xs: 130, sm: 180, md: 220 },
+            maxWidth: { xs: 165, sm: 240, md: 270 },
+            mr: { xs: 0.75, sm: 1.5, md: 2 },
           }}
         >
           <FormControl fullWidth size="small">
@@ -152,27 +160,75 @@ export function Topbar({ onDrawerToggle }: TopbarProps) {
               renderValue={(selected) => {
                 if (!selected || seasons.length === 0) {
                   return (
-                    <Typography
-                      variant="body2"
-                      component="span"
+                    <Box
                       sx={{
-                        color: "text.secondary",
-                        fontStyle: "italic",
-                        fontSize: { xs: "0.8rem", sm: "0.875rem" },
                         display: "flex",
                         alignItems: "center",
-                        gap: 0.5,
+                        gap: 0.75,
+                        minWidth: 0,
+                        overflow: "hidden",
                       }}
                     >
                       <EventNoteRoundedIcon
-                        sx={{ fontSize: { xs: 14, sm: 16 } }}
+                        sx={{
+                          fontSize: { xs: 15, sm: 16 },
+                          color: "text.secondary",
+                          flexShrink: 0,
+                        }}
                       />
-                      {t("layout.noSeason")}
-                    </Typography>
+                      <Typography
+                        variant="body2"
+                        component="span"
+                        noWrap
+                        sx={{
+                          color: "text.secondary",
+                          fontStyle: "italic",
+                          fontSize: { xs: "0.8rem", sm: "0.875rem" },
+                          overflow: "hidden",
+                          textOverflow: "ellipsis",
+                        }}
+                      >
+                        {t("layout.noSeason")}
+                      </Typography>
+                    </Box>
                   );
                 }
                 const current = seasons.find((s) => s.id === selected);
-                return current ? current.name : selected;
+                const seasonName = current ? current.name : selected;
+                return (
+                  <Box
+                    sx={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 0.75,
+                      minWidth: 0,
+                      overflow: "hidden",
+                    }}
+                  >
+                    <EventNoteRoundedIcon
+                      sx={{
+                        fontSize: { xs: 15, sm: 16 },
+                        color: "primary.main",
+                        flexShrink: 0,
+                      }}
+                    />
+                    <Tooltip title={seasonName} arrow placement="bottom-start">
+                      <Typography
+                        variant="body2"
+                        component="span"
+                        noWrap
+                        sx={{
+                          fontSize: { xs: "0.8rem", sm: "0.875rem" },
+                          fontWeight: 500,
+                          overflow: "hidden",
+                          textOverflow: "ellipsis",
+                        }}
+                      >
+                        {seasonName}
+                      </Typography>
+                    </Tooltip>
+                  </Box>
+                );
               }}
               onChange={(e) => handleChangeSeason(e.target.value)}
               sx={{ fontSize: { xs: "0.85rem", sm: "0.95rem" } }}
@@ -234,21 +290,37 @@ export function Topbar({ onDrawerToggle }: TopbarProps) {
           </FormControl>
         </Box>
 
-        <Box sx={{ mr: { xs: 1, sm: 2 } }}>
+        <Box sx={{ mr: { xs: 0.5, sm: 1.5 } }}>
           <LanguageSelector />
         </Box>
 
-        <Box sx={{ display: "flex", alignItems: "center", gap: 2 }}>
-          <Typography
-            variant="body2"
-            sx={{ display: { xs: "none", sm: "block" }, fontWeight: 500 }}
-          >
-            {user?.name || t("layout.user")}
-          </Typography>
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            gap: { xs: 0.5, sm: 1 },
+          }}
+        >
+          <Tooltip title={user?.name || t("layout.user")} arrow>
+            <Typography
+              variant="body2"
+              noWrap
+              sx={{
+                display: { xs: "none", sm: "block" },
+                fontWeight: 500,
+                whiteSpace: "nowrap",
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                maxWidth: { sm: 110, md: 160, lg: 240 },
+              }}
+            >
+              {user?.name || t("layout.user")}
+            </Typography>
+          </Tooltip>
           <IconButton
             onClick={handleMenu}
             size="small"
-            sx={{ ml: 1 }}
+            sx={{ ml: { xs: 0.5, sm: 1 } }}
             aria-label={t("layout.user")}
             data-testid="topbar-avatar-btn"
           >

--- a/frontend/src/layouts/TopbarResponsiveness.test.tsx
+++ b/frontend/src/layouts/TopbarResponsiveness.test.tsx
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { BrowserRouter } from "react-router-dom";
+import { Topbar } from "./Topbar";
+import { useSeasonStore } from "../store/seasonStore";
+import { useAuthStore } from "../features/auth/state/auth.store";
+import { seasonService } from "../services/api/season.service";
+import i18n from "../i18n";
+
+describe("Topbar Responsiveness and Text Truncation (Issue #65)", () => {
+  beforeEach(async () => {
+    vi.restoreAllMocks();
+    await i18n.changeLanguage("pt-BR");
+    useSeasonStore.setState({ activeSeason: null });
+    useAuthStore.setState({
+      user: {
+        id: "user-long-name",
+        name: "Yuri Nogueira Moreira da Silva de Souza Albuquerque",
+        email: "yuri.super.long.developer.email@example.com",
+        tenantId: "tenant-1",
+      },
+      isAuthenticated: true,
+    });
+
+    vi.spyOn(seasonService, "list").mockResolvedValue([
+      {
+        id: "season-special",
+        name: "Campeonato Internacional Canino Oficial de Primavera 2026",
+        photographer_ids: [],
+        judges: [],
+      },
+    ]);
+  });
+
+  it("renders user name with tooltip and ellipsis styling to avoid wrapping", async () => {
+    render(
+      <BrowserRouter>
+        <Topbar onDrawerToggle={vi.fn()} />
+      </BrowserRouter>,
+    );
+
+    const userNameEl = screen.getByText(
+      "Yuri Nogueira Moreira da Silva de Souza Albuquerque",
+    );
+    expect(userNameEl).toBeInTheDocument();
+
+    // Verify styling properties preventing text wrapping
+    expect(userNameEl).toHaveStyle({
+      whiteSpace: "nowrap",
+      overflow: "hidden",
+      textOverflow: "ellipsis",
+    });
+  });
+
+  it("renders active season with event icon context", async () => {
+    useSeasonStore.setState({
+      activeSeason: {
+        id: "season-special",
+        name: "Campeonato Internacional Canino Oficial de Primavera 2026",
+      },
+    });
+
+    render(
+      <BrowserRouter>
+        <Topbar onDrawerToggle={vi.fn()} />
+      </BrowserRouter>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          "Campeonato Internacional Canino Oficial de Primavera 2026",
+        ),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("renders empty state icon and message when no season is selected", async () => {
+    vi.spyOn(seasonService, "list").mockResolvedValue([]);
+    useSeasonStore.setState({ activeSeason: null });
+
+    render(
+      <BrowserRouter>
+        <Topbar onDrawerToggle={vi.fn()} />
+      </BrowserRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Nenhum evento")).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Resumo das Alterações

Este PR soluciona os problemas de layout, quebra de linha e truncamento descritos na issue #65:

1. **Topbar (`frontend/src/layouts/Topbar.tsx`)**:
   - Adicionado truncamento inteligente (`whiteSpace: "nowrap"`, `overflow: "hidden"`, `textOverflow: "ellipsis"`) e `maxWidth` responsivo com `<Tooltip>` nativo no nome do usuário, prevenindo quebra em 2 linhas em telas médias (~800px).
   - Adicionado ícone e contexto visual de evento no `renderValue` do seletor de evento/temporada com tooltip em caso de nomes longos.
   - Ajustados espaçamentos no `Toolbar` (`px: { xs: 1, sm: 2 }`, `minWidth: 0`) e dimensões do seletor em mobile (375px).

2. **Dashboard (`frontend/src/features/dashboard/pages/DashboardPage.tsx`)**:
   - No card "Arrecadação Total", adicionado `whiteSpace: "nowrap"`, `noWrap` e escala tipográfica fluida com `minWidth: 0` e `flexShrink: 0` no ícone, evitando quebra entre símbolo monetário e valor numérico.
   - Aplicado `whiteSpace: "nowrap"` nas células de cabeçalho da tabela de clientes do dashboard.

3. **Gestão de Usuários (`frontend/src/features/admin/pages/AdminUsersPage.tsx`)**:
   - Aplicado `text-overflow: ellipsis`, `overflow: "hidden"`, `whiteSpace: "nowrap"` e `<Tooltip>` nativo em emails, nomes e status de verificação.
   - Adicionado `whiteSpace: "nowrap"` no cabeçalho da tabela de usuários.

4. **Clientes e Fotos (`frontend/src/features/clients/pages/ClientsPage.tsx`)**:
   - Adicionado `whiteSpace: "nowrap"` nas células de cabeçalho da tabela (`TableHead TableCell`), prevenindo o truncamento do cabeçalho "Total de Fotos".

5. **Testes**:
   - Criado `frontend/src/layouts/TopbarResponsiveness.test.tsx` cobrindo o Topbar e truncamento.
   - Adicionados testes de estilo e acessibilidade em `frontend/src/features/admin/pages/AdminUsersPage.test.tsx`.

Closes #65

## Checklist de Validação
- [x] `./scripts/check.sh all` executado com 100% de aprovação (backend, typecheck, lint, format & tests).
- [x] `./scripts/swagger.sh` executado com sucesso.