### PR TITLE
fix(exports): desduplica banner de trial, corrige exibição do histórico e vincula evento ao topo (#86)

### DIFF
--- a/frontend/src/features/clients/components/ClientDetailsModal.tsx
+++ b/frontend/src/features/clients/components/ClientDetailsModal.tsx
@@ -244,13 +244,16 @@ export const ClientDetailsModal = ({
     <>
       <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
         <DialogTitle
+          component="div"
           sx={{
             display: "flex",
             justifyContent: "space-between",
             alignItems: "center",
           }}
         >
-          <Typography variant="h6">{t("clientDetails.title")}</Typography>
+          <Typography variant="h6" component="span">
+            {t("clientDetails.title")}
+          </Typography>
           <Button
             color="error"
             size="small"

--- a/frontend/src/features/dashboard/pages/DashboardPage.test.tsx
+++ b/frontend/src/features/dashboard/pages/DashboardPage.test.tsx
@@ -25,6 +25,19 @@ describe("DashboardPage", () => {
       limit: 10,
     });
     vi.spyOn(photographerService, "list").mockResolvedValue([]);
+    vi.spyOn(clientService, "getById").mockResolvedValue({
+      id: "client-1",
+      person_id: "person-1",
+      season_id: "season-1",
+      dogs: [],
+    });
+    vi.spyOn(personService, "getById").mockResolvedValue({
+      id: "person-1",
+      name: "Carlos Ferreira",
+      email: "carlos@example.com",
+      alternative_email: "",
+      phone: "1199999999",
+    });
   });
 
   it("renders alert when no active season is selected", () => {

--- a/frontend/src/features/exports/components/ExportHistoryTable.tsx
+++ b/frontend/src/features/exports/components/ExportHistoryTable.tsx
@@ -23,7 +23,11 @@ import ErrorOutlineRoundedIcon from "@mui/icons-material/ErrorOutlineRounded";
 import HistoryRoundedIcon from "@mui/icons-material/HistoryRounded";
 import HourglassEmptyRoundedIcon from "@mui/icons-material/HourglassEmptyRounded";
 import { useTranslation } from "react-i18next";
-import { ReportJob, reportService } from "../../../services/api/report.service";
+import {
+  ReportJob,
+  ReportHistoryResponse,
+  reportService,
+} from "../../../services/api/report.service";
 
 interface ExportHistoryTableProps {
   seasonId?: string;
@@ -83,8 +87,10 @@ export const ExportHistoryTable: React.FC<ExportHistoryTableProps> = ({
           limit,
           season_id: seasonId || undefined,
         });
-        setJobs(res.jobs || []);
-        setTotal(res.total || 0);
+        const payload =
+          (res as unknown as { data?: ReportHistoryResponse })?.data || res;
+        setJobs(payload?.jobs || []);
+        setTotal(payload?.total ?? 0);
       } catch (err) {
         console.error("Erro ao carregar histórico de exportações:", err);
       } finally {

--- a/frontend/src/features/exports/pages/ExportsPage.test.tsx
+++ b/frontend/src/features/exports/pages/ExportsPage.test.tsx
@@ -159,4 +159,36 @@ describe("ExportsPage", () => {
       ).toBeInTheDocument();
     });
   });
+
+  it("uses activeSeason from useSeasonStore and does not render event select dropdown", async () => {
+    useSeasonStore.setState({
+      activeSeason: mockSeasons[0],
+    });
+
+    render(
+      <BrowserRouter>
+        <ExportsPage />
+      </BrowserRouter>,
+    );
+
+    // Verify active season badge is displayed
+    expect(
+      screen.getByText(`Evento Ativo: ${mockSeasons[0].name}`),
+    ).toBeInTheDocument();
+
+    // Verify no select dropdown exists for choosing another season
+    expect(
+      screen.queryByLabelText(/Filtrar por Evento/i),
+    ).not.toBeInTheDocument();
+
+    // Trigger CSV export and verify it uses active season ID
+    const exportCsvBtn = screen.getByRole("button", { name: /exportar csv/i });
+    fireEvent.click(exportCsvBtn);
+
+    await waitFor(() => {
+      expect(reportService.exportClientsCsv).toHaveBeenCalledWith(
+        mockSeasons[0].id,
+      );
+    });
+  });
 });

--- a/frontend/src/features/exports/pages/ExportsPage.tsx
+++ b/frontend/src/features/exports/pages/ExportsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import {
   Box,
   Typography,
@@ -6,16 +6,14 @@ import {
   CardContent,
   CardActions,
   Button,
-  FormControl,
-  InputLabel,
-  Select,
-  MenuItem,
   CircularProgress,
   Snackbar,
   Alert,
   Grid,
+  Chip,
 } from "@mui/material";
 import AssessmentRoundedIcon from "@mui/icons-material/AssessmentRounded";
+import EventNoteRoundedIcon from "@mui/icons-material/EventNoteRounded";
 import PictureAsPdfRoundedIcon from "@mui/icons-material/PictureAsPdfRounded";
 import TableChartRoundedIcon from "@mui/icons-material/TableChartRounded";
 import CheckCircleRoundedIcon from "@mui/icons-material/CheckCircleRounded";
@@ -24,26 +22,23 @@ import TuneRoundedIcon from "@mui/icons-material/TuneRounded";
 import DownloadRoundedIcon from "@mui/icons-material/DownloadRounded";
 import SendRoundedIcon from "@mui/icons-material/SendRounded";
 import { useTranslation } from "react-i18next";
-import { useSeasonStore, Season } from "../../../store/seasonStore";
+import { useSeasonStore } from "../../../store/seasonStore";
 import { useTenantStore } from "../../../store/tenantStore";
-import { seasonService } from "../../../services/api/season.service";
 import {
   reportService,
   DynamicPaymentParams,
 } from "../../../services/api/report.service";
-import { TenantStatusBanner } from "../../shared/components/TenantStatusBanner";
 import { DynamicExportDialog } from "../components/DynamicExportDialog";
 import { ExportHistoryTable } from "../components/ExportHistoryTable";
 
 export const ExportsPage: React.FC = () => {
   const { t } = useTranslation();
-  const { activeSeason, setActiveSeason } = useSeasonStore();
+  const { activeSeason } = useSeasonStore();
   const { tenantStatus } = useTenantStore();
 
-  const [seasons, setSeasons] = useState<Season[]>([]);
-  const [selectedSeasonId, setSelectedSeasonId] = useState<string>(
-    activeSeason?.id || "",
-  );
+  const selectedSeasonId = activeSeason?.id || "";
+  const currentSeason = activeSeason;
+
   const [dynamicDialogOpen, setDynamicDialogOpen] = useState(false);
   const [loadingAction, setLoadingAction] = useState<string | null>(null);
   const [refreshTrigger, setRefreshTrigger] = useState(0);
@@ -63,34 +58,6 @@ export const ExportsPage: React.FC = () => {
     tenantStatus?.isTrialExpired ||
     tenantStatus?.clientLimitExceeded,
   );
-
-  useEffect(() => {
-    const loadSeasons = async () => {
-      try {
-        const data = await seasonService.list();
-        setSeasons(data || []);
-      } catch (err) {
-        console.error("Erro ao carregar lista de temporadas:", err);
-      }
-    };
-    loadSeasons();
-  }, []);
-
-  useEffect(() => {
-    if (activeSeason?.id) {
-      setSelectedSeasonId(activeSeason.id);
-    }
-  }, [activeSeason]);
-
-  const handleSeasonChange = (id: string) => {
-    setSelectedSeasonId(id);
-    const season = seasons.find((s) => s.id === id);
-    if (season) {
-      setActiveSeason(season);
-    }
-  };
-
-  const currentSeason = seasons.find((s) => s.id === selectedSeasonId);
 
   const handleExportClientsPdfAsync = async () => {
     setLoadingAction("pdf_async");
@@ -222,8 +189,6 @@ export const ExportsPage: React.FC = () => {
 
   return (
     <Box sx={{ p: { xs: 2, md: 3 }, maxWidth: 1400, mx: "auto" }}>
-      <TenantStatusBanner />
-
       {/* Page Header */}
       <Box
         sx={{
@@ -249,28 +214,23 @@ export const ExportsPage: React.FC = () => {
           </Typography>
         </Box>
 
-        {/* Season Selector */}
-        <Box sx={{ minWidth: 240, width: { xs: "100%", sm: "auto" } }}>
-          <FormControl fullWidth size="small">
-            <InputLabel id="season-select-label">
-              {t("exports.selectEvent")}
-            </InputLabel>
-            <Select
-              labelId="season-select-label"
-              value={selectedSeasonId}
-              label={t("exports.selectEvent")}
-              onChange={(e) => handleSeasonChange(e.target.value)}
-            >
-              <MenuItem value="">
-                <em>{t("exports.allEvents")}</em>
-              </MenuItem>
-              {seasons.map((s) => (
-                <MenuItem key={s.id} value={s.id}>
-                  {s.name}
-                </MenuItem>
-              ))}
-            </Select>
-          </FormControl>
+        {/* Active Event Indicator (Controlled globally by top bar) */}
+        <Box>
+          {activeSeason ? (
+            <Chip
+              icon={<EventNoteRoundedIcon />}
+              label={`${t("exports.activeEvent")}: ${activeSeason.name}`}
+              color="primary"
+              variant="outlined"
+              sx={{ fontWeight: 600, py: 2.2, px: 1, borderRadius: 2 }}
+            />
+          ) : (
+            <Chip
+              label={t("exports.allEvents")}
+              variant="outlined"
+              sx={{ fontWeight: 500, py: 2.2, px: 1, borderRadius: 2 }}
+            />
+          )}
         </Box>
       </Box>
 

--- a/frontend/src/locales/en-US/translation.json
+++ b/frontend/src/locales/en-US/translation.json
@@ -547,6 +547,8 @@
     "subtitle": "Generate custom reports, launch filtered dynamic exports, and track the execution history.",
     "selectEvent": "Filter by Event",
     "allEvents": "All Events",
+    "activeEvent": "Active Event",
+    "noActiveEvent": "No active event selected",
     "blockedAlert": "Exports are currently disabled due to overdue payments or your plan limits.",
     "availableReports": "Available Exports",
     "history": "Export History",

--- a/frontend/src/locales/pt-BR/translation.json
+++ b/frontend/src/locales/pt-BR/translation.json
@@ -547,6 +547,8 @@
     "subtitle": "Gere relatórios customizados, dispare exportações com filtros avançados e acompanhe o histórico completo de execuções.",
     "selectEvent": "Filtrar por Evento",
     "allEvents": "Todos os Eventos",
+    "activeEvent": "Evento Ativo",
+    "noActiveEvent": "Nenhum evento ativo selecionado",
     "blockedAlert": "As exportações estão desabilitadas no momento devido a pendências financeiras ou limites do seu plano.",
     "availableReports": "Exportações Disponíveis",
     "history": "Histórico de Exportações",

--- a/frontend/src/services/api/report.service.ts
+++ b/frontend/src/services/api/report.service.ts
@@ -1,4 +1,5 @@
 import { apiClient } from "./client";
+import { ApiEnvelope } from "../../features/auth/types/auth.types";
 
 export type ReportType =
   | "clients_csv"
@@ -61,55 +62,59 @@ export const reportService = {
   exportClientsCsv: async (
     seasonId?: string,
   ): Promise<ReportExportResponse> => {
-    const { data } = await apiClient.post<ReportExportResponse>(
-      "/reports/clients-csv",
-      null,
-      { params: seasonId ? { season_id: seasonId } : undefined },
-    );
-    return data;
+    const { data } = await apiClient.post<
+      ReportExportResponse | ApiEnvelope<ReportExportResponse>
+    >("/reports/clients-csv", null, {
+      params: seasonId ? { season_id: seasonId } : undefined,
+    });
+    const payload = (data as ApiEnvelope<ReportExportResponse>)?.data || data;
+    return payload as ReportExportResponse;
   },
 
   exportUnpaidClientsCsv: async (
     seasonId?: string,
   ): Promise<ReportExportResponse> => {
-    const { data } = await apiClient.post<ReportExportResponse>(
-      "/reports/unpaid-clients-csv",
-      null,
-      { params: seasonId ? { season_id: seasonId } : undefined },
-    );
-    return data;
+    const { data } = await apiClient.post<
+      ReportExportResponse | ApiEnvelope<ReportExportResponse>
+    >("/reports/unpaid-clients-csv", null, {
+      params: seasonId ? { season_id: seasonId } : undefined,
+    });
+    const payload = (data as ApiEnvelope<ReportExportResponse>)?.data || data;
+    return payload as ReportExportResponse;
   },
 
   exportPaidClientsCsv: async (
     seasonId?: string,
   ): Promise<ReportExportResponse> => {
-    const { data } = await apiClient.post<ReportExportResponse>(
-      "/reports/paid-clients-csv",
-      null,
-      { params: seasonId ? { season_id: seasonId } : undefined },
-    );
-    return data;
+    const { data } = await apiClient.post<
+      ReportExportResponse | ApiEnvelope<ReportExportResponse>
+    >("/reports/paid-clients-csv", null, {
+      params: seasonId ? { season_id: seasonId } : undefined,
+    });
+    const payload = (data as ApiEnvelope<ReportExportResponse>)?.data || data;
+    return payload as ReportExportResponse;
   },
 
   exportClientsPdf: async (
     seasonId?: string,
   ): Promise<ReportExportResponse> => {
-    const { data } = await apiClient.post<ReportExportResponse>(
-      "/reports/clients-pdf",
-      null,
-      { params: seasonId ? { season_id: seasonId } : undefined },
-    );
-    return data;
+    const { data } = await apiClient.post<
+      ReportExportResponse | ApiEnvelope<ReportExportResponse>
+    >("/reports/clients-pdf", null, {
+      params: seasonId ? { season_id: seasonId } : undefined,
+    });
+    const payload = (data as ApiEnvelope<ReportExportResponse>)?.data || data;
+    return payload as ReportExportResponse;
   },
 
   exportDynamicPayment: async (
     params: DynamicPaymentParams,
   ): Promise<ReportExportResponse> => {
-    const { data } = await apiClient.post<ReportExportResponse>(
-      "/reports/dynamic-payment",
-      params,
-    );
-    return data;
+    const { data } = await apiClient.post<
+      ReportExportResponse | ApiEnvelope<ReportExportResponse>
+    >("/reports/dynamic-payment", params);
+    const payload = (data as ApiEnvelope<ReportExportResponse>)?.data || data;
+    return payload as ReportExportResponse;
   },
 
   listHistory: async (params?: {
@@ -117,22 +122,31 @@ export const reportService = {
     limit?: number;
     season_id?: string;
   }): Promise<ReportHistoryResponse> => {
-    const { data } = await apiClient.get<ReportHistoryResponse>(
-      "/reports/history",
-      {
-        params: {
-          page: params?.page || 1,
-          limit: params?.limit || 10,
-          season_id: params?.season_id || undefined,
-        },
+    const { data } = await apiClient.get<
+      ReportHistoryResponse | ApiEnvelope<ReportHistoryResponse>
+    >("/reports/history", {
+      params: {
+        page: params?.page || 1,
+        limit: params?.limit || 10,
+        season_id: params?.season_id || undefined,
       },
-    );
-    return data;
+    });
+    const payload = (data as ApiEnvelope<ReportHistoryResponse>)?.data || data;
+    const history = payload as ReportHistoryResponse;
+    return {
+      jobs: history?.jobs || [],
+      total: history?.total || 0,
+      page: history?.page || params?.page || 1,
+      limit: history?.limit || params?.limit || 10,
+    };
   },
 
   getJob: async (id: string): Promise<ReportJob> => {
-    const { data } = await apiClient.get<ReportJob>(`/reports/jobs/${id}`);
-    return data;
+    const { data } = await apiClient.get<ReportJob | ApiEnvelope<ReportJob>>(
+      `/reports/jobs/${id}`,
+    );
+    const payload = (data as ApiEnvelope<ReportJob>)?.data || data;
+    return payload as ReportJob;
   },
 
   downloadClientsPdfDirect: async (seasonId?: string): Promise<Blob> => {


### PR DESCRIPTION
## Descrição das Mudanças

Correções complementares para a Central de Exportações (#86):

1. **Desduplicação do Banner de Testes**:
   - O `<TenantStatusBanner />` já é renderizado globalmente no `AppLayout`. Foi removida a instância duplicada dentro de `ExportsPage.tsx`.

2. **Sincronização com o Evento Ativo do Topbar**:
   - Removido o seletor `<Select>` de eventos que ficava no corpo da `ExportsPage`.
   - A página agora consome exclusivamente `activeSeason` de `useSeasonStore` (selecionado no topo da tela), impedindo seleção concorrente.
   - Exibição de um `Chip` informativo do evento ativo no cabeçalho.

3. **Correção na Exibição do Histórico de Exportações**:
   - Corrigido o desempacotamento do envelope `ApiEnvelope` (`data.data`) em `report.service.ts` e `ExportHistoryTable.tsx`, garantindo que os jobs de exportação e a contagem total sejam exibidos e paginados corretamente na tabela.

### Validação
- `./scripts/check.sh all`: 100% OK (Go tests & vet, Vitest, TypeScript, ESLint e Prettier).