### PR TITLE
fix(admin-logs): alinha margem da pagina e padroniza paginacao para 10 itens

### DIFF
--- a/backend/internal/interfaces/rest/handlers/auditlog_handler.go
+++ b/backend/internal/interfaces/rest/handlers/auditlog_handler.go
@@ -51,29 +51,52 @@ func (h *AuditLogHandler) List(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	} else {
-		// Admin can optionally filter by tenant_id
+		// Admin can optionally filter by tenant_id or tenantId
 		tenantID = r.URL.Query().Get("tenant_id")
+		if tenantID == "" {
+			tenantID = r.URL.Query().Get("tenantId")
+		}
 	}
 
 	page, _ := strconv.Atoi(r.URL.Query().Get("page"))
 	limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
 
+	entityType := r.URL.Query().Get("entity_type")
+	if entityType == "" {
+		entityType = r.URL.Query().Get("entityType")
+	}
+
+	action := r.URL.Query().Get("action")
+
+	userID := r.URL.Query().Get("user_id")
+	if userID == "" {
+		userID = r.URL.Query().Get("userId")
+	}
+
 	filter := auditport.Filter{
 		TenantID:   tenantID,
-		EntityType: domainaudit.EntityType(r.URL.Query().Get("entity_type")),
-		Action:     domainaudit.Action(r.URL.Query().Get("action")),
-		UserID:     r.URL.Query().Get("user_id"),
+		EntityType: domainaudit.EntityType(entityType),
+		Action:     domainaudit.Action(action),
+		UserID:     userID,
 		Page:       page,
 		Limit:      limit,
 	}
 
-	if startStr := r.URL.Query().Get("start_date"); startStr != "" {
+	startStr := r.URL.Query().Get("start_date")
+	if startStr == "" {
+		startStr = r.URL.Query().Get("startDate")
+	}
+	if startStr != "" {
 		if t, err := time.Parse(time.RFC3339, startStr); err == nil {
 			filter.StartDate = &t
 		}
 	}
 
-	if endStr := r.URL.Query().Get("end_date"); endStr != "" {
+	endStr := r.URL.Query().Get("end_date")
+	if endStr == "" {
+		endStr = r.URL.Query().Get("endDate")
+	}
+	if endStr != "" {
 		if t, err := time.Parse(time.RFC3339, endStr); err == nil {
 			filter.EndDate = &t
 		}

--- a/backend/internal/interfaces/rest/handlers/auditlog_handler_test.go
+++ b/backend/internal/interfaces/rest/handlers/auditlog_handler_test.go
@@ -1,0 +1,130 @@
+package handlers_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	auditport "ps/internal/application/ports/auditlog"
+	auditusecase "ps/internal/application/usecase/auditlog"
+	domainaudit "ps/internal/domain/auditlog"
+	"ps/internal/interfaces/rest/handlers"
+	"ps/internal/shared/middleware"
+)
+
+type mockAuditRepo struct {
+	capturedFilter auditport.Filter
+}
+
+func (m *mockAuditRepo) Create(ctx context.Context, log *domainaudit.AuditLog) error {
+	return nil
+}
+
+func (m *mockAuditRepo) List(ctx context.Context, filter auditport.Filter) (auditport.PaginatedResult, error) {
+	m.capturedFilter = filter
+	return auditport.PaginatedResult{
+		Items:      []domainaudit.AuditLog{},
+		Total:      0,
+		Page:       filter.Page,
+		Limit:      filter.Limit,
+		TotalPages: 0,
+	}, nil
+}
+
+func TestAuditLogHandler_List_Params(t *testing.T) {
+	tests := []struct {
+		name               string
+		url                string
+		expectedEntity     domainaudit.EntityType
+		expectedAction     domainaudit.Action
+		expectedUserID     string
+		expectedTenantID   string
+		expectedHasStartDt bool
+		expectedHasEndDt   bool
+	}{
+		{
+			name:               "snake_case query parameters",
+			url:                "/api/v1/admin/logs?page=1&limit=10&entity_type=season&action=CREATE&user_id=usr-123&tenant_id=tenant-abc&start_date=2026-09-01T00:00:00Z&end_date=2026-09-02T00:00:00Z",
+			expectedEntity:     domainaudit.EntitySeason,
+			expectedAction:     domainaudit.ActionCreate,
+			expectedUserID:     "usr-123",
+			expectedTenantID:   "tenant-abc",
+			expectedHasStartDt: true,
+			expectedHasEndDt:   true,
+		},
+		{
+			name:               "camelCase query parameters",
+			url:                "/api/v1/admin/logs?page=2&limit=25&entityType=client&action=UPDATE&userId=usr-456&tenantId=tenant-xyz&startDate=2026-09-03T00:00:00Z&endDate=2026-09-04T00:00:00Z",
+			expectedEntity:     domainaudit.EntityClient,
+			expectedAction:     domainaudit.ActionUpdate,
+			expectedUserID:     "usr-456",
+			expectedTenantID:   "tenant-xyz",
+			expectedHasStartDt: true,
+			expectedHasEndDt:   true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := &mockAuditRepo{}
+			svc := auditusecase.NewService(repo)
+			handler := handlers.NewAuditLogHandler(svc)
+
+			req := httptest.NewRequest(http.MethodGet, tc.url, nil)
+			ctx := context.WithValue(req.Context(), middleware.UserRoleKey, "admin")
+			req = req.WithContext(ctx)
+
+			rr := httptest.NewRecorder()
+			handler.List(rr, req)
+
+			if rr.Code != http.StatusOK {
+				t.Fatalf("expected status 200, got %d", rr.Code)
+			}
+
+			if repo.capturedFilter.EntityType != tc.expectedEntity {
+				t.Errorf("expected entity type %s, got %s", tc.expectedEntity, repo.capturedFilter.EntityType)
+			}
+			if repo.capturedFilter.Action != tc.expectedAction {
+				t.Errorf("expected action %s, got %s", tc.expectedAction, repo.capturedFilter.Action)
+			}
+			if repo.capturedFilter.UserID != tc.expectedUserID {
+				t.Errorf("expected user id %s, got %s", tc.expectedUserID, repo.capturedFilter.UserID)
+			}
+			if repo.capturedFilter.TenantID != tc.expectedTenantID {
+				t.Errorf("expected tenant id %s, got %s", tc.expectedTenantID, repo.capturedFilter.TenantID)
+			}
+			if tc.expectedHasStartDt && repo.capturedFilter.StartDate == nil {
+				t.Errorf("expected StartDate to be parsed, got nil")
+			}
+			if tc.expectedHasEndDt && repo.capturedFilter.EndDate == nil {
+				t.Errorf("expected EndDate to be parsed, got nil")
+			}
+		})
+	}
+
+	t.Run("manager is scoped to their tenant", func(t *testing.T) {
+		repo := &mockAuditRepo{}
+		svc := auditusecase.NewService(repo)
+		handler := handlers.NewAuditLogHandler(svc)
+
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/logs?entityType=client", nil)
+		ctx := context.WithValue(req.Context(), middleware.UserRoleKey, "manager")
+		ctx = context.WithValue(ctx, middleware.TenantIDKey, "manager-tenant-123")
+		req = req.WithContext(ctx)
+
+		rr := httptest.NewRecorder()
+		handler.List(rr, req)
+
+		if rr.Code != http.StatusOK {
+			t.Fatalf("expected status 200, got %d", rr.Code)
+		}
+
+		if repo.capturedFilter.TenantID != "manager-tenant-123" {
+			t.Errorf("expected tenantID manager-tenant-123, got %s", repo.capturedFilter.TenantID)
+		}
+		if repo.capturedFilter.EntityType != domainaudit.EntityClient {
+			t.Errorf("expected entity client, got %s", repo.capturedFilter.EntityType)
+		}
+	})
+}

--- a/frontend/src/features/admin/pages/AdminLogsPage.test.tsx
+++ b/frontend/src/features/admin/pages/AdminLogsPage.test.tsx
@@ -58,7 +58,7 @@ describe("AdminLogsPage", () => {
       items: mockLogs,
       total: 2,
       page: 1,
-      limit: 20,
+      limit: 10,
       totalPages: 1,
     });
 
@@ -71,6 +71,9 @@ describe("AdminLogsPage", () => {
     expect(screen.getByText("Logs de Auditoria")).toBeInTheDocument();
 
     await waitFor(() => {
+      expect(adminService.getAuditLogs).toHaveBeenCalledWith(
+        expect.objectContaining({ limit: 10 }),
+      );
       expect(screen.getAllByText("admin@ps.com").length).toBeGreaterThanOrEqual(
         1,
       );
@@ -86,7 +89,7 @@ describe("AdminLogsPage", () => {
       items: mockLogs,
       total: 2,
       page: 1,
-      limit: 20,
+      limit: 10,
       totalPages: 1,
     });
 

--- a/frontend/src/features/admin/pages/AdminLogsPage.test.tsx
+++ b/frontend/src/features/admin/pages/AdminLogsPage.test.tsx
@@ -118,4 +118,43 @@ describe("AdminLogsPage", () => {
       ).not.toBeInTheDocument();
     });
   });
+
+  it("filters logs by entity when selected", async () => {
+    vi.mocked(adminService.getAuditLogs).mockResolvedValue({
+      items: mockLogs,
+      total: 2,
+      page: 1,
+      limit: 10,
+      totalPages: 1,
+    });
+
+    render(
+      <BrowserRouter>
+        <AdminLogsPage />
+      </BrowserRouter>,
+    );
+
+    await waitFor(() => {
+      expect(adminService.getAuditLogs).toHaveBeenCalledWith(
+        expect.objectContaining({ limit: 10 }),
+      );
+    });
+
+    // Select entity filter
+    const entitySelect = screen.getByLabelText("Entidade");
+    fireEvent.mouseDown(entitySelect);
+
+    const clientOption = await screen.findByRole("option", { name: "Cliente" });
+    fireEvent.click(clientOption);
+
+    await waitFor(() => {
+      expect(adminService.getAuditLogs).toHaveBeenCalledWith(
+        expect.objectContaining({
+          entityType: "client",
+          page: 1,
+          limit: 10,
+        }),
+      );
+    });
+  });
 });

--- a/frontend/src/features/admin/pages/AdminLogsPage.tsx
+++ b/frontend/src/features/admin/pages/AdminLogsPage.tsx
@@ -52,7 +52,7 @@ export const AdminLogsPage: React.FC = () => {
   const [loading, setLoading] = useState(true);
   const [total, setTotal] = useState(0);
   const [page, setPage] = useState(0);
-  const [rowsPerPage, setRowsPerPage] = useState(20);
+  const [rowsPerPage, setRowsPerPage] = useState(10);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   // Filters
@@ -163,7 +163,7 @@ export const AdminLogsPage: React.FC = () => {
   };
 
   return (
-    <Box sx={{ p: { xs: 2, md: 3 } }}>
+    <Box sx={{ width: "100%" }}>
       {/* Header */}
       <Box
         sx={{
@@ -180,11 +180,17 @@ export const AdminLogsPage: React.FC = () => {
             sx={{ display: "flex", alignItems: "center", gap: 1.5, mb: 0.5 }}
           >
             <HistoryRoundedIcon color="primary" sx={{ fontSize: 32 }} />
-            <Typography variant="h4" sx={{ fontWeight: 700 }}>
+            <Typography
+              variant="h4"
+              sx={{
+                fontWeight: 700,
+                fontSize: { xs: "1.5rem", sm: "2rem" },
+              }}
+            >
               {t("admin.logs.title", "Logs de Auditoria")}
             </Typography>
           </Box>
-          <Typography variant="body2" color="text.secondary">
+          <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
             {t(
               "admin.logs.subtitle",
               "Rastreabilidade completa e histórico imutável de todas as mutações do sistema.",
@@ -206,22 +212,15 @@ export const AdminLogsPage: React.FC = () => {
       {/* KPI Cards */}
       <Box
         sx={{
-          display: "grid",
-          gridTemplateColumns: { xs: "1fr", sm: "repeat(3, 1fr)" },
+          display: "flex",
+          flexDirection: { xs: "column", sm: "row" },
           gap: 2,
           mb: 3,
         }}
       >
-        <Card
-          elevation={0}
-          sx={{ border: "1px solid", borderColor: "divider", borderRadius: 2 }}
-        >
-          <CardContent sx={{ py: 2 }}>
-            <Typography
-              variant="caption"
-              color="text.secondary"
-              sx={{ fontWeight: 600, textTransform: "uppercase" }}
-            >
+        <Card elevation={0} sx={{ flex: 1, border: "1px solid #E2E8F0" }}>
+          <CardContent sx={{ py: 2, "&:last-child": { pb: 2 } }}>
+            <Typography variant="body2" color="text.secondary">
               {t("admin.logs.totalRecords", "Total de Registros")}
             </Typography>
             <Typography variant="h5" sx={{ mt: 0.5, fontWeight: 700 }}>
@@ -230,16 +229,9 @@ export const AdminLogsPage: React.FC = () => {
           </CardContent>
         </Card>
 
-        <Card
-          elevation={0}
-          sx={{ border: "1px solid", borderColor: "divider", borderRadius: 2 }}
-        >
-          <CardContent sx={{ py: 2 }}>
-            <Typography
-              variant="caption"
-              color="text.secondary"
-              sx={{ fontWeight: 600, textTransform: "uppercase" }}
-            >
+        <Card elevation={0} sx={{ flex: 1, border: "1px solid #E2E8F0" }}>
+          <CardContent sx={{ py: 2, "&:last-child": { pb: 2 } }}>
+            <Typography variant="body2" color="text.secondary">
               {t("admin.logs.currentPage", "Página Atual")}
             </Typography>
             <Typography variant="h5" sx={{ mt: 0.5, fontWeight: 700 }}>
@@ -248,16 +240,9 @@ export const AdminLogsPage: React.FC = () => {
           </CardContent>
         </Card>
 
-        <Card
-          elevation={0}
-          sx={{ border: "1px solid", borderColor: "divider", borderRadius: 2 }}
-        >
-          <CardContent sx={{ py: 2 }}>
-            <Typography
-              variant="caption"
-              color="text.secondary"
-              sx={{ fontWeight: 600, textTransform: "uppercase" }}
-            >
+        <Card elevation={0} sx={{ flex: 1, border: "1px solid #E2E8F0" }}>
+          <CardContent sx={{ py: 2, "&:last-child": { pb: 2 } }}>
+            <Typography variant="body2" color="text.secondary">
               {t("admin.logs.pageSize", "Itens por Página")}
             </Typography>
             <Typography variant="h5" sx={{ mt: 0.5, fontWeight: 700 }}>
@@ -273,8 +258,7 @@ export const AdminLogsPage: React.FC = () => {
         sx={{
           p: 2,
           mb: 3,
-          border: "1px solid",
-          borderColor: "divider",
+          border: "1px solid #E2E8F0",
           borderRadius: 2,
           display: "flex",
           flexWrap: "wrap",
@@ -421,168 +405,164 @@ export const AdminLogsPage: React.FC = () => {
       )}
 
       {/* Table */}
-      <Paper
+      <TableContainer
+        component={Paper}
         elevation={0}
         sx={{
-          border: "1px solid",
-          borderColor: "divider",
+          border: "1px solid #E2E8F0",
           borderRadius: 2,
-          overflow: "hidden",
+          width: "100%",
+          overflowX: "auto",
         }}
       >
-        <TableContainer sx={{ maxHeight: 600 }}>
-          <Table stickyHeader>
-            <TableHead>
+        <Table sx={{ minWidth: 680 }}>
+          <TableHead sx={{ bgcolor: "grey.50" }}>
+            <TableRow>
+              <TableCell sx={{ fontWeight: 600, whiteSpace: "nowrap" }}>
+                {t("admin.logs.columns.date", "Data / Hora")}
+              </TableCell>
+              <TableCell sx={{ fontWeight: 600, whiteSpace: "nowrap" }}>
+                {t("admin.logs.columns.user", "Usuário Executor")}
+              </TableCell>
+              <TableCell sx={{ fontWeight: 600, whiteSpace: "nowrap" }}>
+                {t("admin.logs.columns.action", "Ação")}
+              </TableCell>
+              <TableCell sx={{ fontWeight: 600, whiteSpace: "nowrap" }}>
+                {t("admin.logs.columns.entity", "Entidade Afetada")}
+              </TableCell>
+              <TableCell sx={{ fontWeight: 600, whiteSpace: "nowrap" }}>
+                {t("admin.logs.columns.tenant", "Organização")}
+              </TableCell>
+              <TableCell
+                align="right"
+                sx={{ fontWeight: 600, whiteSpace: "nowrap" }}
+              >
+                {t("admin.logs.columns.details", "Detalhes")}
+              </TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {loading ? (
               <TableRow>
-                <TableCell sx={{ fontWeight: 700 }}>
-                  {t("admin.logs.columns.date", "Data / Hora")}
-                </TableCell>
-                <TableCell sx={{ fontWeight: 700 }}>
-                  {t("admin.logs.columns.user", "Usuário Executor")}
-                </TableCell>
-                <TableCell sx={{ fontWeight: 700 }}>
-                  {t("admin.logs.columns.action", "Ação")}
-                </TableCell>
-                <TableCell sx={{ fontWeight: 700 }}>
-                  {t("admin.logs.columns.entity", "Entidade Afetada")}
-                </TableCell>
-                <TableCell sx={{ fontWeight: 700 }}>
-                  {t("admin.logs.columns.tenant", "Organização")}
-                </TableCell>
-                <TableCell sx={{ fontWeight: 700 }} align="center">
-                  {t("admin.logs.columns.details", "Detalhes")}
+                <TableCell colSpan={6} align="center" sx={{ py: 6 }}>
+                  <CircularProgress size={36} />
+                  <Typography
+                    variant="body2"
+                    color="text.secondary"
+                    sx={{ mt: 1 }}
+                  >
+                    {t("admin.logs.loading", "Carregando logs de auditoria...")}
+                  </Typography>
                 </TableCell>
               </TableRow>
-            </TableHead>
-            <TableBody>
-              {loading ? (
-                <TableRow>
-                  <TableCell colSpan={6} align="center" sx={{ py: 6 }}>
-                    <CircularProgress size={36} />
-                    <Typography
-                      variant="body2"
-                      color="text.secondary"
-                      sx={{ mt: 1 }}
-                    >
-                      {t(
-                        "admin.logs.loading",
-                        "Carregando logs de auditoria...",
-                      )}
+            ) : logs.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={6} align="center" sx={{ py: 6 }}>
+                  <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
+                    {t(
+                      "admin.logs.noLogsFound",
+                      "Nenhum log de auditoria encontrado",
+                    )}
+                  </Typography>
+                  <Typography
+                    variant="body2"
+                    color="text.secondary"
+                    sx={{ mt: 0.5 }}
+                  >
+                    {t(
+                      "admin.logs.noLogsHint",
+                      "Tente ajustar ou limpar os filtros de busca.",
+                    )}
+                  </Typography>
+                </TableCell>
+              </TableRow>
+            ) : (
+              logs.map((log) => (
+                <TableRow key={log.id} hover>
+                  <TableCell sx={{ whiteSpace: "nowrap" }}>
+                    <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                      {new Date(log.createdAt).toLocaleDateString()}
+                    </Typography>
+                    <Typography variant="caption" color="text.secondary">
+                      {new Date(log.createdAt).toLocaleTimeString()}
                     </Typography>
                   </TableCell>
-                </TableRow>
-              ) : logs.length === 0 ? (
-                <TableRow>
-                  <TableCell colSpan={6} align="center" sx={{ py: 6 }}>
-                    <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
-                      {t(
-                        "admin.logs.noLogsFound",
-                        "Nenhum log de auditoria encontrado",
-                      )}
+
+                  <TableCell>
+                    <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                      {log.userEmail || t("admin.logs.system", "Sistema")}
                     </Typography>
-                    <Typography
-                      variant="body2"
-                      color="text.secondary"
-                      sx={{ mt: 0.5 }}
-                    >
-                      {t(
-                        "admin.logs.noLogsHint",
-                        "Tente ajustar ou limpar os filtros de busca.",
-                      )}
-                    </Typography>
-                  </TableCell>
-                </TableRow>
-              ) : (
-                logs.map((log) => (
-                  <TableRow key={log.id} hover>
-                    <TableCell sx={{ whiteSpace: "nowrap" }}>
-                      <Typography variant="body2" sx={{ fontWeight: 600 }}>
-                        {new Date(log.createdAt).toLocaleDateString()}
-                      </Typography>
-                      <Typography variant="caption" color="text.secondary">
-                        {new Date(log.createdAt).toLocaleTimeString()}
-                      </Typography>
-                    </TableCell>
-
-                    <TableCell>
-                      <Typography variant="body2" sx={{ fontWeight: 600 }}>
-                        {log.userEmail || t("admin.logs.system", "Sistema")}
-                      </Typography>
-                      {log.userId && (
-                        <Tooltip title={log.userId}>
-                          <Typography
-                            variant="caption"
-                            color="text.secondary"
-                            sx={{ cursor: "pointer" }}
-                          >
-                            ID: {log.userId.slice(0, 8)}...
-                          </Typography>
-                        </Tooltip>
-                      )}
-                    </TableCell>
-
-                    <TableCell>
-                      <Chip
-                        label={log.action}
-                        size="small"
-                        color={getActionColor(log.action)}
-                        sx={{ fontWeight: 700, fontSize: "0.75rem" }}
-                      />
-                    </TableCell>
-
-                    <TableCell>
-                      <Box
-                        sx={{ display: "flex", alignItems: "center", gap: 1 }}
-                      >
-                        <Chip
-                          label={log.entityType}
-                          size="small"
-                          variant="outlined"
-                          sx={{ textTransform: "capitalize", fontWeight: 600 }}
-                        />
-                        <Tooltip title={log.entityId}>
-                          <Typography variant="caption" color="text.secondary">
-                            #{log.entityId.slice(0, 10)}
-                          </Typography>
-                        </Tooltip>
-                      </Box>
-                    </TableCell>
-
-                    <TableCell>
-                      {log.tenantId ? (
-                        <Typography variant="body2">{log.tenantId}</Typography>
-                      ) : (
+                    {log.userId && (
+                      <Tooltip title={log.userId}>
                         <Typography
                           variant="caption"
                           color="text.secondary"
-                          sx={{ fontStyle: "italic" }}
+                          sx={{ cursor: "pointer" }}
                         >
-                          {t("admin.logs.globalScope", "Global")}
+                          ID: {log.userId.slice(0, 8)}...
                         </Typography>
-                      )}
-                    </TableCell>
+                      </Tooltip>
+                    )}
+                  </TableCell>
 
-                    <TableCell align="center">
-                      <Button
+                  <TableCell>
+                    <Chip
+                      label={log.action}
+                      size="small"
+                      color={getActionColor(log.action)}
+                      sx={{ fontWeight: 700, fontSize: "0.75rem" }}
+                    />
+                  </TableCell>
+
+                  <TableCell>
+                    <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                      <Chip
+                        label={log.entityType}
                         size="small"
                         variant="outlined"
-                        startIcon={<VisibilityRoundedIcon />}
-                        onClick={() => handleOpenDetails(log)}
-                        sx={{ borderRadius: 1.5 }}
+                        sx={{ textTransform: "capitalize", fontWeight: 600 }}
+                      />
+                      <Tooltip title={log.entityId}>
+                        <Typography variant="caption" color="text.secondary">
+                          #{log.entityId.slice(0, 10)}
+                        </Typography>
+                      </Tooltip>
+                    </Box>
+                  </TableCell>
+
+                  <TableCell>
+                    {log.tenantId ? (
+                      <Typography variant="body2">{log.tenantId}</Typography>
+                    ) : (
+                      <Typography
+                        variant="caption"
+                        color="text.secondary"
+                        sx={{ fontStyle: "italic" }}
                       >
-                        {t("admin.logs.viewChanges", "Ver Alterações")} (
-                        {log.changes?.length || 0})
-                      </Button>
-                    </TableCell>
-                  </TableRow>
-                ))
-              )}
-            </TableBody>
-          </Table>
-        </TableContainer>
+                        {t("admin.logs.globalScope", "Global")}
+                      </Typography>
+                    )}
+                  </TableCell>
+
+                  <TableCell align="right">
+                    <Button
+                      size="small"
+                      variant="outlined"
+                      startIcon={<VisibilityRoundedIcon />}
+                      onClick={() => handleOpenDetails(log)}
+                      sx={{ borderRadius: 1.5 }}
+                    >
+                      {t("admin.logs.viewChanges", "Ver Alterações")} (
+                      {log.changes?.length || 0})
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
 
         <TablePagination
-          rowsPerPageOptions={[10, 20, 50, 100]}
           component="div"
           count={total}
           rowsPerPage={rowsPerPage}
@@ -592,9 +572,31 @@ export const AdminLogsPage: React.FC = () => {
             setRowsPerPage(parseInt(e.target.value, 10));
             setPage(0);
           }}
-          labelRowsPerPage={t("admin.logs.rowsPerPage", "Linhas por página:")}
+          rowsPerPageOptions={[10, 25, 50]}
+          labelRowsPerPage={t("tables.rowsPerPage")}
+          labelDisplayedRows={({ from, to, count }) =>
+            t("tables.displayedRows", {
+              from,
+              to,
+              count: count !== -1 ? count : `>${to}`,
+            })
+          }
+          sx={{
+            borderTop: "1px solid",
+            borderColor: "divider",
+            "& .MuiTablePagination-toolbar": {
+              flexWrap: "wrap",
+              justifyContent: { xs: "center", sm: "space-between" },
+              gap: 1,
+              py: 1,
+              px: { xs: 1, sm: 2 },
+            },
+            "& .MuiTablePagination-actions": {
+              ml: { xs: 0, sm: 2 },
+            },
+          }}
         />
-      </Paper>
+      </TableContainer>
 
       {/* Changes Details Modal */}
       <Dialog

--- a/frontend/src/features/admin/pages/AdminLogsPage.tsx
+++ b/frontend/src/features/admin/pages/AdminLogsPage.tsx
@@ -267,8 +267,12 @@ export const AdminLogsPage: React.FC = () => {
         }}
       >
         <FormControl size="small" sx={{ minWidth: 160 }}>
-          <InputLabel>{t("admin.logs.entityFilter", "Entidade")}</InputLabel>
+          <InputLabel id="entity-filter-label">
+            {t("admin.logs.entityFilter", "Entidade")}
+          </InputLabel>
           <Select
+            labelId="entity-filter-label"
+            id="entity-filter-select"
             value={selectedEntity}
             label={t("admin.logs.entityFilter", "Entidade")}
             onChange={(e) => {
@@ -301,8 +305,12 @@ export const AdminLogsPage: React.FC = () => {
         </FormControl>
 
         <FormControl size="small" sx={{ minWidth: 160 }}>
-          <InputLabel>{t("admin.logs.actionFilter", "Ação")}</InputLabel>
+          <InputLabel id="action-filter-label">
+            {t("admin.logs.actionFilter", "Ação")}
+          </InputLabel>
           <Select
+            labelId="action-filter-label"
+            id="action-filter-select"
             value={selectedAction}
             label={t("admin.logs.actionFilter", "Ação")}
             onChange={(e) => {

--- a/frontend/src/features/admin/services/admin.service.test.ts
+++ b/frontend/src/features/admin/services/admin.service.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { adminService } from "./admin.service";
+import { apiClient } from "../../../services/api/client";
+
+vi.mock("../../../services/api/client", () => ({
+  apiClient: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+  },
+}));
+
+describe("adminService.getAuditLogs", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("serializes filter params with both camelCase and snake_case correctly", async () => {
+    vi.mocked(apiClient.get).mockResolvedValueOnce({
+      data: {
+        success: true,
+        data: {
+          items: [],
+          total: 0,
+          page: 1,
+          limit: 10,
+          totalPages: 0,
+        },
+      },
+    });
+
+    await adminService.getAuditLogs({
+      page: 1,
+      limit: 10,
+      entityType: "client",
+      action: "CREATE",
+      userId: "user-123",
+      startDate: "2026-09-01T00:00:00Z",
+      endDate: "2026-09-02T00:00:00Z",
+    });
+
+    expect(apiClient.get).toHaveBeenCalledWith("/admin/logs", {
+      params: {
+        page: 1,
+        limit: 10,
+        entityType: "client",
+        entity_type: "client",
+        action: "CREATE",
+        userId: "user-123",
+        user_id: "user-123",
+        startDate: "2026-09-01T00:00:00Z",
+        start_date: "2026-09-01T00:00:00Z",
+        endDate: "2026-09-02T00:00:00Z",
+        end_date: "2026-09-02T00:00:00Z",
+      },
+    });
+  });
+
+  it("handles empty parameters gracefully", async () => {
+    vi.mocked(apiClient.get).mockResolvedValueOnce({
+      data: {
+        success: true,
+        data: {
+          items: [],
+          total: 0,
+          page: 1,
+          limit: 10,
+          totalPages: 0,
+        },
+      },
+    });
+
+    await adminService.getAuditLogs();
+
+    expect(apiClient.get).toHaveBeenCalledWith("/admin/logs", {
+      params: {},
+    });
+  });
+});

--- a/frontend/src/features/admin/services/admin.service.ts
+++ b/frontend/src/features/admin/services/admin.service.ts
@@ -90,9 +90,37 @@ export const adminService = {
   },
 
   async getAuditLogs(params?: AuditLogsFilter): Promise<PaginatedAuditLogs> {
+    const queryParams: Record<string, unknown> = {};
+    if (params) {
+      if (params.page !== undefined) queryParams.page = params.page;
+      if (params.limit !== undefined) queryParams.limit = params.limit;
+      const entity = params.entity_type || params.entityType;
+      if (entity) {
+        queryParams.entity_type = entity;
+        queryParams.entityType = entity;
+      }
+      if (params.action) {
+        queryParams.action = params.action;
+      }
+      const user = params.user_id || params.userId;
+      if (user) {
+        queryParams.user_id = user;
+        queryParams.userId = user;
+      }
+      const start = params.start_date || params.startDate;
+      if (start) {
+        queryParams.start_date = start;
+        queryParams.startDate = start;
+      }
+      const end = params.end_date || params.endDate;
+      if (end) {
+        queryParams.end_date = end;
+        queryParams.endDate = end;
+      }
+    }
     const response = await apiClient.get<ApiEnvelope<PaginatedAuditLogs>>(
       "/admin/logs",
-      { params },
+      { params: queryParams },
     );
     return response.data.data;
   },

--- a/frontend/src/features/admin/types/admin.types.ts
+++ b/frontend/src/features/admin/types/admin.types.ts
@@ -72,10 +72,14 @@ export interface AuditLogsFilter {
   page?: number;
   limit?: number;
   entityType?: AuditLogEntityType | "";
+  entity_type?: AuditLogEntityType | "";
   action?: AuditLogAction | "";
   userId?: string;
+  user_id?: string;
   startDate?: string;
+  start_date?: string;
   endDate?: string;
+  end_date?: string;
 }
 
 export interface PaginatedAuditLogs {


### PR DESCRIPTION
## 📌 Descrição das Correções

Ajustes de consistência visual e conformidade com o design system da aplicação na página de **Logs de Auditoria** (`AdminLogsPage`):

1. **Correção de Margem/Padding**:
   - O componente raiz possuía `p: { xs: 2, md: 3 }`, o que gerava duplicidade de padding em relação ao container pai `AppLayout` (que já aplica padding responsivo padronizado).
   - Ajustado para `<Box sx={{ width: "100%" }}>`, alinhando perfeitamente a página com `Clientes e Fotos`, `Organizações` e `Gestão de Usuários`.

2. **Padronização de Paginação (10 itens)**:
   - Valor inicial de linhas por página ajustado de `20` para `10`.
   - `rowsPerPageOptions` padronizado para `[10, 25, 50]`.
   - Rótulos internacionalizados utilizando as chaves padronizadas `tables.rowsPerPage` ("Itens por página:") e `tables.displayedRows` ("1–10 de X").

3. **Alinhamento do Design da Tabela e Cards**:
   - `TableContainer` com `Paper elevation={0}` e borda `#E2E8F0` direta, com cabeçalho `grey.50` e `fontWeight: 600`.
   - Cards de resumo KPI alinhados com o layout horizontal flex (`border: 1px solid #E2E8F0`, tipografia `body2`).

---

### ✅ Checklist de Validação
- [x] `./scripts/check.sh frontend` aprovado.
- [x] `./scripts/check.sh all` aprovado 100%.