### PR TITLE
feat(exports): consolida rotulos dos botoes de exportacao para consolidado e relatorio geral

### DIFF
--- a/frontend/src/features/exports/pages/ExportsPage.test.tsx
+++ b/frontend/src/features/exports/pages/ExportsPage.test.tsx
@@ -93,7 +93,9 @@ describe("ExportsPage", () => {
       ).toBeInTheDocument();
     });
 
-    const exportCsvBtn = screen.getByRole("button", { name: /exportar csv/i });
+    const exportCsvBtn = screen.getByRole("button", {
+      name: /exportar relatório geral/i,
+    });
     fireEvent.click(exportCsvBtn);
 
     await waitFor(() => {
@@ -125,7 +127,7 @@ describe("ExportsPage", () => {
 
     await waitFor(() => {
       const exportCsvBtn = screen.getByRole("button", {
-        name: /exportar csv/i,
+        name: /exportar relatório geral/i,
       });
       expect(exportCsvBtn).toBeDisabled();
     });
@@ -179,7 +181,9 @@ describe("ExportsPage", () => {
     ).not.toBeInTheDocument();
 
     // Trigger CSV export and verify it uses active season ID
-    const exportCsvBtn = screen.getByRole("button", { name: /exportar csv/i });
+    const exportCsvBtn = screen.getByRole("button", {
+      name: /exportar relatório geral/i,
+    });
     fireEvent.click(exportCsvBtn);
 
     await waitFor(() => {
@@ -207,9 +211,9 @@ describe("ExportsPage", () => {
       screen.queryByRole("button", { name: /download direto/i }),
     ).not.toBeInTheDocument();
 
-    // Trigger async PDF export via "Solicitar via E-mail"
+    // Trigger async PDF export via "Exportar Consolidado"
     const asyncPdfBtn = screen.getByRole("button", {
-      name: /solicitar via e-mail/i,
+      name: /exportar consolidado/i,
     });
     fireEvent.click(asyncPdfBtn);
 

--- a/frontend/src/locales/en-US/translation.json
+++ b/frontend/src/locales/en-US/translation.json
@@ -584,12 +584,12 @@
         "title": "Consolidated Report (PDF)",
         "description": "Comprehensive document formatted in landscape A4 with clients, dogs, photos, judges, and payments.",
         "actionDirect": "Direct Download",
-        "actionAsync": "Request by Email"
+        "actionAsync": "Export Consolidated"
       },
       "clientsCsv": {
         "title": "General Clients Report (CSV)",
         "description": "Consolidated Excel-compatible spreadsheet containing all clients and registered photos.",
-        "action": "Export CSV"
+        "action": "Export General Report"
       },
       "paidClientsCsv": {
         "title": "Paid Clients Report (CSV)",

--- a/frontend/src/locales/pt-BR/translation.json
+++ b/frontend/src/locales/pt-BR/translation.json
@@ -584,12 +584,12 @@
         "title": "Relatório Consolidado (PDF)",
         "description": "Documento completo formatado em A4 paisagem com tabela de clientes, cães, fotos, juízes e pagamentos.",
         "actionDirect": "Download Direto",
-        "actionAsync": "Solicitar via E-mail"
+        "actionAsync": "Exportar Consolidado"
       },
       "clientsCsv": {
         "title": "Relatório Geral de Clientes (CSV)",
         "description": "Planilha consolidada compatível com Excel contendo todos os clientes e fotografias cadastradas.",
-        "action": "Exportar CSV"
+        "action": "Exportar Relatório Geral"
       },
       "paidClientsCsv": {
         "title": "Relatório de Clientes Pagos (CSV)",


### PR DESCRIPTION
## 📋 Descrição das Alterações

Consolidação e harmonização dos rótulos dos botões de exportação na **Central de Exportações** (`ExportsPage`):

1. **Relatório Consolidado (PDF)**:
   - Alterado rótulo da ação assíncrona de `Solicitar via E-mail` para **`Exportar Consolidado`** (`pt-BR`) / `Export Consolidated` (`en-US`).
2. **Relatório Geral de Clientes (CSV)**:
   - Alterado rótulo do botão de `Exportar CSV` para **`Exportar Relatório Geral`** (`pt-BR`) / `Export General Report` (`en-US`).
3. **Testes Unitários**:
   - Atualizados os seletores de botões em `ExportsPage.test.tsx` para assegurar conformidade e regressão zero.

Com esta alteração, os cards passam a exibir uma identidade semântica padronizada:
- **Exportar Consolidado**
- **Exportar Relatório Geral**
- **Exportar Pagos**
- **Exportar Não Pagos**
- **Configurar e Exportar**

---

## 🧪 Validações Executadas

- `./scripts/check.sh all`:
  - ✓ **Backend**: 11 pacotes de teste e `go vet` aprovados
  - ✓ **Frontend**: TypeScript (`tsc`), ESLint, Prettier e Vitest 100% aprovados
  - ✓ **Terraform**: `fmt check` aprovado