### PR TITLE
fix(profile): ajuste de margens da tela de perfil e atalho de usuario no rodape da sidebar (#95)

### DIFF
--- a/frontend/src/features/profile/pages/ProfilePage.test.tsx
+++ b/frontend/src/features/profile/pages/ProfilePage.test.tsx
@@ -75,4 +75,32 @@ describe("ProfilePage", () => {
       }),
     ).toBeInTheDocument();
   });
+
+  it("renders with full-width container matching layout guidelines", async () => {
+    vi.mocked(profileService.getProfile).mockResolvedValueOnce({
+      user: {
+        id: "user-1",
+        name: "Yuri Nogueira",
+        email: "yuri@ps.com",
+        emailVerified: true,
+        createdAt: "2026-08-25T00:00:00Z",
+      },
+    });
+
+    const { container } = render(
+      <BrowserRouter>
+        <ProfilePage />
+      </BrowserRouter>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Meu Perfil & Configurações"),
+      ).toBeInTheDocument();
+    });
+
+    const rootBox = container.firstChild as HTMLElement;
+    expect(rootBox).toHaveStyle({ width: "100%" });
+    expect(rootBox.style.maxWidth).toBeFalsy();
+  });
 });

--- a/frontend/src/features/profile/pages/ProfilePage.tsx
+++ b/frontend/src/features/profile/pages/ProfilePage.tsx
@@ -202,7 +202,7 @@ export function ProfilePage() {
   const isEmailVerified = Boolean(profileData?.user?.emailVerified);
 
   return (
-    <Box sx={{ width: "100%", maxWidth: 1000, mx: "auto" }}>
+    <Box sx={{ width: "100%" }}>
       {/* Page Title */}
       <Box sx={{ mb: 4 }}>
         <Typography

--- a/frontend/src/layouts/Sidebar.test.tsx
+++ b/frontend/src/layouts/Sidebar.test.tsx
@@ -1,0 +1,164 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { Sidebar } from "./Sidebar";
+import { useAuthStore } from "../features/auth/state/auth.store";
+import { authService } from "../features/auth/services/auth.service";
+import i18n from "../i18n";
+
+vi.mock("../features/auth/services/auth.service", () => ({
+  authService: {
+    logout: vi.fn(),
+  },
+}));
+
+const mockedNavigate = vi.fn();
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual("react-router-dom");
+  return {
+    ...actual,
+    useNavigate: () => mockedNavigate,
+  };
+});
+
+describe("Sidebar Layout and User Profile Footer (Issue #95)", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    await i18n.changeLanguage("pt-BR");
+    useAuthStore.setState({
+      user: {
+        id: "user-1",
+        name: "Yuri Nogueira Moreira",
+        email: "yuri@ps.com",
+        role: "admin",
+      },
+      isAuthenticated: true,
+    });
+  });
+
+  it("renders main navigation items and admin items for admin user", () => {
+    render(
+      <MemoryRouter initialEntries={["/dashboard"]}>
+        <Sidebar
+          mobileOpen={false}
+          onDrawerToggle={vi.fn()}
+          drawerWidth={280}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getAllByText("Visão Geral")[0]).toBeInTheDocument();
+    expect(screen.getAllByText("Eventos")[0]).toBeInTheDocument();
+    expect(screen.getAllByText("Fotógrafos")[0]).toBeInTheDocument();
+    expect(screen.getAllByText("Clientes e Fotos")[0]).toBeInTheDocument();
+    expect(screen.getAllByText("Organizações")[0]).toBeInTheDocument();
+    expect(screen.getAllByText("Gestão de Usuários")[0]).toBeInTheDocument();
+    expect(screen.getAllByText("Logs de Auditoria")[0]).toBeInTheDocument();
+  });
+
+  it("renders user profile footer widget with avatar, name, and email", () => {
+    render(
+      <MemoryRouter initialEntries={["/dashboard"]}>
+        <Sidebar
+          mobileOpen={false}
+          onDrawerToggle={vi.fn()}
+          drawerWidth={280}
+        />
+      </MemoryRouter>,
+    );
+
+    // Profile button
+    const profileBtns = screen.getAllByTestId("sidebar-profile-btn");
+    expect(profileBtns.length).toBeGreaterThan(0);
+
+    // Avatar with user initial
+    expect(screen.getAllByText("Y")[0]).toBeInTheDocument();
+
+    // User name and email with truncation styling
+    const nameEl = screen.getAllByText("Yuri Nogueira Moreira")[0];
+    expect(nameEl).toBeInTheDocument();
+    expect(nameEl).toHaveStyle({
+      whiteSpace: "nowrap",
+      overflow: "hidden",
+      textOverflow: "ellipsis",
+    });
+
+    const emailEl = screen.getAllByText("yuri@ps.com")[0];
+    expect(emailEl).toBeInTheDocument();
+    expect(emailEl).toHaveStyle({
+      whiteSpace: "nowrap",
+      overflow: "hidden",
+      textOverflow: "ellipsis",
+    });
+
+    // Logout button
+    const logoutBtns = screen.getAllByTestId("sidebar-logout-btn");
+    expect(logoutBtns.length).toBeGreaterThan(0);
+  });
+
+  it("navigates to /profile on click and closes drawer when mobileOpen is true", () => {
+    const handleToggle = vi.fn();
+    render(
+      <MemoryRouter initialEntries={["/dashboard"]}>
+        <Sidebar
+          mobileOpen={true}
+          onDrawerToggle={handleToggle}
+          drawerWidth={280}
+        />
+      </MemoryRouter>,
+    );
+
+    const profileBtns = screen.getAllByTestId("sidebar-profile-btn");
+    fireEvent.click(profileBtns[0]);
+
+    expect(handleToggle).toHaveBeenCalled();
+    expect(mockedNavigate).toHaveBeenCalledWith("/profile");
+  });
+
+  it("triggers logout, clears auth store, and redirects to /login", async () => {
+    vi.mocked(authService.logout).mockResolvedValueOnce(undefined);
+    const handleToggle = vi.fn();
+
+    render(
+      <MemoryRouter initialEntries={["/dashboard"]}>
+        <Sidebar
+          mobileOpen={true}
+          onDrawerToggle={handleToggle}
+          drawerWidth={280}
+        />
+      </MemoryRouter>,
+    );
+
+    const logoutBtns = screen.getAllByTestId("sidebar-logout-btn");
+    fireEvent.click(logoutBtns[0]);
+
+    expect(handleToggle).toHaveBeenCalled();
+    expect(authService.logout).toHaveBeenCalled();
+
+    // Wait for async logout handler to complete
+    await vi.waitFor(() => {
+      expect(useAuthStore.getState().user).toBeNull();
+      expect(mockedNavigate).toHaveBeenCalledWith("/login");
+    });
+  });
+
+  it("handles fallback gracefully when user is not defined", () => {
+    useAuthStore.setState({
+      user: null,
+      isAuthenticated: false,
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/dashboard"]}>
+        <Sidebar
+          mobileOpen={false}
+          onDrawerToggle={vi.fn()}
+          drawerWidth={280}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getAllByText("Usuário")[0]).toBeInTheDocument();
+    expect(screen.queryByText("yuri@ps.com")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/layouts/Sidebar.tsx
+++ b/frontend/src/layouts/Sidebar.tsx
@@ -9,6 +9,10 @@ import {
   ListItemIcon,
   ListItemText,
   Typography,
+  Avatar,
+  ButtonBase,
+  IconButton,
+  Tooltip,
 } from "@mui/material";
 import DashboardRoundedIcon from "@mui/icons-material/DashboardRounded";
 import EventNoteRoundedIcon from "@mui/icons-material/EventNoteRounded";
@@ -19,8 +23,11 @@ import AssessmentRoundedIcon from "@mui/icons-material/AssessmentRounded";
 import BusinessRoundedIcon from "@mui/icons-material/BusinessRounded";
 import SupervisorAccountRoundedIcon from "@mui/icons-material/SupervisorAccountRounded";
 import HistoryRoundedIcon from "@mui/icons-material/HistoryRounded";
+import LogoutRoundedIcon from "@mui/icons-material/LogoutRounded";
+import AccountCircleRoundedIcon from "@mui/icons-material/AccountCircleRounded";
 import { useTranslation } from "react-i18next";
 import { useAuthStore } from "../features/auth/state/auth.store";
+import { authService } from "../features/auth/services/auth.service";
 import { getUserRole } from "../features/auth/types/auth.types";
 
 interface SidebarProps {
@@ -38,6 +45,22 @@ export function Sidebar({
   const location = useLocation();
   const navigate = useNavigate();
   const user = useAuthStore((state) => state.user);
+  const clearAuth = useAuthStore((state) => state.clear);
+  const isProfileActive = location.pathname.startsWith("/profile");
+
+  const handleLogout = async () => {
+    if (mobileOpen) {
+      onDrawerToggle();
+    }
+    try {
+      await authService.logout();
+    } catch {
+      // ignore network errors on logout
+    } finally {
+      clearAuth();
+      navigate("/login");
+    }
+  };
 
   const menuItems = [
     {
@@ -249,6 +272,125 @@ export function Sidebar({
           </>
         )}
       </List>
+
+      <Box
+        sx={{
+          p: 1.5,
+          display: "flex",
+          alignItems: "center",
+          gap: 0.5,
+          borderTop: "1px solid #E2E8F0",
+          bgcolor: "background.paper",
+        }}
+      >
+        <ButtonBase
+          onClick={() => handleNavigation("/profile")}
+          aria-label={t("layout.myProfile")}
+          data-testid="sidebar-profile-btn"
+          sx={{
+            flex: 1,
+            display: "flex",
+            alignItems: "center",
+            gap: 1.5,
+            p: 1,
+            borderRadius: 2,
+            minWidth: 0,
+            textAlign: "left",
+            justifyContent: "flex-start",
+            bgcolor: isProfileActive
+              ? "rgba(57, 39, 130, 0.08)"
+              : "transparent",
+            border: isProfileActive
+              ? "1px solid rgba(57, 39, 130, 0.2)"
+              : "1px solid transparent",
+            "&:hover": {
+              bgcolor: isProfileActive
+                ? "rgba(57, 39, 130, 0.12)"
+                : "action.hover",
+            },
+            transition: "all 0.2s ease",
+          }}
+        >
+          <Avatar
+            sx={{
+              width: 38,
+              height: 38,
+              bgcolor: "primary.main",
+              color: "primary.contrastText",
+              fontWeight: 700,
+              fontSize: "1rem",
+              flexShrink: 0,
+            }}
+          >
+            {user?.name?.charAt(0).toUpperCase() || (
+              <AccountCircleRoundedIcon sx={{ fontSize: 24 }} />
+            )}
+          </Avatar>
+          <Box sx={{ minWidth: 0, flex: 1, overflow: "hidden" }}>
+            <Tooltip
+              title={user?.name || t("layout.user")}
+              arrow
+              placement="top"
+            >
+              <Typography
+                variant="subtitle2"
+                noWrap
+                sx={{
+                  fontWeight: 600,
+                  fontSize: "0.875rem",
+                  color: "text.primary",
+                  lineHeight: 1.2,
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  whiteSpace: "nowrap",
+                }}
+              >
+                {user?.name || t("layout.user")}
+              </Typography>
+            </Tooltip>
+            {user?.email && (
+              <Tooltip title={user.email} arrow placement="top">
+                <Typography
+                  variant="caption"
+                  noWrap
+                  sx={{
+                    color: "text.secondary",
+                    fontSize: "0.75rem",
+                    display: "block",
+                    lineHeight: 1.2,
+                    mt: 0.25,
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  {user.email}
+                </Typography>
+              </Tooltip>
+            )}
+          </Box>
+        </ButtonBase>
+
+        <Tooltip title={t("layout.logout")} arrow placement="top">
+          <IconButton
+            size="small"
+            onClick={handleLogout}
+            aria-label={t("layout.logout")}
+            data-testid="sidebar-logout-btn"
+            sx={{
+              p: 1,
+              color: "text.secondary",
+              flexShrink: 0,
+              "&:hover": {
+                color: "error.main",
+                bgcolor: "error.lighter",
+              },
+            }}
+          >
+            <LogoutRoundedIcon fontSize="small" />
+          </IconButton>
+        </Tooltip>
+      </Box>
     </Box>
   );
 


### PR DESCRIPTION
## 📌 Resumo das Alterações

Esta PR resolve as inconsistências visuais e de ergonomia de navegação apontadas na issue #95:

1. **Ajuste de margens da tela de Perfil (`ProfilePage.tsx`)**:
   - Remoção da contenção arbitrária (`maxWidth: 1000, mx: "auto"`), definindo o container raiz como `width: "100%"`.
   - Harmonização do alinhamento com o `TenantStatusBanner` e o padrão de layout adotado nas demais telas da aplicação (Single Source of Truth em `AppLayout.tsx`).

2. **Atalho de usuário no rodapé da barra lateral (`Sidebar.tsx`)**:
   - Inclusão de seção de rodapé ancorada na base da gaveta (`Sidebar.tsx`), contendo:
     - Avatar circular estilizado com inicial do usuário em fundo na cor primária.
     - Nome completo do usuário com truncamento elegante (`ellipsis`) e `Tooltip` para visualização de nomes extensos.
     - E-mail do usuário com tipografia secundária e truncamento com `Tooltip`.
     - Ação de clique no bloco redirecionando para `/profile` (fechando automaticamente a gaveta em visualização mobile).
     - Destaque visual ativo quando na rota de perfil (`/profile`).
     - Botão de logout rápido (`LogoutRoundedIcon`) com `Tooltip` e fechamento da gaveta no mobile.
     - Estrutura semântica limpa sem aninhamento inválido de `<button>` para evitar erros de hidratação.

3. **Cobertura de Testes**:
   - Criação de suíte de testes unitários para `Sidebar.tsx` (`Sidebar.test.tsx`), validando navegação, itens administrativos, renderização do widget de perfil/avatar/dados, truncamento, clique para rota `/profile`, logout e fallbacks.
   - Adição de asserção em `ProfilePage.test.tsx` para assegurar container raiz com largura total.

## 🔗 Referência

Resolves #95
Closes #95

## ✅ Checklist de Validações

- [x] `./scripts/check.sh all` aprovado com 100% de sucesso (Backend: 12 pacotes testados e vet ok; Frontend: typecheck, lint, format & tests ok; Terraform: fmt ok).
- [x] Nenhuma alteração em rotas HTTP da API Go (dispensa `./scripts/swagger.sh`).
- [x] Testes unitários novos e existentes passando com sucesso.