### PR TITLE
style(layout): padronização de margens entre telas e documentação de regras de layout (#86)

### DIFF
--- a/.agents/rules/design-system.md
+++ b/.agents/rules/design-system.md
@@ -97,11 +97,62 @@ Os cabeçalhos devem ser organizados de forma sequencial e descendente, sem pula
 - **Sombras (Elevation)**:
   - Cards padrão: `elevation={0}` com `border: 1px solid #E2E8F0` e sombra leve `0 4px 20px -2px rgba(2, 132, 199, 0.06), 0 2px 6px -1px rgba(0, 0, 0, 0.03)`.
   - Hover de Cards interativos: `transform: translateY(-3px)` e sombra `0 10px 25px -3px rgba(2, 132, 199, 0.12)`.
+---
+
+## 📏 7. Padrão de Margens, Padding e Arquitetura de Layouts de Páginas
+
+Para evitar margens desiguais entre páginas e garantir alinhamento perfeito de todos os componentes com o banner de status e cabeçalhos:
+
+1. **Single Source of Truth para Padding de Páginas (`AppLayout.tsx`)**:
+   - O container principal da aplicação (`AppLayout.tsx`) é o **único responsável** por gerenciar o padding externo de tela:
+     ```tsx
+     <Box
+       sx={{
+         flex: 1,
+         p: { xs: 1.5, sm: 2.5, md: 3 },
+         minWidth: 0,
+         maxWidth: "100%",
+       }}
+     >
+       <Box sx={{ maxWidth: 1600, mx: "auto", width: "100%" }}>
+         <TenantStatusBanner />
+         <Outlet />
+       </Box>
+     </Box>
+     ```
+   - Isso garante que o `TenantStatusBanner` e o `<Outlet />` compartilhem **sempre** a mesma largura máxima (`maxWidth: 1600`) e o mesmo espaçamento lateral em qualquer resolução.
+
+2. **Regra de Ouro para Componentes de Página (`*Page.tsx`)**:
+   - **Nunca** adicione padding externo (`p: ...`) no `<Box>` raiz de uma página (`*Page.tsx`).
+   - Isso provocaria **padding duplo** (padding dentro de padding), fazendo com que a página ficasse desalinhada com o banner de status e mais estreita que outras telas.
+   - O `<Box>` raiz de qualquer página deve ser:
+     ```tsx
+     <Box sx={{ width: "100%" }}>
+     ```
+     *(Apenas páginas de formulário/perfil estritamente restritas podem aplicar `maxWidth: 1000, mx: "auto"`, mas **sempre sem `p: ...`**)*.
+
+3. **Semântica Válida em Modais e Diálogos (Prevenção de Erros de Hidratação)**:
+   - No Material-UI, o `<DialogTitle>` renderiza por padrão uma tag `<h2>`.
+   - **Nunca** insira `<Typography variant="h6">` (ou qualquer outro heading) dentro de `<DialogTitle>` sem especificar `component="div"` ou `component="span"`:
+     ```tsx
+     {/* ✅ Correto */}
+     <DialogTitle
+       component="div"
+       sx={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}
+     >
+       <Typography variant="h6" component="span">
+         {t("titulo")}
+       </Typography>
+     </DialogTitle>
+     ```
+   - O aninhamento incorreto gera `<h2><h6>...</h6></h2>` no DOM, violando a especificação HTML e disparando erro de hidratação no React.
 
 ---
 
-## 🚫 7. O que NÃO Fazer
+## 🚫 8. O que NÃO Fazer
 
+- ❌ **Não adicionar padding externo (`p: ...`) na raiz de páginas dentro do `<Outlet />`** (o `AppLayout` já gerencia o espaçamento de forma centralizada).
+- ❌ **Não aninhar `<Typography variant="h6">` dentro de `<DialogTitle>`** sem configurar `component="div"` ou `component="span"`.
 - ❌ Não usar texto branco sobre cores claras como `#4CFCF7` ou `#A7F3D0` (exigem texto escuro `#064E3B` ou `#0F172A`).
 - ❌ Não usar texto azul claro sobre fundo branco em botões (usar `#0369A1` ou `#0F172A` para manter contraste > 4.5:1).
 - ❌ Não pular níveis de heading (ex.: ir direto de `h1` para `h6` ou `h4` para `h6`).

--- a/frontend/src/features/admin/pages/AdminTenantsPage.tsx
+++ b/frontend/src/features/admin/pages/AdminTenantsPage.tsx
@@ -249,7 +249,7 @@ export const AdminTenantsPage = () => {
   );
 
   return (
-    <Box sx={{ p: { xs: 2, sm: 3 } }}>
+    <Box sx={{ width: "100%" }}>
       {/* Header */}
       <Box
         sx={{

--- a/frontend/src/features/admin/pages/AdminUsersPage.tsx
+++ b/frontend/src/features/admin/pages/AdminUsersPage.tsx
@@ -139,7 +139,7 @@ export const AdminUsersPage = () => {
   });
 
   return (
-    <Box sx={{ p: { xs: 2, sm: 3 } }}>
+    <Box sx={{ width: "100%" }}>
       {/* Header */}
       <Box
         sx={{

--- a/frontend/src/features/clients/pages/ClientDetailsPage.tsx
+++ b/frontend/src/features/clients/pages/ClientDetailsPage.tsx
@@ -244,13 +244,13 @@ export const ClientDetailsPage = () => {
 
   if (!client)
     return (
-      <Box sx={{ p: 3 }}>
+      <Box sx={{ width: "100%" }}>
         <Typography>{t("shared.loading")}</Typography>
       </Box>
     );
 
   return (
-    <Box sx={{ p: 3, maxWidth: 1200, margin: "0 auto" }}>
+    <Box sx={{ width: "100%", maxWidth: 1200, mx: "auto" }}>
       <Box
         sx={{
           display: "flex",

--- a/frontend/src/features/clients/pages/ClientsPage.tsx
+++ b/frontend/src/features/clients/pages/ClientsPage.tsx
@@ -389,7 +389,7 @@ export const ClientsPage = () => {
   }
 
   return (
-    <Box sx={{ p: { xs: 1.5, sm: 2.5, md: 3 } }}>
+    <Box sx={{ width: "100%" }}>
       <Box
         sx={{
           display: "flex",

--- a/frontend/src/features/dashboard/pages/DashboardPage.tsx
+++ b/frontend/src/features/dashboard/pages/DashboardPage.tsx
@@ -388,7 +388,7 @@ export const DashboardPage = () => {
   }, [people.length, allSeasonClients]);
 
   return (
-    <Box sx={{ maxWidth: 1600, margin: "0 auto", width: "100%" }}>
+    <Box sx={{ width: "100%" }}>
       {/* Top Header Row with Compact Overview Toggle */}
       <Box
         sx={{

--- a/frontend/src/features/exports/pages/ExportsPage.tsx
+++ b/frontend/src/features/exports/pages/ExportsPage.tsx
@@ -188,7 +188,7 @@ export const ExportsPage: React.FC = () => {
   };
 
   return (
-    <Box sx={{ p: { xs: 2, md: 3 }, maxWidth: 1400, mx: "auto" }}>
+    <Box sx={{ width: "100%" }}>
       {/* Page Header */}
       <Box
         sx={{

--- a/frontend/src/features/people/pages/PeoplePage.tsx
+++ b/frontend/src/features/people/pages/PeoplePage.tsx
@@ -153,7 +153,7 @@ export const PeoplePage = () => {
   };
 
   return (
-    <Box sx={{ p: { xs: 1.5, sm: 2.5, md: 3 } }}>
+    <Box sx={{ width: "100%" }}>
       <Box
         sx={{
           display: "flex",

--- a/frontend/src/features/people/pages/PersonDetailsPage.tsx
+++ b/frontend/src/features/people/pages/PersonDetailsPage.tsx
@@ -586,7 +586,7 @@ export const PersonDetailsPage = () => {
   }
 
   return (
-    <Box sx={{ p: { xs: 2, md: 3 }, maxWidth: 1600, margin: "0 auto" }}>
+    <Box sx={{ width: "100%" }}>
       {/* Top Navigation & Person Header */}
       <Paper
         elevation={0}

--- a/frontend/src/features/photographers/pages/PhotographersPage.tsx
+++ b/frontend/src/features/photographers/pages/PhotographersPage.tsx
@@ -153,7 +153,7 @@ export const PhotographersPage = () => {
   };
 
   return (
-    <Box sx={{ p: { xs: 1.5, sm: 2.5, md: 3 } }}>
+    <Box sx={{ width: "100%" }}>
       <Box
         sx={{
           display: "flex",

--- a/frontend/src/features/profile/pages/ProfilePage.tsx
+++ b/frontend/src/features/profile/pages/ProfilePage.tsx
@@ -202,7 +202,7 @@ export function ProfilePage() {
   const isEmailVerified = Boolean(profileData?.user?.emailVerified);
 
   return (
-    <Box sx={{ p: { xs: 2, sm: 3, md: 4 }, maxWidth: 1000, mx: "auto" }}>
+    <Box sx={{ width: "100%", maxWidth: 1000, mx: "auto" }}>
       {/* Page Title */}
       <Box sx={{ mb: 4 }}>
         <Typography

--- a/frontend/src/features/seasons/pages/SeasonsPage.tsx
+++ b/frontend/src/features/seasons/pages/SeasonsPage.tsx
@@ -228,7 +228,7 @@ export const SeasonsPage = () => {
   };
 
   return (
-    <Box sx={{ p: { xs: 1.5, sm: 2.5, md: 3 } }}>
+    <Box sx={{ width: "100%" }}>
       <Box
         sx={{
           display: "flex",

--- a/frontend/src/layouts/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout.tsx
@@ -69,8 +69,10 @@ export function AppLayout() {
             maxWidth: "100%",
           }}
         >
-          <TenantStatusBanner />
-          <Outlet />
+          <Box sx={{ maxWidth: 1600, mx: "auto", width: "100%" }}>
+            <TenantStatusBanner />
+            <Outlet />
+          </Box>
         </Box>
       </Box>
     </Box>


### PR DESCRIPTION
## Descrição das Mudanças

### 1. Padronização de Margens e Layouts
- **Single Source of Truth para Padding**: O container principal em `AppLayout.tsx` passa a gerenciar de forma centralizada o padding externo (`p: { xs: 1.5, sm: 2.5, md: 3 }`) e a largura máxima unificada (`maxWidth: 1600, mx: "auto"`).
- **Remoção de Padding Duplo nas Páginas**:
  - Removido o padding redundante (`p: ...`) no `<Box>` raiz de todas as telas (`AdminTenantsPage`, `AdminUsersPage`, `DashboardPage`, `SeasonsPage`, `PhotographersPage`, `PeoplePage`, `ClientsPage`, `ExportsPage`, `PersonDetailsPage`, `ClientDetailsPage` e `ProfilePage`).
  - Todas as páginas agora começam no mesmo ponto horizontal (`sx={{ width: "100%" }}`), alinhando perfeitamente os títulos, tabelas, cards e buscas com o `TenantStatusBanner`.

### 2. Documentação nas Regras de Design (`.agents/rules/design-system.md`)
- Adicionada a **Seção 7 (Padrão de Margens, Padding e Arquitetura de Layouts de Páginas)** documentando:
  - Centralização de padding no `AppLayout`.
  - Proibição de padding duplo nas páginas `*Page.tsx`.
  - Semântica de headings e prevenção de aninhamento inválido de `Typography` dentro de `DialogTitle`.
- Atualizada a seção **O que NÃO Fazer** com essas novas regras obrigatórias.

### 3. Validação
- `./scripts/check.sh all`: 100% OK (Go tests & vet, Vitest, TypeScript, ESLint e Prettier).